### PR TITLE
FI-1539 Omit medication resource validation if no medication resources provided.

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/allergy_intolerance_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/allergy_intolerance_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/allergy_intolerance_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/allergy_intolerance_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_allergy_intolerance_validation_test
       title 'AllergyIntolerance resources returned during previous tests conform to the US Core AllergyIntolerance Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core AllergyIntolerance Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyheight/bodyheight_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyheight/bodyheight_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_bodyheight_validation_test
       title 'Observation resources returned during previous tests conform to the Observation Body Height Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [Observation Body Height Profile](http://hl7.org/fhir/StructureDefinition/bodyheight).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/StructureDefinition/bodyheight')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/StructureDefinition/bodyheight',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyheight/bodyheight_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyheight/bodyheight_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/StructureDefinition/bodyheight',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/bodytemp/bodytemp_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodytemp/bodytemp_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_bodytemp_validation_test
       title 'Observation resources returned during previous tests conform to the Observation Body Temperature Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [Observation Body Temperature Profile](http://hl7.org/fhir/StructureDefinition/bodytemp).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/StructureDefinition/bodytemp')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/StructureDefinition/bodytemp',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/bodytemp/bodytemp_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodytemp/bodytemp_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/StructureDefinition/bodytemp',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyweight/bodyweight_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyweight/bodyweight_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/StructureDefinition/bodyweight',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyweight/bodyweight_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyweight/bodyweight_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_bodyweight_validation_test
       title 'Observation resources returned during previous tests conform to the Observation Body Weight Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [Observation Body Weight Profile](http://hl7.org/fhir/StructureDefinition/bodyweight).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/StructureDefinition/bodyweight')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/StructureDefinition/bodyweight',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/bp/bp_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bp/bp_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/StructureDefinition/bp',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/bp/bp_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bp/bp_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_bp_validation_test
       title 'Observation resources returned during previous tests conform to the Observation Blood Pressure Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [Observation Blood Pressure Profile](http://hl7.org/fhir/StructureDefinition/bp).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/StructureDefinition/bp')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/StructureDefinition/bp',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/care_plan/care_plan_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/care_plan/care_plan_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_care_plan_validation_test
       title 'CarePlan resources returned during previous tests conform to the US Core CarePlan Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core CarePlan Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/care_plan/care_plan_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/care_plan/care_plan_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/care_team/care_team_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/care_team/care_team_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_care_team_validation_test
       title 'CareTeam resources returned during previous tests conform to the US Core CareTeam Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core CareTeam Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/care_team/care_team_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/care_team/care_team_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/condition/condition_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/condition/condition_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/condition/condition_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/condition/condition_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_condition_validation_test
       title 'Condition resources returned during previous tests conform to the US Core Condition Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Condition Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/device/device_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/device/device_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_device_validation_test
       title 'Device resources returned during previous tests conform to the US Core Implantable Device Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Implantable Device Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/device/device_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/device/device_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/diagnostic_report_lab_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/diagnostic_report_lab_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/diagnostic_report_lab_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/diagnostic_report_lab_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_diagnostic_report_lab_validation_test
       title 'DiagnosticReport resources returned during previous tests conform to the US Core DiagnosticReport Profile for Laboratory Results Reporting'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core DiagnosticReport Profile for Laboratory Results Reporting](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_note/diagnostic_report_note_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_note/diagnostic_report_note_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_note/diagnostic_report_note_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_note/diagnostic_report_note_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_diagnostic_report_note_validation_test
       title 'DiagnosticReport resources returned during previous tests conform to the US Core DiagnosticReport Profile for Report and Note exchange'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core DiagnosticReport Profile for Report and Note exchange](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_document_reference_validation_test
       title 'DocumentReference resources returned during previous tests conform to the US Core DocumentReference Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core DocumentReference Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/encounter/encounter_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/encounter/encounter_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/encounter/encounter_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/encounter/encounter_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_encounter_validation_test
       title 'Encounter resources returned during previous tests conform to the US Core Encounter Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Encounter Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/goal/goal_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/goal/goal_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_goal_validation_test
       title 'Goal resources returned during previous tests conform to the US Core Goal Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Goal Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/goal/goal_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/goal/goal_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
@@ -154,7 +154,7 @@
   :path: target.measure
 - :type: Quantity
   :strength: example
-  :system:
+  :system: 
   :path: target.detail
 - :type: CodeableConcept
   :strength: example

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_head_circumference_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Pediatric Head Occipital-frontal Circumference Percentile Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Pediatric Head Occipital-frontal Circumference Percentile Profile](http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/heartrate/heartrate_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/heartrate/heartrate_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_heartrate_validation_test
       title 'Observation resources returned during previous tests conform to the Observation Heart Rate Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [Observation Heart Rate Profile](http://hl7.org/fhir/StructureDefinition/heartrate).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/StructureDefinition/heartrate')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/StructureDefinition/heartrate',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/heartrate/heartrate_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/heartrate/heartrate_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/StructureDefinition/heartrate',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/immunization/immunization_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/immunization/immunization_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_immunization_validation_test
       title 'Immunization resources returned during previous tests conform to the US Core Immunization Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Immunization Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/immunization/immunization_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/immunization/immunization_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/medication_request/medication_request_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/medication_request/medication_request_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_medication_request_validation_test
       title 'MedicationRequest resources returned during previous tests conform to the US Core MedicationRequest Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core MedicationRequest Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/medication_request/medication_request_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/medication_request/medication_request_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/medication_request/medication_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/medication_request/medication_validation_test.rb
