### PR TITLE
Rename head_circumference_percentile to head_circumference in v3.1.1

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_must_support_test.rb
@@ -2,7 +2,7 @@ require_relative '../../../must_support_test'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentileMustSupportTest < Inferno::Test
+    class HeadCircumferenceMustSupportTest < Inferno::Test
       include USCoreTestKit::MustSupportTest
 
       title 'All must support elements are provided in the Observation resources returned'
@@ -29,7 +29,7 @@ module USCoreTestKit
       * Observation.value[x]:valueQuantity
       )
 
-      id :us_core_v311_head_circumference_percentile_must_support_test
+      id :us_core_v311_head_circumference_must_support_test
 
       def resource_type
         'Observation'
@@ -40,7 +40,7 @@ module USCoreTestKit
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       run do

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_category_date_search_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_category_date_search_test.rb
@@ -3,7 +3,7 @@ require_relative '../../../generator/group_metadata'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentilePatientCategoryDateSearchTest < Inferno::Test
+    class HeadCircumferencePatientCategoryDateSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
       title 'Server returns valid results for Observation search by patient + category + date'
@@ -17,7 +17,7 @@ none are returned, the test is skipped.
 
       )
 
-      id :us_core_v311_head_circumference_percentile_patient_category_date_search_test
+      id :us_core_v311_head_circumference_patient_category_date_search_test
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
@@ -37,7 +37,7 @@ none are returned, the test is skipped.
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       run do

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_category_search_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_category_search_test.rb
@@ -3,13 +3,13 @@ require_relative '../../../generator/group_metadata'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentilePatientCategoryStatusSearchTest < Inferno::Test
+    class HeadCircumferencePatientCategorySearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
-      title 'Server returns valid results for Observation search by patient + category + status'
+      title 'Server returns valid results for Observation search by patient + category'
       description %(
-  A server SHOULD support searching by
-patient + category + status on the Observation resource. This test
+  A server SHALL support searching by
+patient + category on the Observation resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
@@ -17,9 +17,7 @@ none are returned, the test is skipped.
 
       )
 
-      id :us_core_v311_head_circumference_percentile_patient_category_status_search_test
-      optional
-  
+      id :us_core_v311_head_circumference_patient_category_search_test
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
@@ -27,9 +25,9 @@ none are returned, the test is skipped.
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Observation',
-        search_param_names: ['patient', 'category', 'status'],
-        token_search_params: ['category'],
-        multiple_or_search_params: ['status']
+        search_param_names: ['patient', 'category'],
+        possible_status_search: true,
+        token_search_params: ['category']
         )
       end
 
@@ -38,7 +36,7 @@ none are returned, the test is skipped.
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       run do

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_category_status_search_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_category_status_search_test.rb
@@ -3,13 +3,13 @@ require_relative '../../../generator/group_metadata'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentilePatientCodeDateSearchTest < Inferno::Test
+    class HeadCircumferencePatientCategoryStatusSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
-      title 'Server returns valid results for Observation search by patient + code + date'
+      title 'Server returns valid results for Observation search by patient + category + status'
       description %(
   A server SHOULD support searching by
-patient + code + date on the Observation resource. This test
+patient + category + status on the Observation resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
@@ -17,7 +17,7 @@ none are returned, the test is skipped.
 
       )
 
-      id :us_core_v311_head_circumference_percentile_patient_code_date_search_test
+      id :us_core_v311_head_circumference_patient_category_status_search_test
       optional
   
       input :patient_ids,
@@ -27,10 +27,9 @@ none are returned, the test is skipped.
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Observation',
-        search_param_names: ['patient', 'code', 'date'],
-        possible_status_search: true,
-        token_search_params: ['code'],
-        params_with_comparators: ['date']
+        search_param_names: ['patient', 'category', 'status'],
+        token_search_params: ['category'],
+        multiple_or_search_params: ['status']
         )
       end
 
@@ -39,7 +38,7 @@ none are returned, the test is skipped.
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       run do

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_code_date_search_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_code_date_search_test.rb
@@ -3,13 +3,13 @@ require_relative '../../../generator/group_metadata'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentilePatientCategorySearchTest < Inferno::Test
+    class HeadCircumferencePatientCodeDateSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
-      title 'Server returns valid results for Observation search by patient + category'
+      title 'Server returns valid results for Observation search by patient + code + date'
       description %(
-  A server SHALL support searching by
-patient + category on the Observation resource. This test
+  A server SHOULD support searching by
+patient + code + date on the Observation resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
@@ -17,7 +17,9 @@ none are returned, the test is skipped.
 
       )
 
