### PR TITLE
FI-1502 Handles Must Support Choice

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/device/device_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/device/device_must_support_test.rb
@@ -20,6 +20,8 @@ module USCoreTestKit
       * Device.serialNumber
       * Device.type
       * Device.udiCarrier
+      * Device.udiCarrier.carrierAIDC
+      * Device.udiCarrier.carrierHRF
       * Device.udiCarrier.deviceIdentifier
       )
 

--- a/lib/us_core_test_kit/generated/v3.1.1/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/device/metadata.yml
@@ -1072,6 +1072,8 @@
   :elements:
   - :path: udiCarrier
   - :path: udiCarrier.deviceIdentifier
+  - :path: udiCarrier.carrierAIDC
+  - :path: udiCarrier.carrierHRF
   - :path: distinctIdentifier
   - :path: manufactureDate
   - :path: expirationDate
@@ -1081,6 +1083,10 @@
   - :path: patient
     :types:
     - Reference
+  :choices:
+  - :paths:
+    - udiCarrier.carrierAIDC
+    - udiCarrier.carrierHRF
 :mandatory_elements:
 - Device.udiCarrier.deviceIdentifier
 - Device.deviceName.name

--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_must_support_test.rb
@@ -17,6 +17,8 @@ module USCoreTestKit
       * DocumentReference.content
       * DocumentReference.content.attachment
       * DocumentReference.content.attachment.contentType
+      * DocumentReference.content.attachment.data
+      * DocumentReference.content.attachment.url
       * DocumentReference.content.format
       * DocumentReference.context
       * DocumentReference.context.encounter

--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/metadata.yml
@@ -238,12 +238,18 @@
   - :path: content
   - :path: content.attachment
   - :path: content.attachment.contentType
+  - :path: content.attachment.data
+  - :path: content.attachment.url
   - :path: content.format
   - :path: context
   - :path: context.encounter
     :types:
     - Reference
   - :path: context.period
+  :choices:
+  - :paths:
+    - content.attachment.data
+    - content.attachment.url
 :mandatory_elements:
 - DocumentReference.status
 - DocumentReference.type

--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -1861,6 +1861,8 @@
     :elements:
     - :path: udiCarrier
     - :path: udiCarrier.deviceIdentifier
+    - :path: udiCarrier.carrierAIDC
+    - :path: udiCarrier.carrierHRF
     - :path: distinctIdentifier
     - :path: manufactureDate
     - :path: expirationDate
@@ -1870,6 +1872,10 @@
     - :path: patient
       :types:
       - Reference
+    :choices:
+    - :paths:
+      - udiCarrier.carrierAIDC
+      - udiCarrier.carrierHRF
   :mandatory_elements:
   - Device.udiCarrier.deviceIdentifier
   - Device.deviceName.name
@@ -4637,12 +4643,18 @@
     - :path: content
     - :path: content.attachment
     - :path: content.attachment.contentType
+    - :path: content.attachment.data
+    - :path: content.attachment.url
     - :path: content.format
     - :path: context
     - :path: context.encounter
       :types:
       - Reference
     - :path: context.period
+    :choices:
+    - :paths:
+      - content.attachment.data
+      - content.attachment.url
   :mandatory_elements:
   - DocumentReference.status
   - DocumentReference.type

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference/document_reference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference/document_reference_must_support_test.rb
@@ -17,6 +17,8 @@ module USCoreTestKit
       * DocumentReference.content
       * DocumentReference.content.attachment
       * DocumentReference.content.attachment.contentType
+      * DocumentReference.content.attachment.data
+      * DocumentReference.content.attachment.url
       * DocumentReference.content.format
       * DocumentReference.context
       * DocumentReference.context.encounter

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
@@ -237,12 +237,18 @@
   - :path: content
   - :path: content.attachment
   - :path: content.attachment.contentType
+  - :path: content.attachment.data
+  - :path: content.attachment.url
   - :path: content.format
   - :path: context
   - :path: context.encounter
     :types:
     - Reference
   - :path: context.period
+  :choices:
+  - :paths:
+    - content.attachment.data
+    - content.attachment.url
 :mandatory_elements:
 - DocumentReference.status
 - DocumentReference.type

--- a/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
@@ -214,6 +214,13 @@
   - :path: serviceProvider
     :types:
     - Reference
+  :choices:
+  - :paths:
+    - reasonCode
+    - reasonReference
+  - :paths:
+    - location.location
+    - serviceProvider
 :mandatory_elements:
 - Encounter.identifier.system
 - Encounter.identifier.value

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
@@ -170,6 +170,10 @@
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
   - :path: dosageInstruction
   - :path: dosageInstruction.text
+  :choices:
+  - :paths:
+    - reportedBoolean
+    - reportedReference
 :mandatory_elements:
 - MedicationRequest.status
 - MedicationRequest.intent

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -4660,12 +4660,18 @@
     - :path: content
     - :path: content.attachment
     - :path: content.attachment.contentType
