### PR TITLE
FI-1585 Separate USCDI requirements from USCore requirements

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/device/device_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/device/device_must_support_test.rb
@@ -20,8 +20,7 @@ module USCoreTestKit
         * Device.serialNumber
         * Device.type
         * Device.udiCarrier
-        * Device.udiCarrier.carrierAIDC
-        * Device.udiCarrier.carrierHRF
+        * Device.udiCarrier.carrierAIDC or Device.udiCarrier.carrierHRF
         * Device.udiCarrier.deviceIdentifier
       )
 

--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_must_support_test.rb
@@ -17,8 +17,7 @@ module USCoreTestKit
         * DocumentReference.content
         * DocumentReference.content.attachment
         * DocumentReference.content.attachment.contentType
-        * DocumentReference.content.attachment.data
-        * DocumentReference.content.attachment.url
+        * DocumentReference.content.attachment.data or DocumentReference.content.attachment.url
         * DocumentReference.content.format
         * DocumentReference.context
         * DocumentReference.context.encounter

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference/document_reference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference/document_reference_must_support_test.rb
@@ -17,8 +17,7 @@ module USCoreTestKit
         * DocumentReference.content
         * DocumentReference.content.attachment
         * DocumentReference.content.attachment.contentType
-        * DocumentReference.content.attachment.data
-        * DocumentReference.content.attachment.url
+        * DocumentReference.content.attachment.data or DocumentReference.content.attachment.url
         * DocumentReference.content.format
         * DocumentReference.context
         * DocumentReference.context.encounter

--- a/lib/us_core_test_kit/generated/v4.0.0/encounter/encounter_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/encounter/encounter_must_support_test.rb
@@ -19,15 +19,13 @@ module USCoreTestKit
         * Encounter.identifier.system
         * Encounter.identifier.value
         * Encounter.location
-        * Encounter.location.location
+        * Encounter.location.location or Encounter.serviceProvider
         * Encounter.participant
         * Encounter.participant.individual
         * Encounter.participant.period
         * Encounter.participant.type
         * Encounter.period
-        * Encounter.reasonCode
-        * Encounter.reasonReference
-        * Encounter.serviceProvider
+        * Encounter.reasonCode or Encounter.reasonReference
         * Encounter.status
         * Encounter.subject
         * Encounter.type

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_request_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_request_must_support_test.rb
@@ -19,8 +19,7 @@ module USCoreTestKit
         * MedicationRequest.encounter
         * MedicationRequest.intent
         * MedicationRequest.medication[x]
-        * MedicationRequest.reportedBoolean
-        * MedicationRequest.reportedReference
+        * MedicationRequest.reportedBoolean or MedicationRequest.reportedReference
         * MedicationRequest.requester
         * MedicationRequest.status
         * MedicationRequest.subject

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -5307,7 +5307,7 @@
     :path: target.measure
   - :type: Quantity
     :strength: example
-    :system:
+    :system: 
     :path: target.detail
   - :type: CodeableConcept
     :strength: example
@@ -12156,6 +12156,10 @@
       :fixed_value: old
       :uscdi_only: true
     - :path: name.period.end
+      :uscdi_only: true
+    - :path: telecom
+      :uscdi_only: true
+    - :path: communication
       :uscdi_only: true
     :choices:
     - :paths:

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -12119,13 +12119,10 @@
     :extensions:
     - :id: Patient.extension:race
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
-      :uscdi_only: true
     - :id: Patient.extension:ethnicity
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
-      :uscdi_only: true
     - :id: Patient.extension:birthsex
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
-      :uscdi_only: true
     :slices: []
     :elements:
     - :path: identifier
@@ -12135,11 +12132,8 @@
     - :path: name.family
     - :path: name.given
     - :path: telecom.system
-      :uscdi_only: true
     - :path: telecom.value
-      :uscdi_only: true
     - :path: telecom.use
-      :uscdi_only: true
     - :path: gender
     - :path: birthDate
     - :path: address
