### PR TITLE
FI-1523: Fix error message in read tests when id does not match

### DIFF
--- a/lib/us_core_test_kit/read_test.rb
+++ b/lib/us_core_test_kit/read_test.rb
@@ -52,7 +52,7 @@ module USCoreTestKit
     end
 
     def bad_resource_id_message(expected_id)
-      "Expected resource to have id: `#{id}`, but found `#{resource.id}`"
+      "Expected resource to have id: `#{expected_id.inspect}`, but found `#{resource.id.inspect}`"
     end
 
     def resource_class


### PR DESCRIPTION
Issue raised in https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/71

We're mistakenly adding the test id rather than the resource id to the error message. I added `inspect` to the message so that it will be possible to differentiate between strings and integers in the message.