### PR TITLE
FI-1508 add DocumentReference custodian test

### DIFF
--- a/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
+++ b/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
@@ -28,22 +28,22 @@ module USCoreTestKit
           has_custodian = docref.custodian.present?
 
           if provenances.present?
-            has_agent_who = provenances.any? do |provenance|
+            has_agent = provenances.any? do |provenance|
               provenance.target.any? { |target| target.reference.end_with?("DocumentReference/#{docref.id}") } &&
-              provenance.agent&.any? { |agent| agent.who.present? }
+              provenance.agent.any? { |agent| agent.who.present? || agent.onBehalfOf.present? }
             end
           end
 
 
-          unless has_custodian || has_agent_who
+          unless has_custodian || has_agent
             messages << {
               type: 'error',
-              message: "DocumentReference/#{docref.id} does not have DocumentReference.custodian or Provenance.agent.who"
+              message: "DocumentReference/#{docref.id} does not have DocumentReference.custodian, Provenance.agent.who, nor Provenance.agent.onBehalfOf"
             }
           end
         end
 
-        assert !messages.any?, "Resource does not have DocumentReference.custodian"
+        assert !messages.any?, "Resource does not have DocumentReference.custodian, Provenance.agent.who, nor Provenance.agent.onBehalfOf"
       end
     end
   end

--- a/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
+++ b/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
@@ -1,0 +1,41 @@
+module USCoreTestKit
+  module USCoreV400
+    class DocumentReferenceCustodianTest < Inferno::Test
+      id :us_core_v400_document_reference_custodian_validation_test
+      title 'DocumentReference resources returned during previous tests have custodian'
+      description %(
+        This test verifies the organization responsible for the DocumentReference is present either in DocumentReference.custodian
+        or accessible in the Provenance resource targeting the DocumentReference using Provenance.agent.who or Provenance.agent.onBehalfOf.
+      )
+
+      def scratch_resources
+        scratch[:document_reference_resources] ||= {}
+      end
+
+      def scratch_provenance_resources
+        scratch[:provenance_resources] ||= {}
+      end
+
+      run do
+        resources = scratch_resources[:all] || []
+
+        skip_if resources.blank?,
+                'No DocumentReference resources appeart to be available. ' \
+                'Please use patients with more information.'
+
+        scratch_resources[:all].each_with_index do |docref, index|
+          has_custodian = docref.custodian.present?
+
+          unless has_custodian
+            messages << {
+              type: 'error',
+              message: "DocumentReference/#{docref.id} does not have DocumentReference.custodian"
+            }
+          end
+        end
+
+        assert !messages.any?, "Resource does not have DocumentReference.custodian"
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
+++ b/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
@@ -24,7 +24,7 @@ module USCoreTestKit
                 'No DocumentReference resources appeart to be available. ' \
                 'Please use patients with more information.'
 
-        scratch_resources[:all].each_with_index do |docref, index|
+        scratch_resources[:all].each do |docref|
           has_custodian = docref.custodian.present?
 
           if provenances.present?

--- a/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
+++ b/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
@@ -1,7 +1,7 @@
 module USCoreTestKit
   module USCoreV400
     class DocumentReferenceCustodianTest < Inferno::Test
