### PR TITLE
FI-1604 Fix how Inferno Generate search value

### DIFF
--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -431,16 +431,16 @@ module USCoreTestKit
         end
       end
 
-      params_with_partial_value = resources.each_with_object({}) do |resource, params|
+      params_with_partial_value = resources.each_with_object({}) do |resource, outer_params|
         results_from_one_resource = search_param_names.each_with_object({}) do |name, params|
           value = patient_id_param?(name) ? patient_id : search_param_value(name, resource, include_system: include_system)
           params[name] = value
         end
 
-        params.merge!(results_from_one_resource)
+        outer_params.merge!(results_from_one_resource)
 
         # stop if all parameter values are found
-        return params if params.all? { |_key, value| value.present? }
+        return outer_params if outer_params.all? { |_key, value| value.present? }
       end
 
       params_with_partial_value
@@ -548,7 +548,7 @@ module USCoreTestKit
             if include_system
               coding =
                 find_a_value_at(element, 'coding') { |coding| coding.code.present? && coding.system.present? }
-              coding.present? ? "#{coding.system}|#{coding.code}" : nil
+              "#{coding.system}|#{coding.code}"
             else
               find_a_value_at(element, 'coding.code')
             end

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -82,8 +82,6 @@ module USCoreTestKit
       # TODO: skip if not supported?
       skip_if !any_valid_search_params?(all_search_params), unable_to_resolve_params_message
 
-      require 'pry'; require 'pry-byebug'; binding.pry
-
       resources_returned =
         all_search_params.flat_map do |patient_id, params_list|
           params_list.flat_map { |params| perform_search(params, patient_id) }
@@ -431,16 +429,19 @@ module USCoreTestKit
       # if resources.empty? && patient_id_param?(search_param_names.first)
       #   new_params[search_param_names.first] = patient_id
       # else
-        resources.each_with_object({}) do |resource, params|
+        params = resources.each_with_object({}) do |resource, params|
           results = search_param_names.each_with_object({}) do |name, params|
             value = patient_id_param?(name) ? patient_id : search_param_value(name, resource)
             params[name] = value if value.present?
           end
 
+          #require 'pry'; require 'pry-byebug'; binding.pry
           params.merge!(results)
           return params if results.keys.length == search_param_names.length
         end
       #end
+      #require 'pry'; require 'pry-byebug'; binding.pry
+      params
 
     end
 

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -422,27 +422,28 @@ module USCoreTestKit
     end
 
     def search_params_with_values(search_param_names, patient_id)
-      #new_params = {}
-
       resources = scratch_resources_for_patient(patient_id)
 
-      # if resources.empty? && patient_id_param?(search_param_names.first)
-      #   new_params[search_param_names.first] = patient_id
-      # else
-        params = resources.each_with_object({}) do |resource, params|
-          results = search_param_names.each_with_object({}) do |name, params|
-            value = patient_id_param?(name) ? patient_id : search_param_value(name, resource)
-            params[name] = value if value.present?
-          end
-
-          #require 'pry'; require 'pry-byebug'; binding.pry
-          params.merge!(results)
-          return params if results.keys.length == search_param_names.length
+      # This is first search. The saved resource is empty.
+      #if first_search?
+      if resources.empty?
+        return search_param_names.each_with_object({}) do |name, params|
+          value = patient_id_param?(name) ? patient_id : nil
+          params[name] = value
         end
-      #end
-      #require 'pry'; require 'pry-byebug'; binding.pry
-      params
+      end
 
+      params_with_value = resources.each_with_object({}) do |resource, params|
+        results = search_param_names.each_with_object({}) do |name, params|
+          value = patient_id_param?(name) ? patient_id : search_param_value(name, resource)
+          params[name] = value
+        end
+
+        params.merge!(results)
+
+        # stop if all parameter values are found
+        return params if params.all? { |_key, value| value.present? }
+      end
     end
 
     def patient_id_list

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -256,7 +256,7 @@ module USCoreTestKit
     def perform_search_with_system(params, patient_id)
       return if search_variant_test_records[:token_variants]
 
