### PR TITLE
FI-1657 Add must support test for datetime slicing

### DIFF
--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -140,6 +140,12 @@ module USCoreTestKit
             rescue ArgumentError
               false
             end
+          when 'DateTime'
+            begin
+              DateTime.parse(element)
+            rescue ArgumentError
+              false
+            end
           when 'String'
             element.is_a? String
           else

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -248,6 +248,22 @@ RSpec.describe USCoreTestKit::MustSupportTest do
 
         expect(result.result).to eq('pass')
       end
+
+      it 'skips if datetime format is not correct' do
+        observation.effectiveDateTime = "not a date time"
+        allow_any_instance_of(test_class)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [observation]
+          }
+        )
+
+
+        result = run(test_class)
+
+        expect(result.result).to eq('skip')
+        expect(result.result_message).to include('Observation.effective[x]:effectiveDateTime')
+      end
     end
   end
 end

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -143,55 +143,111 @@ RSpec.describe USCoreTestKit::MustSupportTest do
   end
 
   describe 'must support test for slices' do
-    let(:care_plan_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_care_plan_must_support_test')}
-    let(:careplan) do
-      FHIR::CarePlan.new(
-        text: { status: 'status' },
-        status: 'status',
-        intent: 'intent',
-        category: [
-          {
+    context 'slicing with pattern' do
+      let(:care_plan_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_care_plan_must_support_test')}
+      let(:careplan) do
+        FHIR::CarePlan.new(
+          text: { status: 'status' },
+          status: 'status',
+          intent: 'intent',
+          category: [
+            {
+              coding: [
+                {
+                  system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category',
+                  code: 'assess-plan'
+                }
+              ]
+            }
+          ],
+          subject: {
+            reference: patient_ref
+          }
+        )
+      end
+
+      it 'passes if server suports all MS slices' do
+        allow_any_instance_of(care_plan_must_support_test)
+          .to receive(:scratch_resources).and_return(
+            {
+              all: [careplan]
+            }
+          )
+
+
+        result = run(care_plan_must_support_test)
+
+        expect(result.result).to eq('pass')
+      end
+
+      it 'fails if server does not suport one MS extensions' do
+        careplan.category.first.coding.first.code = 'something else'
+        allow_any_instance_of(care_plan_must_support_test)
+          .to receive(:scratch_resources).and_return(
+            {
+              all: [careplan]
+            }
+          )
+
+        result = run(care_plan_must_support_test)
+
+        expect(result.result).to eq('skip')
+        expect(result.result_message).to include('CarePlan.category:AssessPlan')
+      end
+    end
+
+    context 'slicing with type' do
+      let(:test_class) { USCoreTestKit::USCoreV400::SmokingstatusMustSupportTest }
+      let(:observation) {
+        FHIR::Observation.new(
+          status: 'final',
+          category: [
+            {
+              coding: [
+                {
+                  system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+                  code: 'social-history'
+                }
+              ]
+            }
+          ],
+          code: {
             coding: [
               {
-                system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category',
-                code: 'assess-plan'
+                system: 'http://loinc.org',
+                code: '72166-2'
+              }
+            ],
+            text: 'Tobacco smoking status'
+          },
+          subject: {
+            reference: 'Patient/902'
+          },
+          effectiveDateTime: '2013-04-23T21:07:05Z',
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://snomed.info/sct',
+                code: '449868002'
               }
             ]
           }
-        ],
-        subject: {
-          reference: patient_ref
-        }
-      )
-    end
+        )
+      }
 
-    it 'passes if server suports all MS slices' do
-      allow_any_instance_of(care_plan_must_support_test)
+      it 'passes if server suports all MS slices' do
+        allow_any_instance_of(test_class)
         .to receive(:scratch_resources).and_return(
           {
-            all: [careplan]
+            all: [observation]
           }
         )
 
 
-      result = run(care_plan_must_support_test)
+        result = run(test_class)
 
-      expect(result.result).to eq('pass')
-    end
-
-    it 'fails if server does not suport one MS extensions' do
-      careplan.category.first.coding.first.code = 'something else'
-      allow_any_instance_of(care_plan_must_support_test)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [careplan]
-          }
-        )
-
-      result = run(care_plan_must_support_test)
-
-      expect(result.result).to eq('skip')
-      expect(result.result_message).to include('CarePlan.category:AssessPlan')
+        expect(result.result).to eq('pass')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/178

The root cause is that US Core must_support_test checks slicing of Date and String but not DateTime.

This PR affects US Core 4.0.0 Test Kit and US Core 5.0.1 Test Kit. It does NOT affect US Core 3.1.1 Test Kit.

The change include:
* Adds MustSupport test of slicing with type 'DateTime' 
* Adds Unit Test