### PR TITLE
FI-1407: Use oauth_credentials

### DIFF
--- a/lib/us_core/generated/us_core_test_suite.rb
+++ b/lib/us_core/generated/us_core_test_suite.rb
@@ -61,13 +61,15 @@ module USCore
       title: 'FHIR Endpoint',
       description: 'URL of the FHIR endpoint',
       default: 'https://inferno.healthit.gov/reference-server/r4'
-    input :bearer_token,
-      title: 'Bearer Token',
-      default: 'SAMPLE_TOKEN'
+    input :smart_credentials,
+      title: 'OAuth Credentials',
+      type: :oauth_credentials,
+      optional: true,
+      default: JSON.generate(access_token: 'SAMPLE_TOKEN')
 
     fhir_client do
       url :url
-      bearer_token :bearer_token
+      oauth_credentials :smart_credentials
     end
 
     group from: :us_core_311_capability_statement

--- a/lib/us_core/generated/us_core_test_suite.rb
+++ b/lib/us_core/generated/us_core_test_suite.rb
@@ -1,3 +1,4 @@
+require 'inferno/dsl/oauth_credentials'
 require_relative '../custom_groups/capability_statement_group'
 require_relative '../custom_groups/clinical_notes_guidance_group'
 require_relative '../custom_groups/data_absent_reason_group'
@@ -65,7 +66,7 @@ module USCore
       title: 'OAuth Credentials',
       type: :oauth_credentials,
       optional: true,
-      default: JSON.generate(access_token: 'SAMPLE_TOKEN')
+      default: Inferno::DSL::OAuthCredentials.new(access_token: 'SAMPLE_TOKEN')
 
     fhir_client do
       url :url

--- a/lib/us_core/generator/templates/suite.rb.erb
+++ b/lib/us_core/generator/templates/suite.rb.erb
@@ -1,3 +1,4 @@
+require 'inferno/dsl/oauth_credentials'
 require_relative '../custom_groups/capability_statement_group'
 require_relative '../custom_groups/clinical_notes_guidance_group'
 require_relative '../custom_groups/data_absent_reason_group'
@@ -37,7 +38,7 @@ module USCore
       title: 'OAuth Credentials',
       type: :oauth_credentials,
       optional: true,
-      default: JSON.generate(access_token: 'SAMPLE_TOKEN')
+      default: Inferno::DSL::OAuthCredentials.new(access_token: 'SAMPLE_TOKEN')
 
     fhir_client do
       url :url

--- a/lib/us_core/generator/templates/suite.rb.erb
+++ b/lib/us_core/generator/templates/suite.rb.erb
@@ -33,13 +33,15 @@ module USCore
       title: 'FHIR Endpoint',
       description: 'URL of the FHIR endpoint',
       default: 'https://inferno.healthit.gov/reference-server/r4'
-    input :bearer_token,
-      title: 'Bearer Token',
-      default: 'SAMPLE_TOKEN'
+    input :smart_credentials,
+      title: 'OAuth Credentials',
+      type: :oauth_credentials,
+      optional: true,
+      default: JSON.generate(access_token: 'SAMPLE_TOKEN')
 
     fhir_client do
       url :url
-      bearer_token :bearer_token
+      oauth_credentials :smart_credentials
     end
 
     group from: :us_core_311_capability_statement


### PR DESCRIPTION
Use `oauth_credentials` so that access tokens can automatically refresh.