### PR TITLE
FI-1464: Allow read tests to be configured to read all resources

### DIFF
--- a/lib/us_core/read_test.rb
+++ b/lib/us_core/read_test.rb
@@ -7,18 +7,29 @@ module USCore
     def perform_read_test(resources, reply_handler = nil)
       skip_if resources.blank?, no_resources_skip_message
 
-      resource_given = resources.find do |resource|
-        resource.is_a?(resource_class) || resource.is_a?(FHIR::Reference)
-      end
+      resources_to_read = readable_resources(resources)
 
-      id =
-        if resource_given.is_a? FHIR::Reference
-          resource_given.reference.split('/').last
-        else
-          resource_given&.id
+      assert resources_to_read.present?, "No #{resource_type} id found."
+
+      if config.options[:read_all_resources]
+        resources_to_read.each do |resource|
+          read_and_validate(resource)
         end
+      else
+        read_and_validate(resources_to_read.first)
+      end
+    end
 
-      assert id.present?, "No #{resource_type} id found."
+    def readable_resources(resources)
+      resources
+        .select { |resource| resource.is_a?(resource_class) || resource.is_a?(FHIR::Reference) }
+        .select { |resource| (resource.is_a?(FHIR::Reference) ? resource.reference.split('/').last : resource.id).present? }
+        .compact
+        .uniq { |resource| resource.is_a?(FHIR::Reference) ? resource.reference.split('/').last : resource.id }
+    end
+
+    def read_and_validate(resource_to_read)
+      id = resource_id(resource_to_read)
 
       fhir_read resource_type, id
 
@@ -26,9 +37,13 @@ module USCore
       assert_resource_type(resource_type)
       assert resource.id.present? && resource.id == id, bad_resource_id_message(id)
 
-      if resource_given.is_a? FHIR::Reference
+      if resource_to_read.is_a? FHIR::Reference
         all_scratch_resources << resource
       end
+    end
+
+    def resource_id(resource)
+      resource.is_a?(FHIR::Reference) ? resource.reference.split('/').last : resource.id
     end
 
     def no_resources_skip_message


### PR DESCRIPTION
This branch adds a configuration option for read tests to allow them to read all resources. Generally, it's only necessary to read one resource to verify that the read interaction works. In the g10 test kit, however, there are some groups where the searches are not performed, so multiple resources need to be read in order to adequately check for the presence of must support elements.