### PR TITLE
FI-1599 Skip array item with DAR extension

### DIFF
--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -22,10 +22,11 @@ module USCoreTestKit
       elements = Array.wrap(element)
 
       if path.empty?
-        elements.reject! do |el|
-          el.respond_to?(:extension) &&
-          el.extension.any? { |ext| ext.url == DAR_EXTENSION_URL}
-        end unless include_dar
+        unless include_dar
+          elements.reject! do |el|
+            el.respond_to?(:extension) && el.extension.any? { |ext| ext.url == DAR_EXTENSION_URL}
+          end
+        end
 
         return elements.find { |el| yield(el) } if block_given?
 

--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -23,7 +23,7 @@ module USCoreTestKit
 
       if path.empty?
         unless include_dar
-          elements.reject! do |el|
+          elements = elements.reject do |el|
             el.respond_to?(:extension) && el.extension.any? { |ext| ext.url == DAR_EXTENSION_URL}
           end
         end

--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -1,5 +1,7 @@
 module USCoreTestKit
   module FHIRResourceNavigation
+    DAR_EXTENSION_URL = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'.freeze
+
     def resolve_path(elements, path)
       elements = Array.wrap(elements)
       return elements if path.blank?
@@ -14,12 +16,17 @@ module USCoreTestKit
       end.compact
     end
 
-    def find_a_value_at(element, path)
+    def find_a_value_at(element, path, include_dar: false)
       return nil if element.nil?
 
       elements = Array.wrap(element)
 
       if path.empty?
+        elements.reject! do |el|
+          el.respond_to?(:extension) &&
+          el.extension.any? { |ext| ext.url == DAR_EXTENSION_URL}
+        end unless include_dar
+
         return elements.find { |el| yield(el) } if block_given?
 
         return elements.first
@@ -43,9 +50,9 @@ module USCoreTestKit
         child = get_next_value(element, segment)
         element_found =
           if block_given?
-            find_a_value_at(child, remaining_path) { |value_found| yield(value_found) }
+            find_a_value_at(child, remaining_path, include_dar: include_dar) { |value_found| yield(value_found) }
           else
-            find_a_value_at(child, remaining_path)
+            find_a_value_at(child, remaining_path, include_dar: include_dar)
           end
 
         return element_found if element_found.present? || element_found == false

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -515,7 +515,8 @@ module USCoreTestKit
       paths = search_param_paths(name)
       search_value = nil
       paths.each do |path|
-        element = find_a_value_at(scratch_resources_for_patient(patient_id), path)
+            #require 'pry'; require 'pry-byebug'; binding.pry
+        element =  find_a_value_at(scratch_resources_for_patient(patient_id), path)
 
         search_value =
           case element

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -515,7 +515,6 @@ module USCoreTestKit
       paths = search_param_paths(name)
       search_value = nil
       paths.each do |path|
-            #require 'pry'; require 'pry-byebug'; binding.pry
         element =  find_a_value_at(scratch_resources_for_patient(patient_id), path)
 
         search_value =

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -515,7 +515,7 @@ module USCoreTestKit
       paths = search_param_paths(name)
       search_value = nil
       paths.each do |path|
-        element =  find_a_value_at(scratch_resources_for_patient(patient_id), path)
+        element = find_a_value_at(scratch_resources_for_patient(patient_id), path)
 
         search_value =
           case element

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -704,7 +704,7 @@ RSpec.describe USCoreTestKit::SearchTest do
   end
 
   describe '#search_param_value' do
-    let(:tester) { USCoreTestKit::USCoreV311::PatientNameSearchTest.new }
+    let(:test) { USCoreTestKit::USCoreV311::PatientNameSearchTest.new }
     let(:search_value) {'family_name'}
 
     it 'returns search value from the first of name array' do
@@ -722,7 +722,7 @@ RSpec.describe USCoreTestKit::SearchTest do
       allow_any_instance_of(USCoreTestKit::USCoreV311::PatientNameSearchTest)
         .to receive(:scratch_resources_for_patient).and_return(Array.wrap(patient))
 
-      element = tester.search_param_value('name', '123')
+      element = test.search_param_value('name', '123')
 
       expect(element).to eq(search_value)
     end
@@ -750,7 +750,7 @@ RSpec.describe USCoreTestKit::SearchTest do
       allow_any_instance_of(USCoreTestKit::USCoreV311::PatientNameSearchTest)
         .to receive(:scratch_resources_for_patient).and_return(Array.wrap(patient))
 
-      element = tester.search_param_value('name', '123')
+      element = test.search_param_value('name', '123')
 
       expect(element).to eq(search_value)
     end

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -702,4 +702,57 @@ RSpec.describe USCoreTestKit::SearchTest do
       end
     end
   end
+
+  describe '#search_param_value' do
+    let(:tester) { USCoreTestKit::USCoreV311::PatientNameSearchTest.new }
+    let(:search_value) {'family_name'}
+
+    it 'returns search value from the first of name array' do
+      patient = FHIR::Patient.new(
+        name: [
+          {
+            family: search_value,
+            given: [
+              'first_name'
+            ]
+          }
+        ]
+      )
+
+      allow_any_instance_of(USCoreTestKit::USCoreV311::PatientNameSearchTest)
+        .to receive(:scratch_resources_for_patient).and_return(Array.wrap(patient))
+
+      element = tester.search_param_value('name', '123')
+
+      expect(element).to eq(search_value)
+    end
+
+    it 'returns search value from the first none-DAR name of name array' do
+      patient = FHIR::Patient.new(
+        name: [
+          {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+                valueCode: 'unknown'
+              }
+            ]
+          },
+          {
+            family: search_value,
+            given: [
+              'first_name'
+            ]
+          }
+        ]
+      )
+
+      allow_any_instance_of(USCoreTestKit::USCoreV311::PatientNameSearchTest)
+        .to receive(:scratch_resources_for_patient).and_return(Array.wrap(patient))
+
+      element = tester.search_param_value('name', '123')
+
+      expect(element).to eq(search_value)
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes part of GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/142

The changes includes
* Add parameter `include_dar: false` to method `find_a_value_at`. The method skips element with DAR extension when  `include_dar == false`
* Add unit test to cover this use case

Testing
* A unit test was created to cover the use case. The simplest testing is observing all unit tests pass
* To run integration test:
** Create a patient with name having DAR as the first item. Example
```
"name": [
      {
        "extension": [
          {
            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
            "valueCode": "unknown"
          }
        ]
      },
      {
        "use": "official",
        "text": "Johnny LastName",
        "family": "LastName",
        "given": [
          "Johnny"
        ]
      }
    ],
```
** Run the Patient Tests (Test Group 2) and verify the search by name test (Test 2.03) passes