-      id :us_core_v400_document_reference_custodian_validation_test
+      id :us_core_v400_document_reference_custodian_test
       title 'DocumentReference resources returned during previous tests have custodian'
       description %(
         This test verifies the organization responsible for the DocumentReference is present either in DocumentReference.custodian

--- a/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
+++ b/lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test.rb
@@ -29,7 +29,7 @@ module USCoreTestKit
 
           if provenances.present?
             has_agent_who = provenances.any? do |provenance|
-              provenance.target.any? { |target| target.reference.include?("DocumentReference/#{docref.id}")} &&
+              provenance.target.any? { |target| target.reference.end_with?("DocumentReference/#{docref.id}") } &&
               provenance.agent&.any? { |agent| agent.who.present? }
             end
           end

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
@@ -369,6 +369,8 @@
   :file_name: document_reference_must_support_test.rb
 - :id: us_core_v400_document_reference_reference_resolution_test
   :file_name: document_reference_reference_resolution_test.rb
+- :id: us_core_v400_document_reference_custodian_test
+  :file_name: "../../custom_groups/v4.0.0/document_reference_custodian_test.rb"
 :id: us_core_v400_document_reference
 :file_name: document_reference_group.rb
 :delayed_references:

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference_group.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference_group.rb
@@ -10,6 +10,7 @@ require_relative 'document_reference/document_reference_provenance_revinclude_se
 require_relative 'document_reference/document_reference_validation_test'
 require_relative 'document_reference/document_reference_must_support_test'
 require_relative 'document_reference/document_reference_reference_resolution_test'
+require_relative '../../custom_groups/v4.0.0/document_reference_custodian_test'
 
 module USCoreTestKit
   module USCoreV400
@@ -96,6 +97,7 @@ fail if any attempted read fails.
       test from: :us_core_v400_document_reference_validation_test
       test from: :us_core_v400_document_reference_must_support_test
       test from: :us_core_v400_document_reference_reference_resolution_test
+      test from: :us_core_v400_document_reference_custodian_test
     end
   end
 end

--- a/lib/us_core_test_kit/generator/group_generator.rb
+++ b/lib/us_core_test_kit/generator/group_generator.rb
@@ -80,10 +80,18 @@ module USCoreTestKit
       end
 
       def generate
+        add_special_tests
         File.open(output_file_name, 'w') { |f| f.write(output) }
         group_metadata.id = group_id
         group_metadata.file_name = base_output_file_name
         File.open(metadata_file_name, 'w') { |f| f.write(YAML.dump(group_metadata.to_hash)) }
+      end
+
+      def add_special_tests
+        group_metadata.add_test(
+          id: 'us_core_v400_document_reference_custodian_test',
+          file_name: '../../custom_groups/v4.0.0/document_reference_custodian_test.rb'
+        ) if group_metadata.resource == 'DocumentReference' && group_metadata.reformatted_version == 'v400'
       end
 
       def test_id_list
@@ -93,7 +101,10 @@ module USCoreTestKit
 
       def test_file_list
         @test_file_list ||=
-          group_metadata.tests.map { |test| test[:file_name].delete_suffix('.rb') }
+          group_metadata.tests.map do |test|
+            name_without_suffix = test[:file_name].delete_suffix('.rb')
+            name_without_suffix.start_with?('..') ? name_without_suffix : "#{profile_identifier}/#{name_without_suffix}"
+          end
       end
 
       def required_searches

--- a/lib/us_core_test_kit/generator/templates/group.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/group.rb.erb
@@ -1,4 +1,4 @@
-<% test_file_list.each do |file_name| %>require_relative '<%= profile_identifier %>/<%= file_name %>'
+<% test_file_list.each do |file_name| %>require_relative '<%= file_name %>'
 <% end %>
 module USCoreTestKit
   module <%= module_name %>

--- a/spec/us_core/document_reference_custodian_test_spec.rb
+++ b/spec/us_core/document_reference_custodian_test_spec.rb
@@ -85,7 +85,30 @@ RSpec.describe USCoreTestKit::USCoreV400::DocumentReferenceCustodianTest do
       )
 
     result = run(document_reference_custodian_test)
-    binding.pry
     expect(result.result).to eq('pass')
+  end
+
+  it 'fails if no Provenance.target does not have this DocumentReference' do
+    allow_any_instance_of(document_reference_custodian_test)
+      .to receive(:scratch_resources).and_return(
+        {
+          all: [ documentreference ]
+        }
+      )
+
+    provenance.target = [
+      FHIR::Reference.new(reference: 'DocumentReference/100')
+    ]
+    provenance.agent << FHIR::Provenance::Agent.new(who: FHIR::Reference.new(reference: 'Organization/1'))
+
+    allow_any_instance_of(document_reference_custodian_test)
+      .to receive(:scratch_provenance_resources).and_return(
+        {
+          all: [ provenance ]
+        }
+      )
+
+    result = run(document_reference_custodian_test)
+    expect(result.result).to eq('fail')
   end
 end