@@ -12149,19 +12143,14 @@
     - :path: address.postalCode
     - :path: address.period
     - :path: communication.language
-      :uscdi_only: true
     - :path: name.suffix
-      :uscdi_only: true
     - :path: name.use
       :fixed_value: old
-      :uscdi_only: true
     - :path: name.period.end
-      :uscdi_only: true
     :choices:
     - :paths:
       - name.period.end
       - name.use
-      :uscdi_only: true
   :mandatory_elements:
   - Patient.identifier
   - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -12119,10 +12119,13 @@
     :extensions:
     - :id: Patient.extension:race
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
+      :uscdi_only: true
     - :id: Patient.extension:ethnicity
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
+      :uscdi_only: true
     - :id: Patient.extension:birthsex
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+      :uscdi_only: true
     :slices: []
     :elements:
     - :path: identifier
@@ -12132,8 +12135,11 @@
     - :path: name.family
     - :path: name.given
     - :path: telecom.system
+      :uscdi_only: true
     - :path: telecom.value
+      :uscdi_only: true
     - :path: telecom.use
+      :uscdi_only: true
     - :path: gender
     - :path: birthDate
     - :path: address
@@ -12143,14 +12149,19 @@
     - :path: address.postalCode
     - :path: address.period
     - :path: communication.language
+      :uscdi_only: true
     - :path: name.suffix
+      :uscdi_only: true
     - :path: name.use
       :fixed_value: old
+      :uscdi_only: true
     - :path: name.period.end
+      :uscdi_only: true
     :choices:
     - :paths:
       - name.period.end
       - name.use
+      :uscdi_only: true
   :mandatory_elements:
   - Patient.identifier
   - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -5307,7 +5307,7 @@
     :path: target.measure
   - :type: Quantity
     :strength: example
-    :system: 
+    :system:
     :path: target.detail
   - :type: CodeableConcept
     :strength: example

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -189,6 +189,10 @@
     :uscdi_only: true
   - :path: name.period.end
     :uscdi_only: true
+  - :path: telecom
+    :uscdi_only: true
+  - :path: communication
+    :uscdi_only: true
   :choices:
   - :paths:
     - name.period.end

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -151,13 +151,10 @@
   :extensions:
   - :id: Patient.extension:race
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
-    :uscdi_only: true
   - :id: Patient.extension:ethnicity
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
-    :uscdi_only: true
   - :id: Patient.extension:birthsex
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
-    :uscdi_only: true
   :slices: []
   :elements:
   - :path: identifier
@@ -167,11 +164,8 @@
   - :path: name.family
   - :path: name.given
   - :path: telecom.system
-    :uscdi_only: true
   - :path: telecom.value
-    :uscdi_only: true
   - :path: telecom.use
-    :uscdi_only: true
   - :path: gender
   - :path: birthDate
   - :path: address
@@ -181,19 +175,14 @@
   - :path: address.postalCode
   - :path: address.period
   - :path: communication.language
-    :uscdi_only: true
   - :path: name.suffix
-    :uscdi_only: true
   - :path: name.use
     :fixed_value: old
-    :uscdi_only: true
   - :path: name.period.end
-    :uscdi_only: true
   :choices:
   - :paths:
     - name.period.end
     - name.use
-    :uscdi_only: true
 :mandatory_elements:
 - Patient.identifier
 - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -151,10 +151,13 @@
   :extensions:
   - :id: Patient.extension:race
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
+    :uscdi_only: true
   - :id: Patient.extension:ethnicity
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
+    :uscdi_only: true
   - :id: Patient.extension:birthsex
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
+    :uscdi_only: true
   :slices: []
   :elements:
   - :path: identifier
@@ -164,8 +167,11 @@
   - :path: name.family
   - :path: name.given
   - :path: telecom.system
+    :uscdi_only: true
   - :path: telecom.value
+    :uscdi_only: true
   - :path: telecom.use
+    :uscdi_only: true
   - :path: gender
   - :path: birthDate
   - :path: address
