### PR TITLE
FI-1304 Adding Observation.component MS check for BP profile. Remove dataAbsentReason MS check from Observation profiles

### DIFF
--- a/lib/us_core/generated/bodyheight/bodyheight_must_support_test.rb
+++ b/lib/us_core/generated/bodyheight/bodyheight_must_support_test.rb
@@ -17,7 +17,6 @@ module USCore
       * Observation.category.coding.system
       * Observation.category:VSCat
       * Observation.code
-      * Observation.dataAbsentReason
       * Observation.effective[x]
       * Observation.status
       * Observation.subject

--- a/lib/us_core/generated/bodyheight/metadata.yml
+++ b/lib/us_core/generated/bodyheight/metadata.yml
@@ -161,7 +161,6 @@
   - :path: value[x].system
     :fixed_value: http://unitsofmeasure.org
   - :path: value[x].code
-  - :path: dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core/generated/bodytemp/bodytemp_must_support_test.rb
+++ b/lib/us_core/generated/bodytemp/bodytemp_must_support_test.rb
@@ -17,7 +17,6 @@ module USCore
       * Observation.category.coding.system
       * Observation.category:VSCat
       * Observation.code
-      * Observation.dataAbsentReason
       * Observation.effective[x]
       * Observation.status
       * Observation.subject

--- a/lib/us_core/generated/bodytemp/metadata.yml
+++ b/lib/us_core/generated/bodytemp/metadata.yml
@@ -161,7 +161,6 @@
   - :path: value[x].system
     :fixed_value: http://unitsofmeasure.org
   - :path: value[x].code
-  - :path: dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core/generated/bodyweight/bodyweight_must_support_test.rb
+++ b/lib/us_core/generated/bodyweight/bodyweight_must_support_test.rb
@@ -17,7 +17,6 @@ module USCore
       * Observation.category.coding.system
       * Observation.category:VSCat
       * Observation.code
-      * Observation.dataAbsentReason
       * Observation.effective[x]
       * Observation.status
       * Observation.subject

--- a/lib/us_core/generated/bodyweight/metadata.yml
+++ b/lib/us_core/generated/bodyweight/metadata.yml
@@ -161,7 +161,6 @@
   - :path: value[x].system
     :fixed_value: http://unitsofmeasure.org
   - :path: value[x].code
-  - :path: dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core/generated/bp/bp_must_support_test.rb
+++ b/lib/us_core/generated/bp/bp_must_support_test.rb
@@ -17,7 +17,15 @@ module USCore
       * Observation.category.coding.system
       * Observation.category:VSCat
       * Observation.code
-      * Observation.dataAbsentReason
+      * Observation.component
+      * Observation.component.code
+      * Observation.component.value[x]
+      * Observation.component.value[x].code
+      * Observation.component.value[x].system
+      * Observation.component.value[x].unit
+      * Observation.component.value[x].value
+      * Observation.component:DiastolicBP
+      * Observation.component:SystolicBP
       * Observation.effective[x]
       * Observation.status
       * Observation.subject

--- a/lib/us_core/generated/bp/metadata.yml
+++ b/lib/us_core/generated/bp/metadata.yml
@@ -139,6 +139,24 @@
         :value: vital-signs
       - :path: coding.system
         :value: http://terminology.hl7.org/CodeSystem/observation-category
+  - :name: Observation.component:SystolicBP
+    :path: component
+    :discriminator:
+      :type: value
+      :values:
+      - :path: code.coding.code
+        :value: 8480-6
+      - :path: code.coding.system
+        :value: http://loinc.org
+  - :name: Observation.component:DiastolicBP
+    :path: component
+    :discriminator:
+      :type: value
+      :values:
+      - :path: code.coding.code
+        :value: 8462-4
+      - :path: code.coding.system
+        :value: http://loinc.org
   :elements:
   - :path: status
   - :path: category
@@ -150,7 +168,15 @@
   - :path: code
   - :path: subject
   - :path: effective[x]
-  - :path: dataAbsentReason
+  - :path: component
+  - :path: component.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component.value[x].code
+    :fixed_value: mm[Hg]
+  - :path: component.code
+  - :path: component.value[x]
+  - :path: component.value[x].value
+  - :path: component.value[x].unit
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core/generated/heartrate/heartrate_must_support_test.rb
+++ b/lib/us_core/generated/heartrate/heartrate_must_support_test.rb
@@ -17,7 +17,6 @@ module USCore
       * Observation.category.coding.system
       * Observation.category:VSCat
       * Observation.code
-      * Observation.dataAbsentReason
       * Observation.effective[x]
       * Observation.status
       * Observation.subject

--- a/lib/us_core/generated/heartrate/metadata.yml
+++ b/lib/us_core/generated/heartrate/metadata.yml
@@ -162,7 +162,6 @@
     :fixed_value: http://unitsofmeasure.org
   - :path: value[x].code
     :fixed_value: "/min"
-  - :path: dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core/generated/metadata.yml
+++ b/lib/us_core/generated/metadata.yml
@@ -7689,7 +7689,6 @@
     - :path: subject
     - :path: effective[x]
     - :path: value[x]
