### PR TITLE
FI-1459 Fix Smoking Status search

### DIFF
--- a/lib/us_core/generated/smokingstatus/smokingstatus_patient_category_date_search_test.rb
+++ b/lib/us_core/generated/smokingstatus/smokingstatus_patient_category_date_search_test.rb
@@ -17,6 +17,8 @@ none are returned, the test is skipped.
     )
 
     id :us_core_311_smokingstatus_patient_category_date_search_test
+    optional
+
     input :patient_ids,
       title: 'Patient IDs',
       description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements',

--- a/lib/us_core/generated/smokingstatus/smokingstatus_patient_category_search_test.rb
+++ b/lib/us_core/generated/smokingstatus/smokingstatus_patient_category_search_test.rb
@@ -17,6 +17,8 @@ none are returned, the test is skipped.
     )
 
     id :us_core_311_smokingstatus_patient_category_search_test
+    optional
+
     input :patient_ids,
       title: 'Patient IDs',
       description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements',

--- a/lib/us_core/generator/search_test_generator.rb
+++ b/lib/us_core/generator/search_test_generator.rb
@@ -127,7 +127,8 @@ module USCore
       end
 
       def optional?
-        conformance_expectation != 'SHALL'
+        conformance_expectation != 'SHALL' ||
+        !search_metadata[:must_support_or_mandatory] 
       end
 
       def search_definition(name)

--- a/lib/us_core/generator/search_test_generator.rb
+++ b/lib/us_core/generator/search_test_generator.rb
@@ -127,8 +127,7 @@ module USCore
       end
 
       def optional?
-        conformance_expectation != 'SHALL' ||
-        !search_metadata[:must_support_or_mandatory] 
+        conformance_expectation != 'SHALL' || !search_metadata[:must_support_or_mandatory] 
       end
 
       def search_definition(name)


### PR DESCRIPTION
Some search combinations are required in CapabilityStatement for Observation but SmokingStatus profile does have all search element as required or MustSupport.

Change those search combinations from required search test to optional search test