### PR TITLE
Filter bundle result for comparator search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /data/*.db-journal
 /data/redis/*.rdb
 /data/redis/*.aof
+/data/redis/appendonlydir
 /tmp
 .env.local
 .env.*.local

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -228,8 +228,9 @@ module USCoreTestKit
 
           search_and_check_response(params_with_comparator)
 
-          fetch_all_bundled_resources
-            .each { |resource| check_resource_against_params(resource, params_with_comparator) }
+          fetch_all_bundled_resources.each do |resource| 
+            check_resource_against_params(resource, params_with_comparator) if resource.resourceType == resource_type
+          end
         end
 
         search_variant_test_records[:comparator_searches] << name


### PR DESCRIPTION
This PR fixes GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/171

The changes include
* Filter result of `fetch_all_bundled_resources` with `resource_type`
* Add unit test