### PR TITLE
FI-1619 - Readd resource mismatch but downgrade to informational.

### DIFF
--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -529,6 +529,20 @@ module USCoreTestKit
         page_count += 1
       end
 
+      valid_resource_types = [resource_type, 'OperationOutcome'].concat(additional_resource_types)
+      valid_resource_types << 'Medication' if resource_type == 'MedicationRequest'
+
+      invalid_resource_types =
+        resources.reject { |entry| valid_resource_types.include? entry.resourceType }
+                 .map(&:resourceType)
+                 .uniq
+
+      if invalid_resource_types.any?
+        info "Received resource type(s) #{invalid_resource_types.join(', ')} in search bundle, " \
+             "but only expected resource types #{valid_resource_types.join(', ')}. " + \
+             "This is unusual but allowed if the server believes additional resource types are relevant."
+      end
+
       resources
     end
 


### PR DESCRIPTION
Based on further discussion with ONC, it is a good idea to provide an 'informational' message when there is an unexpected resource type returned from a search.  See #46 where we removed the check.  The reasoning is that it seems that likely they shouldn't be doing this, even if they are technically allowed, so its nice to point out that we see this happening (without implying they are wring, as a warning would).  Also, I can see us reviewing this sometime in the future and not realizing that we decided to remove it, and by mistake just readding it... by having this in there we will know that we intentionally aren't failing systems for type mismatches.

To test, the easiest thing to do is add the following line at 535, in fetch_all_bundled_resources:

```
      valid_resource_types = ['Patient', 'OperationOutcome']
```
Then, run US Core v3.1.1 test suite, with the reference server as a preset, and run any of the Profile searches.

Then, you'll see the following informational start showing up:

<img width="1254" alt="Screen Shot 2022-07-06 at 2 48 31 PM" src="https://user-images.githubusercontent.com/412901/177621647-86f946b7-af44-4ad7-b223-e7840b940af1.png">