@@ -31,7 +31,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication',
-                                must_demonstrate_resource_type: false)
+                                skip_if_empty: false)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/medication_request/medication_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/medication_request/medication_validation_test.rb
@@ -8,7 +8,7 @@ module USCoreTestKit
       id :us_core_v311_medication_validation_test
       title 'Medication resources returned during previous tests conform to the US Core Medication Profile'
       description %(
-  This test verifies resources returned from previous tests conform to
+This test verifies resources returned from previous tests conform to
 the [US Core Medication Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication).
 
 It verifies the presence of mandatory elements and that elements with
@@ -29,7 +29,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication',
+                                must_demonstrate_resource_type: false)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -5269,7 +5269,7 @@
     :path: target.measure
   - :type: Quantity
     :strength: example
-    :system:
+    :system: 
     :path: target.detail
   - :type: CodeableConcept
     :strength: example

--- a/lib/us_core_test_kit/generated/v3.1.1/observation_lab/observation_lab_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/observation_lab/observation_lab_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/observation_lab/observation_lab_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/observation_lab/observation_lab_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_observation_lab_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Laboratory Result Observation Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Laboratory Result Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/organization/organization_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/organization/organization_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_organization_validation_test
       title 'Organization resources returned during previous tests conform to the US Core Organization Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Organization Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/organization/organization_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/organization/organization_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/patient/patient_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/patient/patient_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_patient_validation_test
       title 'Patient resources returned during previous tests conform to the US Core Patient Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Patient Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/patient/patient_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/patient/patient_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/pediatric_bmi_for_age_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/pediatric_bmi_for_age_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/pediatric_bmi_for_age_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/pediatric_bmi_for_age_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_pediatric_bmi_for_age_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Pediatric BMI for Age Observation Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Pediatric BMI for Age Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/pediatric_weight_for_height_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/pediatric_weight_for_height_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/pediatric_weight_for_height_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/pediatric_weight_for_height_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_pediatric_weight_for_height_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Pediatric Weight for Height Observation Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Pediatric Weight for Height Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/practitioner/practitioner_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/practitioner/practitioner_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/practitioner/practitioner_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/practitioner/practitioner_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_practitioner_validation_test
       title 'Practitioner resources returned during previous tests conform to the US Core Practitioner Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Practitioner Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/procedure/procedure_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/procedure/procedure_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_procedure_validation_test
       title 'Procedure resources returned during previous tests conform to the US Core Procedure Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Procedure Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/procedure/procedure_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/procedure/procedure_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/provenance/provenance_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/provenance/provenance_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_provenance_validation_test
       title 'Provenance resources returned during previous tests conform to the US Core Provenance Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Provenance Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/provenance/provenance_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/provenance/provenance_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_pulse_oximetry_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Pulse Oximetry Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Pulse Oximetry Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/resprate/resprate_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/resprate/resprate_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/StructureDefinition/resprate',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/resprate/resprate_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/resprate/resprate_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_resprate_validation_test
       title 'Observation resources returned during previous tests conform to the Observation Respiratory Rate Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [Observation Respiratory Rate Profile](http://hl7.org/fhir/StructureDefinition/resprate).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/StructureDefinition/resprate')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/StructureDefinition/resprate',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/smokingstatus_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/smokingstatus_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v311_smokingstatus_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Smoking Status Observation Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Smoking Status Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/smokingstatus_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/smokingstatus_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/allergy_intolerance_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/allergy_intolerance_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/allergy_intolerance_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/allergy_intolerance_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_allergy_intolerance_validation_test
       title 'AllergyIntolerance resources returned during previous tests conform to the US Core AllergyIntolerance Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core AllergyIntolerance Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_blood_pressure_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Blood Pressure Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Blood Pressure Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/bmi/bmi_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/bmi/bmi_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_bmi_validation_test
       title 'Observation resources returned during previous tests conform to the US Core BMI Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core BMI Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/bmi/bmi_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/bmi/bmi_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/body_height/body_height_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_height/body_height_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/body_height/body_height_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_height/body_height_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_body_height_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Body Height Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Body Height Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/body_temperature/body_temperature_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_temperature/body_temperature_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_body_temperature_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Body Temperature Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Body Temperature Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/body_temperature/body_temperature_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_temperature/body_temperature_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/body_weight/body_weight_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_weight/body_weight_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/body_weight/body_weight_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_weight/body_weight_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_body_weight_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Body Weight Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Body Weight Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/care_plan/care_plan_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_plan/care_plan_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_care_plan_validation_test
       title 'CarePlan resources returned during previous tests conform to the US Core CarePlan Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core CarePlan Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/care_plan/care_plan_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_plan/care_plan_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/care_team/care_team_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_team/care_team_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_care_team_validation_test
       title 'CareTeam resources returned during previous tests conform to the US Core CareTeam Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core CareTeam Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/care_team/care_team_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_team/care_team_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/condition/condition_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/condition/condition_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/condition/condition_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/condition/condition_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_condition_validation_test
       title 'Condition resources returned during previous tests conform to the US Core Condition Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Condition Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/device/device_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/device/device_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/device/device_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/device/device_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_device_validation_test
       title 'Device resources returned during previous tests conform to the US Core Implantable Device Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Implantable Device Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/diagnostic_report_lab_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/diagnostic_report_lab_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/diagnostic_report_lab_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/diagnostic_report_lab_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_diagnostic_report_lab_validation_test
       title 'DiagnosticReport resources returned during previous tests conform to the US Core DiagnosticReport Profile for Laboratory Results Reporting'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core DiagnosticReport Profile for Laboratory Results Reporting](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/diagnostic_report_note_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/diagnostic_report_note_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_diagnostic_report_note_validation_test
       title 'DiagnosticReport resources returned during previous tests conform to the US Core DiagnosticReport Profile for Report and Note exchange'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core DiagnosticReport Profile for Report and Note exchange](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/diagnostic_report_note_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/diagnostic_report_note_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference/document_reference_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference/document_reference_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_document_reference_validation_test
       title 'DocumentReference resources returned during previous tests conform to the US Core DocumentReference Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core DocumentReference Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference/document_reference_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference/document_reference_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/encounter/encounter_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/encounter/encounter_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/encounter/encounter_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/encounter/encounter_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_encounter_validation_test
       title 'Encounter resources returned during previous tests conform to the US Core Encounter Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Encounter Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/goal/goal_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/goal/goal_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_goal_validation_test
       title 'Goal resources returned during previous tests conform to the US Core Goal Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Goal Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/goal/goal_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/goal/goal_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
@@ -151,7 +151,7 @@
   :path: target.measure
 - :type: Quantity
   :strength: example
-  :system:
+  :system: 
   :path: target.detail
 - :type: CodeableConcept
   :strength: example

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference/head_circumference_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference/head_circumference_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference/head_circumference_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference/head_circumference_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_head_circumference_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Head Circumference Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Head Circumference Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/head_circumference_percentile_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/head_circumference_percentile_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_head_circumference_percentile_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Pediatric Head Occipital-frontal Circumference Percentile Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Pediatric Head Occipital-frontal Circumference Percentile Profile](http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/head_circumference_percentile_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/head_circumference_percentile_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/heart_rate/heart_rate_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/heart_rate/heart_rate_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_heart_rate_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Heart Rate Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Heart Rate Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/heart_rate/heart_rate_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/heart_rate/heart_rate_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/immunization/immunization_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/immunization/immunization_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_immunization_validation_test
       title 'Immunization resources returned during previous tests conform to the US Core Immunization Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Immunization Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/immunization/immunization_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/immunization/immunization_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_request_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_request_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_medication_request_validation_test
       title 'MedicationRequest resources returned during previous tests conform to the US Core MedicationRequest Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core MedicationRequest Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_request_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_request_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_validation_test.rb
@@ -31,7 +31,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication',
-                                must_demonstrate_resource_type: false)
+                                skip_if_empty: false)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_validation_test.rb
@@ -8,7 +8,7 @@ module USCoreTestKit
       id :us_core_v400_medication_validation_test
       title 'Medication resources returned during previous tests conform to the US Core Medication Profile'
       description %(
-  This test verifies resources returned from previous tests conform to
+This test verifies resources returned from previous tests conform to
 the [US Core Medication Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication).
 
 It verifies the presence of mandatory elements and that elements with
@@ -29,7 +29,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication',
+                                must_demonstrate_resource_type: false)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -5307,7 +5307,7 @@
     :path: target.measure
   - :type: Quantity
     :strength: example