-      id :us_core_v311_head_circumference_percentile_patient_category_search_test
+      id :us_core_v311_head_circumference_patient_code_date_search_test
+      optional
+  
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
@@ -25,9 +27,10 @@ none are returned, the test is skipped.
       def self.properties
         @properties ||= SearchTestProperties.new(
           resource_type: 'Observation',
-        search_param_names: ['patient', 'category'],
+        search_param_names: ['patient', 'code', 'date'],
         possible_status_search: true,
-        token_search_params: ['category']
+        token_search_params: ['code'],
+        params_with_comparators: ['date']
         )
       end
 
@@ -36,7 +39,7 @@ none are returned, the test is skipped.
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       run do

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_code_search_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_patient_code_search_test.rb
@@ -3,7 +3,7 @@ require_relative '../../../generator/group_metadata'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentilePatientCodeSearchTest < Inferno::Test
+    class HeadCircumferencePatientCodeSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
       title 'Server returns valid results for Observation search by patient + code'
@@ -30,7 +30,7 @@ requirement of US Core v3.1.1.
 
       )
 
-      id :us_core_v311_head_circumference_percentile_patient_code_search_test
+      id :us_core_v311_head_circumference_patient_code_search_test
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
@@ -53,7 +53,7 @@ requirement of US Core v3.1.1.
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       run do

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_provenance_revinclude_search_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_provenance_revinclude_search_test.rb
@@ -3,7 +3,7 @@ require_relative '../../../generator/group_metadata'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentileProvenanceRevincludeSearchTest < Inferno::Test
+    class HeadCircumferenceProvenanceRevincludeSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
       title 'Server returns Provenance resources from Observation search by patient + code + revInclude:Provenance:target'
@@ -14,7 +14,7 @@ module USCoreTestKit
         will pass if a Provenance resource is found in the response.
       %)
 
-      id :us_core_v311_head_circumference_percentile_provenance_revinclude_search_test
+      id :us_core_v311_head_circumference_provenance_revinclude_search_test
   
       input :patient_ids,
         title: 'Patient IDs',
@@ -38,7 +38,7 @@ module USCoreTestKit
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       def scratch_provenance_resources

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_read_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_read_test.rb
@@ -2,20 +2,20 @@ require_relative '../../../read_test'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentileReadTest < Inferno::Test
+    class HeadCircumferenceReadTest < Inferno::Test
       include USCoreTestKit::ReadTest
 
       title 'Server returns correct Observation resource from Observation read interaction'
       description 'A server SHALL support the Observation read interaction.'
 
-      id :us_core_v311_head_circumference_percentile_read_test
+      id :us_core_v311_head_circumference_read_test
 
       def resource_type
         'Observation'
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       run do

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_reference_resolution_test.rb
@@ -3,7 +3,7 @@ require_relative '../resource_list'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentileReferenceResolutionTest < Inferno::Test
+    class HeadCircumferenceReferenceResolutionTest < Inferno::Test
       include USCoreTestKit::ReferenceResolutionTest
       include ResourceList
 
@@ -16,7 +16,7 @@ module USCoreTestKit
   
       )
 
-      id :us_core_v311_head_circumference_percentile_reference_resolution_test
+      id :us_core_v311_head_circumference_reference_resolution_test
 
       def resource_type
         'Observation'
@@ -27,7 +27,7 @@ module USCoreTestKit
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       run do

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_validation_test.rb
@@ -2,10 +2,10 @@ require_relative '../../../validation_test'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentileValidationTest < Inferno::Test
+    class HeadCircumferenceValidationTest < Inferno::Test
       include USCoreTestKit::ValidationTest
 