@@ -175,14 +181,19 @@
   - :path: address.postalCode
   - :path: address.period
   - :path: communication.language
+    :uscdi_only: true
   - :path: name.suffix
+    :uscdi_only: true
   - :path: name.use
     :fixed_value: old
+    :uscdi_only: true
   - :path: name.period.end
+    :uscdi_only: true
   :choices:
   - :paths:
     - name.period.end
     - name.use
+    :uscdi_only: true
 :mandatory_elements:
 - Patient.identifier
 - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
@@ -29,12 +29,14 @@ module USCoreTestKit
 
         For ONC USCDI requirements, each Patient must support the following additional elements:
 
+        * Patient.communication
         * Patient.communication.language
         * Patient.extension:birthsex
         * Patient.extension:ethnicity
         * Patient.extension:race
         * Patient.name.period.end or Patient.name.use
         * Patient.name.suffix
+        * Patient.telecom
         * Patient.telecom.system
         * Patient.telecom.use
         * Patient.telecom.value

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
@@ -19,10 +19,6 @@ module USCoreTestKit
         * Patient.address.postalCode
         * Patient.address.state
         * Patient.birthDate
-        * Patient.communication.language
-        * Patient.extension:birthsex
-        * Patient.extension:ethnicity
-        * Patient.extension:race
         * Patient.gender
         * Patient.identifier
         * Patient.identifier.system
@@ -30,9 +26,15 @@ module USCoreTestKit
         * Patient.name
         * Patient.name.family
         * Patient.name.given
-        * Patient.name.period.end
+
+        For ONC USCDI requirements, each Patient must support the following additional elements:
+
+        * Patient.communication.language
+        * Patient.extension:birthsex
+        * Patient.extension:ethnicity
+        * Patient.extension:race
+        * Patient.name.period.end or Patient.name.use
         * Patient.name.suffix
-        * Patient.name.use
         * Patient.telecom.system
         * Patient.telecom.use
         * Patient.telecom.value

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -358,7 +358,8 @@ module USCoreTestKit
             choices << { paths: ['reportedBoolean', 'reportedReference'] }
           when 'Patient'
             choices << {
-              paths: ['name.period.end', 'name.use']
+              paths: ['name.period.end', 'name.use'],
+              uscdi_only: true
             }
           end
         end
@@ -381,26 +382,36 @@ module USCoreTestKit
           #US Core 4.0.0 Section 10.112.1.1 Additional USCDI v1 Requirement:
           @must_supports[:extensions] << {
             id: 'Patient.extension:race',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+            uscdi_only: true
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:ethnicity',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
+            uscdi_only: true
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:birthsex',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
+            uscdi_only: true
           }
           @must_supports[:elements] << {
-            path: 'name.suffix'
+            path: 'name.suffix',
+            uscdi_only: true
           }
           @must_supports[:elements] << {
             path: 'name.use',
-            fixed_value: 'old'
+            fixed_value: 'old',
+            uscdi_only: true
           }
           @must_supports[:elements] << {
-            path: 'name.period.end'
+            path: 'name.period.end',
+            uscdi_only: true
           }
+          @must_supports[:elements].each do |element|
+            path = element[:path]
+            element[:uscdi_only] = true if path.include?('telecom.') || path.include?('communication.')
+          end
         end
       end
 

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -408,6 +408,14 @@ module USCoreTestKit
             path: 'name.period.end',
             uscdi_only: true
           }