-    :system:
+    :system: 
     :path: target.detail
   - :type: CodeableConcept
     :strength: example

--- a/lib/us_core_test_kit/generated/v4.0.0/observation_lab/observation_lab_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/observation_lab/observation_lab_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/observation_lab/observation_lab_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/observation_lab/observation_lab_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_observation_lab_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Laboratory Result Observation Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Laboratory Result Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/organization/organization_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/organization/organization_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_organization_validation_test
       title 'Organization resources returned during previous tests conform to the US Core Organization Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Organization Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/organization/organization_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/organization/organization_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_patient_validation_test
       title 'Patient resources returned during previous tests conform to the US Core Patient Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Patient Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/pediatric_bmi_for_age_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/pediatric_bmi_for_age_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/pediatric_bmi_for_age_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/pediatric_bmi_for_age_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_pediatric_bmi_for_age_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Pediatric BMI for Age Observation Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Pediatric BMI for Age Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/pediatric_weight_for_height_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/pediatric_weight_for_height_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/pediatric_weight_for_height_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/pediatric_weight_for_height_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_pediatric_weight_for_height_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Pediatric Weight for Height Observation Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Pediatric Weight for Height Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/practitioner/practitioner_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/practitioner/practitioner_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/practitioner/practitioner_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/practitioner/practitioner_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_practitioner_validation_test
       title 'Practitioner resources returned during previous tests conform to the US Core Practitioner Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Practitioner Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/procedure/procedure_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/procedure/procedure_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_procedure_validation_test
       title 'Procedure resources returned during previous tests conform to the US Core Procedure Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Procedure Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/procedure/procedure_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/procedure/procedure_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/provenance_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/provenance_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/provenance_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/provenance_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_provenance_validation_test
       title 'Provenance resources returned during previous tests conform to the US Core Provenance Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Provenance Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_pulse_oximetry_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Pulse Oximetry Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Pulse Oximetry Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/respiratory_rate_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/respiratory_rate_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_respiratory_rate_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Respiratory Rate Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Respiratory Rate Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/respiratory_rate_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/respiratory_rate_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/smokingstatus_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/smokingstatus_validation_test.rb
