### PR TITLE
Remove us-core-organization from agent.who target profiles

### DIFF
--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -13995,7 +13995,6 @@
       - Reference
       :target_profiles:
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
-      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     - :path: agent.onBehalfOf
       :types:
       - Reference

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
@@ -64,7 +64,6 @@
     - Reference
     :target_profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
-    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   - :path: agent.onBehalfOf
     :types:
     - Reference

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -277,7 +277,6 @@ module USCoreTestKit
         when '4.0.0'
           add_device_distinct_identifier
           add_patient_uscdi_elements
-          add_provenance_agent_who
         end
       end
 
@@ -420,15 +419,6 @@ module USCoreTestKit
             path = element[:path]
             element[:uscdi_only] = true if path.include?('telecom.') || path.include?('communication.')
           end
-        end
-      end
-
-      def add_provenance_agent_who
-        # FHIR-36344 US Core 4.0.0 mistakenly not lable us-core-organization as MS for Provenance.agent.who
-        # This will be fixed in US Core 5.0.0
-        if profile.type == 'Provenance'
-          target_element = @must_supports[:elements].find { |element| element[:path] == 'agent.who'}
-          target_element[:target_profiles] << 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'
         end
       end
     end


### PR DESCRIPTION
We made an assumption about how US Core fixes https://jira.hl7.org/browse/FHIR-36344. The actual fix does not include us-core-organization profile in target profile list of Provenance.agent.who

This change includes
* Remove us-core-organization from agent.who MS target profiles.