### PR TITLE
FI-1514: Fix escaped string interpolation

### DIFF
--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -682,7 +682,7 @@ module USCoreTestKit
               # references can also be URL's, so we made need to resolve those url's
               if ['subject', 'patient'].include? name.to_s
                 id = search_value.split('Patient/').last
-                possible_values = [id, 'Patient/' + id, "#{url}/Patient/\#{id}"]
+                possible_values = [id, "Patient/#{id}", "#{url}/Patient/#{id}"]
                 values_found.any? do |reference|
                   possible_values.include? reference
                 end

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -679,7 +679,7 @@ module USCoreTestKit
               end
             else
               # searching by patient requires special case because we are searching by a resource identifier
-              # references can also be URL's, so we made need to resolve those url's
+              # references can also be URLs, so we may need to resolve those URLs
               if ['subject', 'patient'].include? name.to_s
                 id = search_value.split('Patient/').last
                 possible_values = [id, "Patient/#{id}", "#{url}/Patient/#{id}"]


### PR DESCRIPTION
Fix an incorrectly escaped string interpolation which prevents absolute urls from matching search parameters. Raised in https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/63