-      new_search_params = search_params_with_values(token_search_params, patient_id)
+      new_search_params = search_params_with_values(token_search_params, patient_id, include_system: true)
       return if new_search_params.any? { |_name, value| value.blank? }
 
       search_params = params.merge(new_search_params)
@@ -421,7 +421,7 @@ module USCoreTestKit
       end
     end
 
-    def search_params_with_values(search_param_names, patient_id)
+    def search_params_with_values(search_param_names, patient_id, include_system: false)
       resources = scratch_resources_for_patient(patient_id)
 
       if resources.empty?
@@ -433,7 +433,7 @@ module USCoreTestKit
 
       params_with_partial_value = resources.each_with_object({}) do |resource, params|
         results_from_one_resource = search_param_names.each_with_object({}) do |name, params|
-          value = patient_id_param?(name) ? patient_id : search_param_value(name, resource)
+          value = patient_id_param?(name) ? patient_id : search_param_value(name, resource, include_system: include_system)
           params[name] = value
         end
 

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -515,7 +515,8 @@ module USCoreTestKit
       paths = search_param_paths(name)
       search_value = nil
       paths.each do |path|
-        element = find_a_value_at(scratch_resources_for_patient(patient_id), path)
+            #require 'pry'; require 'pry-byebug'; binding.pry
+        element =  find_a_value_at(scratch_resources_for_patient(patient_id), path)
 
         search_value =
           case element

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -515,7 +515,6 @@ module USCoreTestKit
       paths = search_param_paths(name)
       search_value = nil
       paths.each do |path|
-            #require 'pry'; require 'pry-byebug'; binding.pry
         element =  find_a_value_at(scratch_resources_for_patient(patient_id), path)
 
         search_value =

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -603,7 +603,7 @@ module USCoreTestKit
       when FHIR::Identifier
         include_system ? element.value.present? && element.system.present? : element.value.present?
       when FHIR::Coding
-        include_system ? element.code.present? && element.system.present? : element.present?
+        include_system ? element.code.present? && element.system.present? : element.code.present?
       when FHIR::HumanName
         (element.family || element.given&.first || element.text).present?
       when FHIR::Address

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -424,8 +424,6 @@ module USCoreTestKit
     def search_params_with_values(search_param_names, patient_id)
       resources = scratch_resources_for_patient(patient_id)
 
-      # This is first search. The saved resource is empty.
-      #if first_search?
       if resources.empty?
         return search_param_names.each_with_object({}) do |name, params|
           value = patient_id_param?(name) ? patient_id : nil
@@ -433,17 +431,19 @@ module USCoreTestKit
         end
       end
 
-      params_with_value = resources.each_with_object({}) do |resource, params|
-        results = search_param_names.each_with_object({}) do |name, params|
+      params_with_partial_value = resources.each_with_object({}) do |resource, params|
+        results_from_one_resource = search_param_names.each_with_object({}) do |name, params|
           value = patient_id_param?(name) ? patient_id : search_param_value(name, resource)
           params[name] = value
         end
 
-        params.merge!(results)
+        params.merge!(results_from_one_resource)
 
         # stop if all parameter values are found
         return params if params.all? { |_key, value| value.present? }
       end
+
+      params_with_partial_value
     end
 
     def patient_id_list

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -515,7 +515,7 @@ module USCoreTestKit
       paths = search_param_paths(name)
       search_value = nil
       paths.each do |path|
-        element =  find_a_value_at(scratch_resources_for_patient(patient_id), path)
+        element = find_a_value_at(scratch_resources_for_patient(patient_id), path)
 
         search_value =
           case element

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -299,44 +299,46 @@ RSpec.describe USCoreTestKit::SearchTest do
           )
         end
       end
-      let(:device_search_test) do
-        Class.new(Inferno::Test) do
-          include USCoreTestKit::SearchTest
+      # let(:device_search_test) do
+      #   Class.new(Inferno::Test) do
+      #     include USCoreTestKit::SearchTest
 