@@ -8,8 +8,9 @@ module USCoreTestKit
       id :us_core_v400_smokingstatus_validation_test
       title 'Observation resources returned during previous tests conform to the US Core Smoking Status Observation Profile'
       description %(
-  This test verifies resources returned from the first search conform to
+This test verifies resources returned from the first search conform to
 the [US Core Smoking Status Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus).
+Systems must demonstrate at least one valid example in order to pass this test.
 
 It verifies the presence of mandatory elements and that elements with
 required bindings contain appropriate values. CodeableConcept element
@@ -29,7 +30,9 @@ fail if their code/system are not found in the valueset.
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus')
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
+                                must_demonstrate_resource_type: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/smokingstatus_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/smokingstatus_validation_test.rb
@@ -32,7 +32,7 @@ fail if their code/system are not found in the valueset.
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
       end
     end
   end

--- a/lib/us_core_test_kit/generator/templates/validation.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/validation.rb.erb
@@ -23,7 +23,7 @@ module USCoreTestKit
       run do
         perform_validation_test(scratch_resources[:all] || [],
                                 '<%= profile_url %>',
-                                must_demonstrate_resource_type: <%= must_demonstrate_resource_type %>)
+                                skip_if_empty: <%= skip_if_empty %>)
       end
     end
   end

--- a/lib/us_core_test_kit/generator/templates/validation.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/validation.rb.erb
@@ -8,7 +8,7 @@ module USCoreTestKit
       id :<%= test_id %>
       title '<%= resource_type %> resources returned during previous tests conform to the <%= profile_name %>'
       description %(
-  <%= description %>
+<%= description %>
       )
       output :dar_code_found, :dar_extension_found
 