--- a/spec/us_core/document_reference_custodian_test_spec.rb
+++ b/spec/us_core/document_reference_custodian_test_spec.rb
@@ -1,0 +1,66 @@
+require_relative '../../lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test'
+
+RSpec.describe USCoreTestKit::USCoreV400::DocumentReferenceCustodianTest do
+  let(:document_reference_custodian_test) { Inferno::Repositories::Tests.new.find('us_core_v400_document_reference_custodian_validation_test') }
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('us_core_v400') }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name: name,
+        value: value,
+        type: runnable.config.input_type(name)
+      )
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  it 'skips if no DocumentReference saved' do
+    allow_any_instance_of(document_reference_custodian_test)
+    .to receive(:scratch_resources).and_return({})
+
+    result = run(document_reference_custodian_test)
+    expect(result.result).to eq('skip')
+  end
+
+  it 'passes if no DocumentReference.custodian presents' do
+    allow_any_instance_of(document_reference_custodian_test)
+    .to receive(:scratch_resources).and_return(
+      {
+        all: [
+          FHIR::DocumentReference.new(
+            id: '1',
+            custodian: FHIR::Reference.new(
+              reference: 'Oganization/1'
+            )
+          )
+        ]
+      }
+    )
+
+    result = run(document_reference_custodian_test)
+    expect(result.result).to eq('pass')
+  end
+
+  it 'fails if no DocumentReference.custodian is not present' do
+    allow_any_instance_of(document_reference_custodian_test)
+    .to receive(:scratch_resources).and_return(
+      {
+        all: [
+          FHIR::DocumentReference.new(
+            id: '1'
+          )
+        ]
+      }
+    )
+
+    result = run(document_reference_custodian_test)
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to eq('Resource does not have DocumentReference.custodian')
+  end
+end

--- a/spec/us_core/document_reference_custodian_test_spec.rb
+++ b/spec/us_core/document_reference_custodian_test_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe USCoreTestKit::USCoreV400::DocumentReferenceCustodianTest do
     expect(result.result).to eq('skip')
   end
 
-  it 'passes if no DocumentReference.custodian presents' do
+  it 'passes if DocumentReference.custodian presents' do
     documentreference.custodian = FHIR::Reference.new(
       reference: 'Oganization/1'
     )
@@ -87,7 +87,7 @@ RSpec.describe USCoreTestKit::USCoreV400::DocumentReferenceCustodianTest do
     expect(result.result).to eq('pass')
   end
 
-  it 'fails if no Provenance.target does not have this DocumentReference' do
+  it 'fails if Provenance.target does not include DocumentReference/1' do
     allow_any_instance_of(document_reference_custodian_test)
       .to receive(:scratch_resources).and_return(
         {

--- a/spec/us_core/document_reference_custodian_test_spec.rb
+++ b/spec/us_core/document_reference_custodian_test_spec.rb
@@ -64,10 +64,9 @@ RSpec.describe USCoreTestKit::USCoreV400::DocumentReferenceCustodianTest do
 
     result = run(document_reference_custodian_test)
     expect(result.result).to eq('fail')
-    expect(result.result_message).to eq('Resource does not have DocumentReference.custodian')
   end
 
-  it 'passes if no Provenance.agent.who presents' do
+  it 'passes if Provenance.agent.who presents' do
     allow_any_instance_of(document_reference_custodian_test)
       .to receive(:scratch_resources).and_return(
         {
@@ -110,5 +109,26 @@ RSpec.describe USCoreTestKit::USCoreV400::DocumentReferenceCustodianTest do
 
     result = run(document_reference_custodian_test)
     expect(result.result).to eq('fail')
+  end
+
+  it 'passes if Provenance.agent.onBehalfOf presents' do
+    allow_any_instance_of(document_reference_custodian_test)
+      .to receive(:scratch_resources).and_return(
+        {
+          all: [ documentreference ]
+        }
+      )
+
+    provenance.agent << FHIR::Provenance::Agent.new(onBehalfOf: FHIR::Reference.new(reference: 'Organization/1'))
+
+    allow_any_instance_of(document_reference_custodian_test)
+      .to receive(:scratch_provenance_resources).and_return(
+        {
+          all: [ provenance ]
+        }
+      )
+
+    result = run(document_reference_custodian_test)
+    expect(result.result).to eq('pass')
   end
 end

--- a/spec/us_core/document_reference_custodian_test_spec.rb
+++ b/spec/us_core/document_reference_custodian_test_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../lib/us_core_test_kit/custom_groups/v4.0.0/document_reference_custodian_test'
 
 RSpec.describe USCoreTestKit::USCoreV400::DocumentReferenceCustodianTest do
-  let(:document_reference_custodian_test) { Inferno::Repositories::Tests.new.find('us_core_v400_document_reference_custodian_validation_test') }
+  let(:document_reference_custodian_test) { Inferno::Repositories::Tests.new.find('us_core_v400_document_reference_custodian_test') }
   let(:suite) { Inferno::Repositories::TestSuites.new.find('us_core_v400') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }


### PR DESCRIPTION
This PR adds a custom test for that DocumentReference SHALL have a custodian (DocumentReference.custodian or Provenance.agent.who or Provenance.agent.onBehalfOf