+          @must_supports[:elements] << {
+            path: 'telecom',
+            uscdi_only: true
+          }
+          @must_supports[:elements] << {
+            path: 'communication',
+            uscdi_only: true
+          }
           @must_supports[:elements].each do |element|
             path = element[:path]
             element[:uscdi_only] = true if path.include?('telecom.') || path.include?('communication.')

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -395,8 +395,7 @@ module USCoreTestKit
             path: 'name.suffix'
           }
           @must_supports[:elements] << {
-            path: 'name.use',
-            fixed_value: 'old'
+            path: 'name.period.end'
           }
           @must_supports[:elements] << {
             path: 'name.period.end'

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -358,7 +358,8 @@ module USCoreTestKit
             choices << { paths: ['reportedBoolean', 'reportedReference'] }
           when 'Patient'
             choices << {
-              paths: ['name.period.end', 'name.use']
+              paths: ['name.period.end', 'name.use'],
+              uscdi_only: true
             }
           end
         end
@@ -381,15 +382,18 @@ module USCoreTestKit
           #US Core 4.0.0 Section 10.112.1.1 Additional USCDI v1 Requirement:
           @must_supports[:extensions] << {
             id: 'Patient.extension:race',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+            uscdi_only: true
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:ethnicity',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
+            uscdi_only: true
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:birthsex',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
+            uscdi_only: true
           }
           @must_supports[:elements] << {
             path: 'name.suffix'
@@ -398,8 +402,13 @@ module USCoreTestKit
             path: 'name.period.end'
           }
           @must_supports[:elements] << {
-            path: 'name.period.end'
+            path: 'name.period.end',
+            uscdi_only: true
           }
+          @must_supports[:elements].each do |element|
+            path = element[:path]
+            element[:uscdi_only] = true if path.include?('telecom.') || path.include?('communication.')
+          end
         end
       end
 

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -358,8 +358,7 @@ module USCoreTestKit
             choices << { paths: ['reportedBoolean', 'reportedReference'] }
           when 'Patient'
             choices << {
-              paths: ['name.period.end', 'name.use'],
-              uscdi_only: true
+              paths: ['name.period.end', 'name.use']
             }
           end
         end
@@ -382,33 +381,26 @@ module USCoreTestKit
           #US Core 4.0.0 Section 10.112.1.1 Additional USCDI v1 Requirement:
           @must_supports[:extensions] << {
             id: 'Patient.extension:race',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
-            uscdi_only: true
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:ethnicity',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
-            uscdi_only: true
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
           }
           @must_supports[:extensions] << {
             id: 'Patient.extension:birthsex',
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
-            uscdi_only: true
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
           }
           @must_supports[:elements] << {
             path: 'name.suffix'
           }
           @must_supports[:elements] << {
-            path: 'name.period.end'
+            path: 'name.use',
+            fixed_value: 'old'
           }
           @must_supports[:elements] << {
-            path: 'name.period.end',
-            uscdi_only: true
+            path: 'name.period.end'
           }
-          @must_supports[:elements].each do |element|
-            path = element[:path]
-            element[:uscdi_only] = true if path.include?('telecom.') || path.include?('communication.')
-          end
         end
       end
 

--- a/lib/us_core_test_kit/generator/must_support_test_generator.rb
+++ b/lib/us_core_test_kit/generator/must_support_test_generator.rb
@@ -75,25 +75,21 @@ module USCoreTestKit
         build_must_support_list_string(true)
       end
 
-      def nil_to_false(element)
-        element.nil? ? false : element
-      end
-
       def build_must_support_list_string(uscdi_only)
         slice_names = group_metadata.must_supports[:slices]
-          .select { |slice| nil_to_false(slice[:uscdi_only]) == uscdi_only }
+          .select { |slice| slice[:uscdi_only].presence == uscdi_only.presence }
           .map { |slice| slice[:name] }
 
         element_names = group_metadata.must_supports[:elements]
-          .select { |element| nil_to_false(element[:uscdi_only]) == uscdi_only }
+          .select { |element| element[:uscdi_only].presence == uscdi_only.presence }
           .map { |element| "#{resource_type}.#{element[:path]}" }
 
         extension_names = group_metadata.must_supports[:extensions]
-          .select { |extension| nil_to_false(extension[:uscdi_only]) == uscdi_only }
+          .select { |extension| extension[:uscdi_only].presence == uscdi_only.presence }
           .map { |extension| extension[:id] }
 
         group_metadata.must_supports[:choices]&.each do |choice|
-          next unless nil_to_false(choice[:uscdi_only]) == uscdi_only
+          next unless choice[:uscdi_only].presence == uscdi_only.presence
           choice[:paths].each { |path| element_names.delete("#{resource_type}.#{path}") }
           element_names << choice[:paths].map { |path| "#{resource_type}.#{path}" }.join(' or ')
         end

--- a/lib/us_core_test_kit/generator/templates/must_support.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/must_support.rb.erb
@@ -12,7 +12,11 @@ module USCoreTestKit
         Statement. This test will look through the <%= resource_type %> resources
         found previously for the following must support elements:
 
-<%= must_support_list_string %>
+<%= must_support_list_string %><% if uscdi_list_string.present? %>
+
+        For ONC USCDI requirements, each <%= resource_type %> must support the following additional elements:
+
+<%= uscdi_list_string %><% end %>
       )
 
       id :<%= test_id %>

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -36,8 +36,16 @@ module USCoreTestKit
       end
     end
 