@@ -21,7 +21,9 @@ module USCoreTestKit
       end
 
       run do
-        perform_validation_test(scratch_resources[:all] || [], '<%= profile_url %>')
+        perform_validation_test(scratch_resources[:all] || [],
+                                '<%= profile_url %>',
+                                must_demonstrate_resource_type: <%= must_demonstrate_resource_type %>)
       end
     end
   end

--- a/lib/us_core_test_kit/generator/validation_test_generator.rb
+++ b/lib/us_core_test_kit/generator/validation_test_generator.rb
@@ -84,6 +84,12 @@ module USCoreTestKit
         read_interaction[:expectation]
       end
 
+      def must_demonstrate_resource_type
+        # Return true if a system must demonstrate at least one example of the resource type.
+        # This drives omit vs. skip result statuses in this test.
+        resource_type != 'Medication'
+      end
+
       def generate
         FileUtils.mkdir_p(output_file_directory)
         File.open(output_file_name, 'w') { |f| f.write(output) }
@@ -121,6 +127,7 @@ module USCoreTestKit
           <<~GENERIC_INTRO
           This test verifies resources returned from the first search conform to
           the [#{profile_name}](#{profile_url}).
+          Systems must demonstrate at least one valid example in order to pass this test.
           GENERIC_INTRO
         end
       end

--- a/lib/us_core_test_kit/generator/validation_test_generator.rb
+++ b/lib/us_core_test_kit/generator/validation_test_generator.rb
@@ -84,7 +84,7 @@ module USCoreTestKit
         read_interaction[:expectation]
       end
 
-      def must_demonstrate_resource_type
+      def skip_if_empty
         # Return true if a system must demonstrate at least one example of the resource type.
         # This drives omit vs. skip result statuses in this test.
         resource_type != 'Medication'

--- a/lib/us_core_test_kit/validation_test.rb
+++ b/lib/us_core_test_kit/validation_test.rb
@@ -3,9 +3,15 @@ module USCoreTestKit
     DAR_CODE_SYSTEM_URL = 'http://terminology.hl7.org/CodeSystem/data-absent-reason'.freeze
     DAR_EXTENSION_URL = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'.freeze
 
-    def perform_validation_test(resources, profile_url)
-      skip_if resources.blank?,
-              "No #{resource_type} resources conforming to the #{profile_url} profile were returned."
+    def perform_validation_test(resources,
+                                profile_url,
+                                must_demonstrate_resource_type: true)
+
+      skip_if must_demonstrate_resource_type && resources.blank?,
+              "No #{resource_type} resources conforming to the #{profile_url} profile were returned"
+
+      omit_if resources.blank?,
+              "No #{resource_type} resources provided so the #{profile_url} profile does not apply"
 
       resources.each do |resource|
         resource_is_valid?(resource: resource, profile_url: profile_url)

--- a/lib/us_core_test_kit/validation_test.rb
+++ b/lib/us_core_test_kit/validation_test.rb
@@ -5,9 +5,9 @@ module USCoreTestKit
 
     def perform_validation_test(resources,
                                 profile_url,
-                                must_demonstrate_resource_type: true)
+                                skip_if_empty: true)
 
-      skip_if must_demonstrate_resource_type && resources.blank?,
+      skip_if skip_if_empty && resources.blank?,
               "No #{resource_type} resources conforming to the #{profile_url} profile were returned"
 
       omit_if resources.blank?,


### PR DESCRIPTION
Test 13.08 in the v3.1.1 US Core Test kit should not 'skip' systems that do not provide any medication resources, because they are optional to implement (you can provide `MedicationRequest.medicationCodeableConcept` instead of a reference to a Medication resource per US Core).  This also applies to US Core 4.0.0.

To test, run against the Reference server against only patient 355.  Previously, the test would skip against this resource, because it provides no example of Medication references in MedicationRequest.  Now, it will omit.  We didn't notice this because we typically test against both patients 85 and 355, and patient 85 provides an example of this.

This was reported against the g10 test kit here: https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/101