+    - :path: content.attachment.data
+    - :path: content.attachment.url
     - :path: content.format
     - :path: context
     - :path: context.encounter
       :types:
       - Reference
     - :path: context.period
+    :choices:
+    - :paths:
+      - content.attachment.data
+      - content.attachment.url
   :mandatory_elements:
   - DocumentReference.status
   - DocumentReference.type
@@ -4985,6 +4991,13 @@
     - :path: serviceProvider
       :types:
       - Reference
+    :choices:
+    - :paths:
+      - reasonCode
+      - reasonReference
+    - :paths:
+      - location.location
+      - serviceProvider
   :mandatory_elements:
   - Encounter.identifier.system
   - Encounter.identifier.value
@@ -5943,6 +5956,10 @@
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
     - :path: dosageInstruction
     - :path: dosageInstruction.text
+    :choices:
+    - :paths:
+      - reportedBoolean
+      - reportedReference
   :mandatory_elements:
   - MedicationRequest.status
   - MedicationRequest.intent

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -271,11 +271,12 @@ module USCoreTestKit
         remove_vital_sign_component
         remove_blood_pressure_value
         remove_observation_data_absent_reason
-        remove_document_reference_attachment_data_url
+        #remove_document_reference_attachment_data_url
+        add_must_support_choices
 
         case profile.version
         when '3.1.1'
-          remove_device_carrier
+          #remove_device_carrier
         when '4.0.0'
           add_device_distinct_identifier
           add_patient_uscdi_elements
@@ -340,6 +341,27 @@ module USCoreTestKit
             ['content.attachment.data', 'content.attachment.url'].include?(element[:path])
           end
         end
+      end
+
+      def add_must_support_choices
+        choices = []
+        
+        choices << {paths: ['content.attachment.data', 'content.attachment.url']} if profile.type == 'DocumentReference'
+
+        case profile.version
+        when '3.1.1'
+          choices << {paths: ['udiCarrier.carrierAIDC', 'udiCarrier.carrierHRF']} if profile.type == 'Device'
+        when '4.0.0'
+          case profile.type
+          when 'Encounter'
+            choices << {paths: ['reasonCode', 'reasonReference']}
+            choices << {paths: ['location.location', 'serviceProvider']}
+          when 'MedicationRequest'
+            choices << {paths: ['reportedBoolean', 'reportedReference']}
+          end
+        end
+
+        @must_supports[:choices] = choices if choices.present?
       end
 
       def add_device_distinct_identifier

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -271,12 +271,9 @@ module USCoreTestKit
         remove_vital_sign_component
         remove_blood_pressure_value
         remove_observation_data_absent_reason
-        #remove_document_reference_attachment_data_url
         add_must_support_choices
 
         case profile.version
-        when '3.1.1'
-          #remove_device_carrier
         when '4.0.0'
           add_device_distinct_identifier
           add_patient_uscdi_elements
@@ -345,7 +342,7 @@ module USCoreTestKit
 
       def add_must_support_choices
         choices = []
-        
+
         choices << {paths: ['content.attachment.data', 'content.attachment.url']} if profile.type == 'DocumentReference'
 
         case profile.version

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -64,16 +64,16 @@ module USCoreTestKit
 
               (value_without_extensions.present? || value_without_extensions == false) &&
                 (element_definition[:fixed_value].blank? || value == element_definition[:fixed_value])
-                
+
             end
 
             # Note that false.present? => false, which is why we need to add this extra check
             value_found.present? || value_found == false
           end
         end
-      
+
       if metadata.must_supports[:choices].present?
-        @missing_elements.delete_if do |element| 
+        @missing_elements.delete_if do |element|
           choice_paths = metadata.must_supports[:choices].find { |choice| choice[:paths].include?(element[:path]) }
 
           choice_paths.present? &&

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -80,6 +80,8 @@ module USCoreTestKit
             choice_paths[:paths].any? { |path| @missing_elements.none? { |element| element[:path] == path } }
         end
       end
+
+      @missing_elements
     end
 
     def must_support_slices

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -71,6 +71,15 @@ module USCoreTestKit
             value_found.present? || value_found == false
           end
         end
+      
+      if metadata.must_supports[:choices].present?
+        @missing_elements.delete_if do |element| 
+          choice_paths = metadata.must_supports[:choices].find { |choice| choice[:paths].include?(element[:path]) }
+
+          choice_paths.present? &&
+            choice_paths[:paths].any? { |path| @missing_elements.none? { |element| element[:path] == path } }
+        end
+      end
     end
 
     def must_support_slices

--- a/spec/fixtures/device_metadata.yml
+++ b/spec/fixtures/device_metadata.yml
@@ -1072,6 +1072,8 @@
   :elements:
   - :path: udiCarrier
   - :path: udiCarrier.deviceIdentifier
+  - :path: udiCarrier.carrierAIDC
+  - :path: udiCarrier.carrierHRF
   - :path: distinctIdentifier
   - :path: manufactureDate
   - :path: expirationDate
