### PR TITLE
Fix full_path parsing on expressions with two types

### DIFF
--- a/lib/us_core_test_kit/generator/search_definition_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/search_definition_metadata_extractor.rb
@@ -37,8 +37,9 @@ module USCoreTestKit
           begin
             path = param.expression.gsub(/.where\((.*)/, '')
             path = path[1..-2] if path.start_with?('(') && path.end_with?(')')
-            as_type = path.scan(/[. ]as[( ]([^)]*)[)]?/).flatten.first
-            path.gsub!(/[. ]as[( ]([^)]*)[)]?/, as_type.upcase_first) if as_type.present?
+            path.scan(/[. ]as[( ]([^)]*)[)]?/).flatten.map do |as_type|
+              path.gsub!(/[. ]as[( ](#{as_type}[^)]*)[)]?/, as_type.upcase_first) if as_type.present?
+            end
             path
           end
       end

--- a/spec/us_core/generator/search_definition_metadata_extractor_spec.rb
+++ b/spec/us_core/generator/search_definition_metadata_extractor_spec.rb
@@ -1,0 +1,50 @@
+require_relative '../../../lib/us_core_test_kit/generator/search_metadata_extractor.rb'
+
+RSpec.describe USCoreTestKit::Generator::SearchDefinitionMetadataExtractor do
+
+  # really slime the subject here because we don't care about interactions
+  # if this test file grows, this will likely break and more stubbing and setup will be required
+  subject { described_class.new("test", "nothing", "nope", "no") }
+
+  describe '#full_path' do
+    let(:param) do
+      ig_resource = double()
+      allow(ig_resource).to receive(:expression).and_return(expression)
+      ig_resource
+    end
+
+    context "a single dateTime expression" do
+      let(:expression) { "Condition.onset.as(dateTime)" }
+
+      it 'parses correctly' do
+        allow(subject).to receive(:param).and_return(param)
+
+        expected = "Condition.onsetDateTime"
+        expect(subject.full_path).to eq(expected)
+      end
+    end
+
+    context "a single period expression" do
+      let(:expression) { "Condition.onset.as(Period)" }
+
+      it 'parses correctly' do
+        allow(subject).to receive(:param).and_return(param)
+
+        expected = "Condition.onsetPeriod"
+        expect(subject.full_path).to eq(expected)
+      end
+    end
+
+    context "two expressions" do
+      let(:expression) { "Condition.onset.as(dateTime)|Condition.onset.as(Period)" }
+
+      it 'parses correctly' do
+        allow(subject).to receive(:param).and_return(param)
+
+        expected = "Condition.onsetDateTime|Condition.onsetPeriod"
+        expect(subject.full_path).to eq(expected)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Fix reported bug

> The method full_path does not handle search parameter having multiple types correctly. Ex US Core condition-onset-date:
> "expression": "Condition.onset.as(dateTime)|Condition.onset.as(Period)"
> and full_path returns:
> ["Condition.onsetDateTime", "Condition.onsetDateTime"]