-      id :us_core_v311_head_circumference_percentile_validation_test
+      id :us_core_v311_head_circumference_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Pediatric Head Occipital-frontal Circumference Percentile Profile'
       description %(
   This test verifies resources returned from the first search conform to
@@ -25,7 +25,7 @@ fail if their code/system are not found in the valueset.
       end
 
       def scratch_resources
-        scratch[:head_circumference_percentile_resources] ||= {}
+        scratch[:head_circumference_resources] ||= {}
       end
 
       run do

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/metadata.yml
@@ -309,26 +309,26 @@
   - http://hl7.org/fhir/StructureDefinition/MolecularSequence
   - http://hl7.org/fhir/StructureDefinition/vitalsigns
 :tests:
-- :id: us_core_v311_head_circumference_percentile_patient_code_search_test
-  :file_name: head_circumference_percentile_patient_code_search_test.rb
-- :id: us_core_v311_head_circumference_percentile_patient_category_date_search_test
-  :file_name: head_circumference_percentile_patient_category_date_search_test.rb
-- :id: us_core_v311_head_circumference_percentile_patient_category_status_search_test
-  :file_name: head_circumference_percentile_patient_category_status_search_test.rb
-- :id: us_core_v311_head_circumference_percentile_patient_code_date_search_test
-  :file_name: head_circumference_percentile_patient_code_date_search_test.rb
-- :id: us_core_v311_head_circumference_percentile_patient_category_search_test
-  :file_name: head_circumference_percentile_patient_category_search_test.rb
-- :id: us_core_v311_head_circumference_percentile_read_test
-  :file_name: head_circumference_percentile_read_test.rb
-- :id: us_core_v311_head_circumference_percentile_provenance_revinclude_search_test
-  :file_name: head_circumference_percentile_provenance_revinclude_search_test.rb
-- :id: us_core_v311_head_circumference_percentile_validation_test
-  :file_name: head_circumference_percentile_validation_test.rb
-- :id: us_core_v311_head_circumference_percentile_must_support_test
-  :file_name: head_circumference_percentile_must_support_test.rb
-- :id: us_core_v311_head_circumference_percentile_reference_resolution_test
-  :file_name: head_circumference_percentile_reference_resolution_test.rb
-:id: us_core_v311_head_circumference_percentile
-:file_name: head_circumference_percentile_group.rb
+- :id: us_core_v311_head_circumference_patient_code_search_test
+  :file_name: head_circumference_patient_code_search_test.rb
+- :id: us_core_v311_head_circumference_patient_category_date_search_test
+  :file_name: head_circumference_patient_category_date_search_test.rb
+- :id: us_core_v311_head_circumference_patient_category_status_search_test
+  :file_name: head_circumference_patient_category_status_search_test.rb
+- :id: us_core_v311_head_circumference_patient_code_date_search_test
+  :file_name: head_circumference_patient_code_date_search_test.rb
+- :id: us_core_v311_head_circumference_patient_category_search_test
+  :file_name: head_circumference_patient_category_search_test.rb
+- :id: us_core_v311_head_circumference_read_test
+  :file_name: head_circumference_read_test.rb
+- :id: us_core_v311_head_circumference_provenance_revinclude_search_test
+  :file_name: head_circumference_provenance_revinclude_search_test.rb
+- :id: us_core_v311_head_circumference_validation_test
+  :file_name: head_circumference_validation_test.rb
+- :id: us_core_v311_head_circumference_must_support_test
+  :file_name: head_circumference_must_support_test.rb
+- :id: us_core_v311_head_circumference_reference_resolution_test
+  :file_name: head_circumference_reference_resolution_test.rb
+:id: us_core_v311_head_circumference
+:file_name: head_circumference_group.rb
 :delayed_references: []

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference_group.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference_group.rb
@@ -1,17 +1,17 @@
-require_relative 'head_circumference_percentile/head_circumference_percentile_patient_code_search_test'
-require_relative 'head_circumference_percentile/head_circumference_percentile_patient_category_date_search_test'
-require_relative 'head_circumference_percentile/head_circumference_percentile_patient_category_status_search_test'
-require_relative 'head_circumference_percentile/head_circumference_percentile_patient_code_date_search_test'
-require_relative 'head_circumference_percentile/head_circumference_percentile_patient_category_search_test'
-require_relative 'head_circumference_percentile/head_circumference_percentile_read_test'
-require_relative 'head_circumference_percentile/head_circumference_percentile_provenance_revinclude_search_test'
-require_relative 'head_circumference_percentile/head_circumference_percentile_validation_test'
-require_relative 'head_circumference_percentile/head_circumference_percentile_must_support_test'
-require_relative 'head_circumference_percentile/head_circumference_percentile_reference_resolution_test'
+require_relative 'head_circumference/head_circumference_patient_code_search_test'
+require_relative 'head_circumference/head_circumference_patient_category_date_search_test'
+require_relative 'head_circumference/head_circumference_patient_category_status_search_test'
+require_relative 'head_circumference/head_circumference_patient_code_date_search_test'
+require_relative 'head_circumference/head_circumference_patient_category_search_test'
+require_relative 'head_circumference/head_circumference_read_test'
+require_relative 'head_circumference/head_circumference_provenance_revinclude_search_test'
+require_relative 'head_circumference/head_circumference_validation_test'
+require_relative 'head_circumference/head_circumference_must_support_test'
+require_relative 'head_circumference/head_circumference_reference_resolution_test'
 
 module USCoreTestKit
   module USCoreV311
-    class HeadCircumferencePercentileGroup < Inferno::TestGroup
+    class HeadCircumferenceGroup < Inferno::TestGroup
       title 'Pediatric Head Occipital-frontal Circumference Percentile Tests'
       short_description 'Verify support for the server capabilities required by the US Core Pediatric Head Occipital-frontal Circumference Percentile Profile.'
       description %(
@@ -73,23 +73,23 @@ fail if any attempted read fails.
 
       )
 
-      id :us_core_v311_head_circumference_percentile
+      id :us_core_v311_head_circumference
       run_as_group
 
       def self.metadata
-        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'head_circumference_percentile', 'metadata.yml')))
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'head_circumference', 'metadata.yml')))
       end
   