-          def properties
-            @properties ||= USCoreTestKit::SearchTestProperties.new(
-              resource_type: 'Device',
-              search_param_names: ['patient'],
-              first_search: true
-            )
-          end
+      #     def properties
+      #       @properties ||= USCoreTestKit::SearchTestProperties.new(
+      #         resource_type: 'Device',
+      #         search_param_names: ['patient'],
+      #         first_search: true
+      #       )
+      #     end
 
-          def self.metadata
-            @metadata ||=
-              USCoreTestKit::Generator::GroupMetadata.new(
-                YAML.load_file(
-                  File.join(
-                    __dir__,
-                    '..',
-                    'fixtures',
-                    'device_metadata.yml'
-                  )
-                )
-              )
-          end
+      #     def self.metadata
+      #       @metadata ||=
+      #         USCoreTestKit::Generator::GroupMetadata.new(
+      #           YAML.load_file(
+      #             File.join(
+      #               __dir__,
+      #               '..',
+      #               'fixtures',
+      #               'device_metadata.yml'
+      #             )
+      #           )
+      #         )
+      #     end
 
-          def scratch_resources
-            scratch[:device_resources] ||= {}
-          end
+      #     def scratch_resources
+      #       scratch[:device_resources] ||= {}
+      #     end
 
-          fhir_client { url :url }
-          input :url, :patient_ids, :implantable_device_codes
+      #     fhir_client { url :url }
+      #     input :url, :patient_ids, :implantable_device_codes
 
-          run do
-            run_search_test
-          end
-        end
-      end
+      #     run do
+      #       run_search_test
+      #     end
+      #   end
+      # end
+
+      let(:device_search_test) {USCoreTestKit::USCoreV311::DevicePatientSearchTest}
       let(:bundle) do
         entries = devices.map do |device|
           { resource: device }
@@ -359,8 +361,9 @@ RSpec.describe USCoreTestKit::SearchTest do
         implantable_devices = devices[0..1]
         non_implantable_device = devices.last
         code_input = "#{implantable_device_code1}, #{implantable_device_code2}"
-        result = run(device_search_test, patient_ids: patient_id, url: url, implantable_device_codes: code_input)
+        result = run(device_search_test, patient_ids: patient_id, implantable_device_codes: code_input)
 
+        require 'pry'; require 'pry-byebug'; binding.pry
         expect(result.result).to eq('pass')
         expect(test_scratch[:device_resources][:all]).to eq(implantable_devices)
         expect(test_scratch[:device_resources][:all]).to_not include(non_implantable_device)

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -752,6 +752,7 @@ RSpec.describe USCoreTestKit::SearchTest do
 
       params = test.search_params_with_values(test.search_param_names, patient_id)
 
+      require 'pry'; require 'pry-byebug'; binding.pry
       expect(params).not_to be_empty
       expect(params['patient']).to eq(patient_id)
       expect(params['category']).to eq(category_code)

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -703,56 +703,139 @@ RSpec.describe USCoreTestKit::SearchTest do
     end
   end
 