@@ -1081,6 +1083,10 @@
   - :path: patient
     :types:
     - Reference
+  :choices:
+  - :paths:
+    - udiCarrier.carrierAIDC
+    - udiCarrier.carrierHRF
 :mandatory_elements:
 - Device.udiCarrier.deviceIdentifier
 - Device.deviceName.name

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -1,0 +1,110 @@
+RSpec.describe USCoreTestKit::MustSupportTest do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('us_core_v400') }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:url) { 'http://example.com/fhir' }
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name: name,
+        value: value,
+        type: runnable.config.input_type(name)
+      )
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  describe 'must support test with choice elements' do
+    let(:must_support_test) do
+      Class.new(Inferno::Test) do
+        include USCoreTestKit::MustSupportTest
+
+        def self.metadata
+          @metadata ||=
+            USCoreTestKit::Generator::GroupMetadata.new(
+              YAML.load_file(
+                File.join(
+                  __dir__,
+                  '..',
+                  'fixtures',
+                  'device_metadata.yml'
+                )
+              )
+            )
+        end
+
+        def resource_type
+          'Device'
+        end
+
+        def scratch_resources
+          scratch[:device] ||= {}
+        end
+
+        fhir_client { url :url }
+        input :url
+
+        run do
+          perform_must_support_test(all_scratch_resources)
+        end
+      end
+    end
+    let(:patient_ref) { 'Patient/85' }
+    let(:device) do
+      FHIR::Device.new(
+        udiCarrier: [
+          {
+              deviceIdentifier: '43069338026389'
+          }
+        ],
+        distinctIdentifier: '43069338026389',
+        manufactureDate: '2000-03-02T18:33:18-05:00',
+        expirationDate: '2025-03-17T19:33:18-04:00',
+        lotNumber: '1134',
+        serialNumber: '842026117977',
+        type: {
+          text: 'Implantable defibrillator, device (physical object)'
+        },
+        patient: {
+          reference: patient_ref
+        }
+      )
+    end
+
+    before do
+      Inferno::Repositories::Tests.new.insert(must_support_test)
+    end
+
+    it 'fails if server supports none of the choice' do    
+      allow_any_instance_of(must_support_test)
+        .to receive(:scratch_resources).and_return(
+              {
+                all: [device]
+              }
+            )
+      
+      result = run(must_support_test, url: url)
+      expect(result.result).to eq('skip')
+      expect(result.result_message).to include('udiCarrier.carrierAIDC, udiCarrier.carrierHRF')
+    end
+
+    it 'passes if server supports at least one of the choice' do 
+      device.udiCarrier.first.carrierHRF = '(01)43069338026389(11)000302(17)250317(10)1134(21)842026117977'
+      allow_any_instance_of(must_support_test)
+        .to receive(:scratch_resources).and_return(
+              {
+                all: [device]
+              }
+            )
+      
+      result = run(must_support_test, url: url)
+      expect(result.result).to eq('pass')
+    end
+
+  end
+end

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -80,20 +80,20 @@ RSpec.describe USCoreTestKit::MustSupportTest do
       Inferno::Repositories::Tests.new.insert(must_support_test)
     end
 
-    it 'fails if server supports none of the choice' do    
+    it 'fails if server supports none of the choice' do
       allow_any_instance_of(must_support_test)
         .to receive(:scratch_resources).and_return(
               {
                 all: [device]
               }
             )
-      
+
       result = run(must_support_test, url: url)
       expect(result.result).to eq('skip')
       expect(result.result_message).to include('udiCarrier.carrierAIDC, udiCarrier.carrierHRF')
     end
 
-    it 'passes if server supports at least one of the choice' do 
+    it 'passes if server supports at least one of the choice' do
       device.udiCarrier.first.carrierHRF = '(01)43069338026389(11)000302(17)250317(10)1134(21)842026117977'
       allow_any_instance_of(must_support_test)
         .to receive(:scratch_resources).and_return(
@@ -101,7 +101,7 @@ RSpec.describe USCoreTestKit::MustSupportTest do
                 all: [device]
               }
             )
-      
+
       result = run(must_support_test, url: url)
       expect(result.result).to eq('pass')
     end

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -105,6 +105,5 @@ RSpec.describe USCoreTestKit::MustSupportTest do
       result = run(must_support_test, url: url)
       expect(result.result).to eq('pass')
     end
-
   end
 end


### PR DESCRIPTION
US Core use narrative section to fine turn some MustSupport elements, such as:

Although both are marked as must support, servers are not required to support both Encounter.location.location and Encounter.serviceProvider, but they SHALL support at least one of these elements.

This PR added "choices" to metadata to indicate which elements are in the choice pair. For example, in the encounter's metadata.yml

```
:must_supports:
  :choices:
  - :paths:
    - location.location
    - serviceProvider
```

must_support_test remove a miss element is it is one of the choice element and the other choice element is not missing.

This PR shall be reviewed and merged after PR #17 