-      test from: :us_core_v311_head_circumference_percentile_patient_code_search_test
-      test from: :us_core_v311_head_circumference_percentile_patient_category_date_search_test
-      test from: :us_core_v311_head_circumference_percentile_patient_category_status_search_test
-      test from: :us_core_v311_head_circumference_percentile_patient_code_date_search_test
-      test from: :us_core_v311_head_circumference_percentile_patient_category_search_test
-      test from: :us_core_v311_head_circumference_percentile_read_test
-      test from: :us_core_v311_head_circumference_percentile_provenance_revinclude_search_test
-      test from: :us_core_v311_head_circumference_percentile_validation_test
-      test from: :us_core_v311_head_circumference_percentile_must_support_test
-      test from: :us_core_v311_head_circumference_percentile_reference_resolution_test
+      test from: :us_core_v311_head_circumference_patient_code_search_test
+      test from: :us_core_v311_head_circumference_patient_category_date_search_test
+      test from: :us_core_v311_head_circumference_patient_category_status_search_test
+      test from: :us_core_v311_head_circumference_patient_code_date_search_test
+      test from: :us_core_v311_head_circumference_patient_category_search_test
+      test from: :us_core_v311_head_circumference_read_test
+      test from: :us_core_v311_head_circumference_provenance_revinclude_search_test
+      test from: :us_core_v311_head_circumference_validation_test
+      test from: :us_core_v311_head_circumference_must_support_test
+      test from: :us_core_v311_head_circumference_reference_resolution_test
     end
   end
 end

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -20,7 +20,7 @@ require_relative 'pediatric_weight_for_height_group'
 require_relative 'observation_lab_group'
 require_relative 'pediatric_bmi_for_age_group'
 require_relative 'pulse_oximetry_group'
-require_relative 'head_circumference_percentile_group'
+require_relative 'head_circumference_group'
 require_relative 'bodyheight_group'
 require_relative 'bodytemp_group'
 require_relative 'bp_group'
@@ -75,7 +75,7 @@ module USCoreTestKit
       end
 
       group from: :us_core_v311_capability_statement
-
+  
       group from: :us_core_v311_patient
       group from: :us_core_v311_allergy_intolerance
       group from: :us_core_v311_care_plan
@@ -93,7 +93,7 @@ module USCoreTestKit
       group from: :us_core_v311_observation_lab
       group from: :us_core_v311_pediatric_bmi_for_age
       group from: :us_core_v311_pulse_oximetry
-      group from: :us_core_v311_head_circumference_percentile
+      group from: :us_core_v311_head_circumference
       group from: :us_core_v311_bodyheight
       group from: :us_core_v311_bodytemp
       group from: :us_core_v311_bp

--- a/lib/us_core_test_kit/generator/naming.rb
+++ b/lib/us_core_test_kit/generator/naming.rb
@@ -41,7 +41,9 @@ module USCoreTestKit
           resource = group_metadata.resource
           return resource.underscore unless resource_has_multiple_profiles?(resource)
 
-          return 'head_circumference_percentile' if group_metadata.profile_url == HEAD_CIRCUMFERENCE
+          if group_metadata.profile_url == HEAD_CIRCUMFERENCE
+            return group_metadata.reformatted_version == 'v311' ? 'head_circumference' : 'head_circumference_percentile'
+          end
 
           group_metadata.name
             .delete_prefix('us_core_')

--- a/lib/us_core_test_kit/generator/search_test_generator.rb
+++ b/lib/us_core_test_kit/generator/search_test_generator.rb
@@ -132,7 +132,7 @@ module USCoreTestKit
       end
 
       def optional?
-        conformance_expectation != 'SHALL' || !search_metadata[:must_support_or_mandatory] 
+        conformance_expectation != 'SHALL' || !search_metadata[:must_support_or_mandatory]
       end
 
       def search_definition(name)


### PR DESCRIPTION
This PR renames head_circumference_percentile back to head_circumference to be compatible with testing result from previous version. 

This does not affect naming change for v4.0.0 

The PR can be reviewed and merged after PR #22 