-  describe '#search_param_value' do
-    let(:test) { USCoreTestKit::USCoreV311::PatientNameSearchTest.new }
-    let(:search_value) {'family_name'}
-
-    it 'returns search value from the first of name array' do
-      patient = FHIR::Patient.new(
-        name: [
+  describe '#search_params_with_values' do
+    let(:test_class) { USCoreTestKit::USCoreV311::DocumentReferencePatientCategoryDateSearchTest }
+    let(:test) { test_class.new }
+    let(:patient_id) {'123'}
+    let(:category_code) {'something-else'}
+    let(:date) {'2020-05-14T11:02:00+05:00'}
+    let(:resource_with_category) {
+      FHIR::DocumentReference.new(
+        subject: {
+          reference: "Patient/#{patient_id}"
+        },
+        category: [
           {
-            family: search_value,
-            given: [
-              'first_name'
-            ]
-          }
-        ]
-      )
-
-      allow_any_instance_of(USCoreTestKit::USCoreV311::PatientNameSearchTest)
-        .to receive(:scratch_resources_for_patient).and_return(Array.wrap(patient))
-
-      element = test.search_param_value('name', '123')
-
-      expect(element).to eq(search_value)
-    end
-
-    it 'returns search value from the first none-DAR name of name array' do
-      patient = FHIR::Patient.new(
-        name: [
-          {
-            extension: [
+            coding: [
               {
-                url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
-                valueCode: 'unknown'
+                code: 'clinical-note'
               }
             ]
-          },
-          {
-            family: search_value,
-            given: [
-              'first_name'
-            ]
           }
         ]
       )
+    }
+    let(:resource_with_category_date) {
+      FHIR::DocumentReference.new(
+        subject: {
+          reference: "Patient/#{patient_id}"
+        },
+        category: [
+          {
+            coding: [
+              {
+                code: category_code
+              }
+            ]
+          }
+        ],
+        date: date
+      )
+    }
 
-      allow_any_instance_of(USCoreTestKit::USCoreV311::PatientNameSearchTest)
-        .to receive(:scratch_resources_for_patient).and_return(Array.wrap(patient))
+    it 'returns search values from the same resource' do
+      allow_any_instance_of(test_class)
+        .to receive(:scratch_resources_for_patient).and_return([
+          resource_with_category,
+          resource_with_category_date
+        ])
 
-      element = test.search_param_value('name', '123')
+      params = test.search_params_with_values(test.search_param_names, patient_id)
 
-      expect(element).to eq(search_value)
+      expect(params).not_to be_empty
+      expect(params['patient']).to eq(patient_id)
+      expect(params['category']).to eq(category_code)
+      expect(params['date']).to eq(date)
+    end
+  end
+
+  describe '#search_param_value' do
+    context 'Array element having DAR extension' do
+      let(:test_class) { USCoreTestKit::USCoreV311::PatientNameSearchTest }
+      let(:test) { test_class.new }
+      let(:search_value) {'family_name'}
+      let(:patient) {
+        FHIR::Patient.new(
+          name: [
+            {
+              extension: [
+                {
+                  url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+                  valueCode: 'unknown'
+                }
+              ]
+            },
+            {
+              family: search_value,
+              given: [
+                'first_name'
+              ]
+            }
+          ]
+        )
+      }
+
+      it 'returns search value from the first none-DAR name of name array' do
+        element = test.search_param_value('name', Array.wrap(patient))
+
+        expect(element).to eq(search_value)
+      end
+    end
+
+    context 'CodeablcConcept with text only' do
+      let(:test_class) { USCoreTestKit::USCoreV311::DiagnosticReportLabPatientCategorySearchTest }
+      let(:test) { test_class.new }
+
+      it 'returns nil if category has text only' do
+        diagnostic_report = FHIR::DiagnosticReport.new(
+          category: [
+            {
+              text: 'Lab Report'
+            }
+          ]
+        )
+
+        element = test.search_param_value('category', Array.wrap(diagnostic_report))
+
+        expect(element).to be_nil
+      end
+
+      it 'returns code value if category has one coding with code' do
+        diagnostic_report = FHIR::DiagnosticReport.new(
+          category: [
+            {
+              text: 'This is a display text'
+            },
+            {
+              coding: [
+                {
+                  display: 'This is a display text'
+                },
+                {
+                  code: 'LAB',
+                  system: 'http://terminology.hl7.org/CodeSystem/v2-0074'
+                }
+              ]
+            }
+          ]
+        )
+
+        element = test.search_param_value('category', Array.wrap(diagnostic_report))
+        element_with_system = test.search_param_value('category', Array.wrap(diagnostic_report), include_system: true)
+
+        expect(element).to eq('LAB')
+        expect(element_with_system).to eq('http://terminology.hl7.org/CodeSystem/v2-0074|LAB')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes part of GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/138

This PR include these changes
* Retrieve values for multiple search parameters from one resource
* Skip these elements when retrieving search values for existing resources
** CodeableConcept without `coding` 
** Reference without `reference` 
** Coding without `code` and/or `system`
** Identifier without `value` and/or `system`
** HumanName without `family`, `given`, and `text`
** Address without `text`, `city`, `state`, `postCode`, and `country`

Testing
* Multiple unit tests are added to cover the code changes