### PR TITLE
FI-1557 Fix Patient's previous name Must Support test

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This is an [Inferno](https://github.com/inferno-community/inferno-core) test kit
 for the [US Core Implementation Guide
-v3.1.1](http://hl7.org/fhir/us/core/STU3.1.1/).
+v3.1.1](http://hl7.org/fhir/us/core/STU3.1.1/), and [US Core Implementation Guide
+v4.0.0](http://hl7.org/fhir/us/core/STU4/)
 
 It is highly recommended that you use [Docker](https://www.docker.com/) to run
 these tests so that you don't have to configure ruby and the FHIR validator

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -12119,13 +12119,10 @@
     :extensions:
     - :id: Patient.extension:race
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
-      :uscdi_only: true
     - :id: Patient.extension:ethnicity
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
-      :uscdi_only: true
     - :id: Patient.extension:birthsex
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
-      :uscdi_only: true
     :slices: []
     :elements:
     - :path: identifier
@@ -12135,11 +12132,8 @@
     - :path: name.family
     - :path: name.given
     - :path: telecom.system
-      :uscdi_only: true
     - :path: telecom.value
-      :uscdi_only: true
     - :path: telecom.use
-      :uscdi_only: true
     - :path: gender
     - :path: birthDate
     - :path: address
@@ -12149,19 +12143,14 @@
     - :path: address.postalCode
     - :path: address.period
     - :path: communication.language
-      :uscdi_only: true
     - :path: name.suffix
-      :uscdi_only: true
     - :path: name.use
       :fixed_value: old
-      :uscdi_only: true
     - :path: name.period.end
-      :uscdi_only: true
     :choices:
     - :paths:
       - name.period.end
       - name.use
-      :uscdi_only: true
   :mandatory_elements:
   - Patient.identifier
   - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -12119,10 +12119,13 @@
     :extensions:
     - :id: Patient.extension:race
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
+      :uscdi_only: true
     - :id: Patient.extension:ethnicity
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
+      :uscdi_only: true
     - :id: Patient.extension:birthsex
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+      :uscdi_only: true
     :slices: []
     :elements:
     - :path: identifier
@@ -12132,8 +12135,11 @@
     - :path: name.family
     - :path: name.given
     - :path: telecom.system
+      :uscdi_only: true
     - :path: telecom.value
+      :uscdi_only: true
     - :path: telecom.use
+      :uscdi_only: true
     - :path: gender
     - :path: birthDate
     - :path: address
@@ -12143,9 +12149,19 @@
     - :path: address.postalCode
     - :path: address.period
     - :path: communication.language
-    - :path: telecom
+      :uscdi_only: true
     - :path: name.suffix
+      :uscdi_only: true
+    - :path: name.use
+      :fixed_value: old
+      :uscdi_only: true
     - :path: name.period.end
+      :uscdi_only: true
+    :choices:
+    - :paths:
+      - name.period.end
+      - name.use
+      :uscdi_only: true
   :mandatory_elements:
   - Patient.identifier
   - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -12145,8 +12145,7 @@
     - :path: communication.language
     - :path: telecom
     - :path: name.suffix
-    - :path: name.use
-      :fixed_value: old
+    - :path: name.period.end
   :mandatory_elements:
   - Patient.identifier
   - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -151,13 +151,10 @@
   :extensions:
   - :id: Patient.extension:race
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
-    :uscdi_only: true
   - :id: Patient.extension:ethnicity
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
-    :uscdi_only: true
   - :id: Patient.extension:birthsex
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
-    :uscdi_only: true
   :slices: []
   :elements:
   - :path: identifier
@@ -167,11 +164,8 @@
   - :path: name.family
   - :path: name.given
   - :path: telecom.system
-    :uscdi_only: true
   - :path: telecom.value
-    :uscdi_only: true
   - :path: telecom.use
-    :uscdi_only: true
   - :path: gender
   - :path: birthDate
   - :path: address
@@ -181,19 +175,14 @@
   - :path: address.postalCode
   - :path: address.period
   - :path: communication.language
-    :uscdi_only: true
   - :path: name.suffix
-    :uscdi_only: true
   - :path: name.use
     :fixed_value: old
-    :uscdi_only: true
   - :path: name.period.end
-    :uscdi_only: true
   :choices:
   - :paths:
     - name.period.end
     - name.use
-    :uscdi_only: true
 :mandatory_elements:
 - Patient.identifier
 - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -177,8 +177,7 @@
   - :path: communication.language
   - :path: telecom
   - :path: name.suffix
-  - :path: name.use
-    :fixed_value: old
+  - :path: name.period.end
 :mandatory_elements:
 - Patient.identifier
 - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -151,10 +151,13 @@
   :extensions:
   - :id: Patient.extension:race
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
+    :uscdi_only: true
   - :id: Patient.extension:ethnicity
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
+    :uscdi_only: true
   - :id: Patient.extension:birthsex
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    :uscdi_only: true
   :slices: []
   :elements:
   - :path: identifier
@@ -164,8 +167,11 @@
   - :path: name.family
   - :path: name.given
   - :path: telecom.system
+    :uscdi_only: true
   - :path: telecom.value
+    :uscdi_only: true
   - :path: telecom.use
+    :uscdi_only: true
   - :path: gender
   - :path: birthDate
   - :path: address
@@ -175,9 +181,19 @@
   - :path: address.postalCode
   - :path: address.period
   - :path: communication.language
-  - :path: telecom
+    :uscdi_only: true
   - :path: name.suffix
+    :uscdi_only: true
+  - :path: name.use
+    :fixed_value: old
+    :uscdi_only: true
   - :path: name.period.end
+    :uscdi_only: true
+  :choices:
+  - :paths:
+    - name.period.end
+    - name.use
+    :uscdi_only: true
 :mandatory_elements:
 - Patient.identifier
 - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
@@ -32,7 +32,7 @@ module USCoreTestKit
         * Patient.name.given
         * Patient.name.period.end
         * Patient.name.suffix
-        * Patient.telecom
+        * Patient.name.use
         * Patient.telecom.system
         * Patient.telecom.use
         * Patient.telecom.value

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
@@ -30,8 +30,8 @@ module USCoreTestKit
         * Patient.name
         * Patient.name.family
         * Patient.name.given
+        * Patient.name.period.end
         * Patient.name.suffix
-        * Patient.name.use
         * Patient.telecom
         * Patient.telecom.system
         * Patient.telecom.use

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -358,8 +358,7 @@ module USCoreTestKit
             choices << { paths: ['reportedBoolean', 'reportedReference'] }
           when 'Patient'
             choices << {
-              paths: ['name.period.end', 'name.use'],
-              uscdi_only: true
+              paths: ['name.period.end', 'name.use']
             }
           end
         end
@@ -382,36 +381,26 @@ module USCoreTestKit
           #US Core 4.0.0 Section 10.112.1.1 Additional USCDI v1 Requirement:
           @must_supports[:extensions] << {
             id: 'Patient.extension:race',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
-            uscdi_only: true
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:ethnicity',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
-            uscdi_only: true
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:birthsex',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
-            uscdi_only: true
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
           }
           @must_supports[:elements] << {
-            path: 'name.suffix',
-            uscdi_only: true
+            path: 'name.suffix'
           }
           @must_supports[:elements] << {
             path: 'name.use',
-            fixed_value: 'old',
-            uscdi_only: true
+            fixed_value: 'old'
           }
           @must_supports[:elements] << {
-            path: 'name.period.end',
-            uscdi_only: true
+            path: 'name.period.end'
           }
-          @must_supports[:elements].each do |element|
-            path = element[:path]
-            element[:uscdi_only] = true if path.include?('telecom.') || path.include?('communication.')
-          end
         end
       end
 

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -394,8 +394,7 @@ module USCoreTestKit
             path: 'name.suffix'
           }
           @must_supports[:elements] << {
-            path: 'name.use',
-            fixed_value: 'old'
+            path: 'name.period.end'
           }
         end
       end

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -344,18 +344,23 @@ module USCoreTestKit
       def add_must_support_choices
         choices = []
 
-        choices << {paths: ['content.attachment.data', 'content.attachment.url']} if profile.type == 'DocumentReference'
+        choices << { paths: ['content.attachment.data', 'content.attachment.url'] } if profile.type == 'DocumentReference'
 
         case profile.version
         when '3.1.1'
-          choices << {paths: ['udiCarrier.carrierAIDC', 'udiCarrier.carrierHRF']} if profile.type == 'Device'
+          choices << { paths: ['udiCarrier.carrierAIDC', 'udiCarrier.carrierHRF'] } if profile.type == 'Device'
         when '4.0.0'
           case profile.type
           when 'Encounter'
-            choices << {paths: ['reasonCode', 'reasonReference']}
-            choices << {paths: ['location.location', 'serviceProvider']}
+            choices << { paths: ['reasonCode', 'reasonReference'] }
+            choices << { paths: ['location.location', 'serviceProvider'] }
           when 'MedicationRequest'
-            choices << {paths: ['reportedBoolean', 'reportedReference']}
+            choices << { paths: ['reportedBoolean', 'reportedReference'] }
+          when 'Patient'
+            choices << {
+              paths: ['name.period.end', 'name.use'],
+              uscdi_only: true
+            }
           end
         end
 
@@ -377,25 +382,36 @@ module USCoreTestKit
           #US Core 4.0.0 Section 10.112.1.1 Additional USCDI v1 Requirement:
           @must_supports[:extensions] << {
             id: 'Patient.extension:race',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+            uscdi_only: true
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:ethnicity',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
+            uscdi_only: true
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:birthsex',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
+            uscdi_only: true
           }
           @must_supports[:elements] << {
-            path: 'telecom'
+            path: 'name.suffix',
+            uscdi_only: true
           }
           @must_supports[:elements] << {
-            path: 'name.suffix'
+            path: 'name.use',
+            fixed_value: 'old',
+            uscdi_only: true
           }
           @must_supports[:elements] << {
-            path: 'name.period.end'
+            path: 'name.period.end',
+            uscdi_only: true
           }
+          @must_supports[:elements].each do |element|
+            path = element[:path]
+            element[:uscdi_only] = true if path.include?('telecom.') || path.include?('communication.')
+          end
         end
       end
 


### PR DESCRIPTION
This PR updates testing logic for patient's previous name MustSupport test
* US Core 4.0 does not list patient's previous name as a MustSupport in StructureDefinition
* US Core 4.0 mentioned patient's previous as "Additional USCDI requirement"
* US Core 4.0 states that "Previous name is represented by providing an end date in the Patient.name.period element for a previous name."
* ONC CCG clarifies that "Either the US Core IG Profile “StructureDefinition-us-core-patient” element “name.period” or “name.use” is required for testing and certification in the ONC Certification Program to meet the USCDI requirement to support the “Patient Demographics” data class: “Previous Name” data element"

This PR includes
* Adds both name.period.end and name.use:old as MustSupport elements
* Adds name.period.end and name.use as MustSupport choices

