### PR TITLE
Change Patient.name.use MS to Patient.name.period.end MS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This is an [Inferno](https://github.com/inferno-community/inferno-core) test kit
 for the [US Core Implementation Guide
-v3.1.1](http://hl7.org/fhir/us/core/STU3.1.1/).
+v3.1.1](http://hl7.org/fhir/us/core/STU3.1.1/), and [US Core Implementation Guide
+v4.0.0](http://hl7.org/fhir/us/core/STU4/)
 
 It is highly recommended that you use [Docker](https://www.docker.com/) to run
 these tests so that you don't have to configure ruby and the FHIR validator

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -12145,8 +12145,7 @@
     - :path: communication.language
     - :path: telecom
     - :path: name.suffix
-    - :path: name.use
-      :fixed_value: old
+    - :path: name.period.end
   :mandatory_elements:
   - Patient.identifier
   - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -177,8 +177,7 @@
   - :path: communication.language
   - :path: telecom
   - :path: name.suffix
-  - :path: name.use
-    :fixed_value: old
+  - :path: name.period.end
 :mandatory_elements:
 - Patient.identifier
 - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
@@ -30,8 +30,8 @@ module USCoreTestKit
         * Patient.name
         * Patient.name.family
         * Patient.name.given
+        * Patient.name.period.end
         * Patient.name.suffix
-        * Patient.name.use
         * Patient.telecom
         * Patient.telecom.system
         * Patient.telecom.use

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -394,8 +394,7 @@ module USCoreTestKit
             path: 'name.suffix'
           }
           @must_supports[:elements] << {
-            path: 'name.use',
-            fixed_value: 'old'
+            path: 'name.period.end'
           }
         end
       end


### PR DESCRIPTION
A minor fix of MustSupport verification for Patient's previous name.

US Core v4.0 uses Patient.name.period.end
US Core v5.0 uses Patient.name.use == 'old'

Fix MustSupport check to use the correct logic in US Core v4.0.

Also add US Core v.4 support in README