+    def include_uscdi_only_test
+      config.options[:include_uscdi_only_test] == true
+    end
+
     def must_support_extensions
-      metadata.must_supports[:extensions]
+      if include_uscdi_only_test
+        metadata.must_supports[:extensions]
+      else
+        metadata.must_supports[:extensions].select{ |extension| !extension[:uscdi_only] }
+      end
     end
 
     def missing_extensions(resources = [])
@@ -50,7 +58,11 @@ module USCoreTestKit
     end
 
     def must_support_elements
-      metadata.must_supports[:elements]
+      if include_uscdi_only_test
+        metadata.must_supports[:elements]
+      else
+        metadata.must_supports[:elements].select{ |element| !element[:uscdi_only] }
+      end
     end
 
     def missing_elements(resources = [])
@@ -85,7 +97,11 @@ module USCoreTestKit
     end
 
     def must_support_slices
-      metadata.must_supports[:slices]
+      if include_uscdi_only_test
+        metadata.must_supports[:slices]
+      else
+        metadata.must_supports[:slices].select{ |slice| !slice[:uscdi_only] }
+      end
     end
 
     def missing_slices(resources = [])

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -36,15 +36,15 @@ module USCoreTestKit
       end
     end
 
-    def include_uscdi_only_test
+    def include_uscdi_only_test?
       config.options[:include_uscdi_only_test] == true
     end
 
     def must_support_extensions
-      if include_uscdi_only_test
+      if include_uscdi_only_test?
         metadata.must_supports[:extensions]
       else
-        metadata.must_supports[:extensions].select{ |extension| !extension[:uscdi_only] }
+        metadata.must_supports[:extensions].reject{ |extension| extension[:uscdi_only] }
       end
     end
 
@@ -58,10 +58,10 @@ module USCoreTestKit
     end
 
     def must_support_elements
-      if include_uscdi_only_test
+      if include_uscdi_only_test?
         metadata.must_supports[:elements]
       else
-        metadata.must_supports[:elements].select{ |element| !element[:uscdi_only] }
+        metadata.must_supports[:elements].reject{ |element| element[:uscdi_only] }
       end
     end
 
@@ -97,10 +97,10 @@ module USCoreTestKit
     end
 
     def must_support_slices
-      if include_uscdi_only_test
+      if include_uscdi_only_test?
         metadata.must_supports[:slices]
       else
-        metadata.must_supports[:slices].select{ |slice| !slice[:uscdi_only] }
+        metadata.must_supports[:slices].reject{ |slice| slice[:uscdi_only] }
       end
     end
 


### PR DESCRIPTION
USCore v4.0 starts separation of USCDI requirements into "Additional USCDI requirement" narrative section. 

This PR changes
* Add uscdi_only tag to those USCDI requirements 
* Add logic in must_support_test to load or not load USCDI tests based on configuration
* Update Must Support test description to concatenate MustSupport choices with "or"

This PR depends on #43 