-    - :path: dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -8304,7 +8303,6 @@
       :fixed_value: http://unitsofmeasure.org
     - :path: value[x].code
       :fixed_value: "%"
-    - :path: dataAbsentReason
     - :path: component
     - :path: component.code
     - :path: component.code.coding.code
@@ -8320,7 +8318,6 @@
     - :path: component.value[x].unit
     - :path: component.value[x].code
       :fixed_value: "%"
-    - :path: component.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -8966,7 +8963,6 @@
     - :path: value[x].system
       :fixed_value: http://unitsofmeasure.org
     - :path: value[x].code
-    - :path: dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -9273,7 +9269,6 @@
     - :path: value[x].system
       :fixed_value: http://unitsofmeasure.org
     - :path: value[x].code
-    - :path: dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -9558,6 +9553,24 @@
           :value: vital-signs
         - :path: coding.system
           :value: http://terminology.hl7.org/CodeSystem/observation-category
+    - :name: Observation.component:SystolicBP
+      :path: component
+      :discriminator:
+        :type: value
+        :values:
+        - :path: code.coding.code
+          :value: 8480-6
+        - :path: code.coding.system
+          :value: http://loinc.org
+    - :name: Observation.component:DiastolicBP
+      :path: component
+      :discriminator:
+        :type: value
+        :values:
+        - :path: code.coding.code
+          :value: 8462-4
+        - :path: code.coding.system
+          :value: http://loinc.org
     :elements:
     - :path: status
     - :path: category
@@ -9569,7 +9582,15 @@
     - :path: code
     - :path: subject
     - :path: effective[x]
-    - :path: dataAbsentReason
+    - :path: component
+    - :path: component.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component.value[x].code
+      :fixed_value: mm[Hg]
+    - :path: component.code
+    - :path: component.value[x]
+    - :path: component.value[x].value
+    - :path: component.value[x].unit
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -9911,7 +9932,6 @@
     - :path: value[x].system
       :fixed_value: http://unitsofmeasure.org
     - :path: value[x].code
-    - :path: dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -10219,7 +10239,6 @@
       :fixed_value: http://unitsofmeasure.org
     - :path: value[x].code
       :fixed_value: "/min"
-    - :path: dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -10523,7 +10542,6 @@
       :fixed_value: http://unitsofmeasure.org
     - :path: value[x].code
       :fixed_value: "/min"
-    - :path: dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category

--- a/lib/us_core/generated/observation_lab/metadata.yml
+++ b/lib/us_core/generated/observation_lab/metadata.yml
@@ -1143,7 +1143,6 @@
   - :path: subject
   - :path: effective[x]
   - :path: value[x]
-  - :path: dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core/generated/observation_lab/observation_lab_must_support_test.rb
+++ b/lib/us_core/generated/observation_lab/observation_lab_must_support_test.rb
@@ -14,7 +14,6 @@ module USCore
       * Observation.category
       * Observation.category:Laboratory
       * Observation.code
-      * Observation.dataAbsentReason
       * Observation.effective[x]
       * Observation.status
       * Observation.subject

--- a/lib/us_core/generated/pulse_oximetry/metadata.yml
+++ b/lib/us_core/generated/pulse_oximetry/metadata.yml
@@ -191,7 +191,6 @@
     :fixed_value: http://unitsofmeasure.org
   - :path: value[x].code
     :fixed_value: "%"
-  - :path: dataAbsentReason
   - :path: component
   - :path: component.code
   - :path: component.code.coding.code
@@ -207,7 +206,6 @@
   - :path: component.value[x].unit
   - :path: component.value[x].code
     :fixed_value: "%"
-  - :path: component.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core/generated/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core/generated/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -25,7 +25,6 @@ module USCore
       * Observation.component.code
       * Observation.component.code.coding.code
       * Observation.component.code.coding.code
-      * Observation.component.dataAbsentReason
       * Observation.component.value[x]
       * Observation.component.value[x].code
       * Observation.component.value[x].code
@@ -34,7 +33,6 @@ module USCore
       * Observation.component.value[x].value
       * Observation.component:Concentration
       * Observation.component:FlowRate
-      * Observation.dataAbsentReason
       * Observation.effective[x]
       * Observation.status
       * Observation.subject

--- a/lib/us_core/generated/resprate/metadata.yml
+++ b/lib/us_core/generated/resprate/metadata.yml
@@ -162,7 +162,6 @@
     :fixed_value: http://unitsofmeasure.org
   - :path: value[x].code
     :fixed_value: "/min"
-  - :path: dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core/generated/resprate/resprate_must_support_test.rb
+++ b/lib/us_core/generated/resprate/resprate_must_support_test.rb
@@ -17,7 +17,6 @@ module USCore
       * Observation.category.coding.system
       * Observation.category:VSCat
       * Observation.code
-      * Observation.dataAbsentReason
       * Observation.effective[x]
       * Observation.status
       * Observation.subject


### PR DESCRIPTION
This PR migrate https://github.com/onc-healthit/inferno-program/pull/354 to Inferno 2.0 uscore-test-kit.

Changes:
Add component MS check back to BP profile
Remove dataAbsentReason and component.dataAbsentReson for Observtion profiles