### PR TITLE
US Core 4.0 Move Patient.telecom.* and Patient.communicaiton.* out of USCDI

### DIFF
--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -12166,11 +12166,8 @@
     - :path: name.family
     - :path: name.given
     - :path: telecom.system
-      :uscdi_only: true
     - :path: telecom.value
-      :uscdi_only: true
     - :path: telecom.use
-      :uscdi_only: true
     - :path: gender
     - :path: birthDate
     - :path: address
@@ -12180,17 +12177,12 @@
     - :path: address.postalCode
     - :path: address.period
     - :path: communication.language
-      :uscdi_only: true
     - :path: name.suffix
       :uscdi_only: true
     - :path: name.use
       :fixed_value: old
       :uscdi_only: true
     - :path: name.period.end
-      :uscdi_only: true
-    - :path: telecom
-      :uscdi_only: true
-    - :path: communication
       :uscdi_only: true
     :choices:
     - :paths:

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -168,11 +168,8 @@
   - :path: name.family
   - :path: name.given
   - :path: telecom.system
-    :uscdi_only: true
   - :path: telecom.value
-    :uscdi_only: true
   - :path: telecom.use
-    :uscdi_only: true
   - :path: gender
   - :path: birthDate
   - :path: address
@@ -182,17 +179,12 @@
   - :path: address.postalCode
   - :path: address.period
   - :path: communication.language
-    :uscdi_only: true
   - :path: name.suffix
     :uscdi_only: true
   - :path: name.use
     :fixed_value: old
     :uscdi_only: true
   - :path: name.period.end
-    :uscdi_only: true
-  - :path: telecom
-    :uscdi_only: true
-  - :path: communication
     :uscdi_only: true
   :choices:
   - :paths:

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
@@ -19,6 +19,7 @@ module USCoreTestKit
         * Patient.address.postalCode
         * Patient.address.state
         * Patient.birthDate
+        * Patient.communication.language
         * Patient.gender
         * Patient.identifier
         * Patient.identifier.system
@@ -26,20 +27,17 @@ module USCoreTestKit
         * Patient.name
         * Patient.name.family
         * Patient.name.given
+        * Patient.telecom.system
+        * Patient.telecom.use
+        * Patient.telecom.value
 
         For ONC USCDI requirements, each Patient must support the following additional elements:
 
-        * Patient.communication
-        * Patient.communication.language
         * Patient.extension:birthsex
         * Patient.extension:ethnicity
         * Patient.extension:race
         * Patient.name.period.end or Patient.name.use
         * Patient.name.suffix
-        * Patient.telecom
-        * Patient.telecom.system
-        * Patient.telecom.use
-        * Patient.telecom.value
       )
 
       id :us_core_v400_patient_must_support_test

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -407,18 +407,6 @@ module USCoreTestKit
             path: 'name.period.end',
             uscdi_only: true
           }
-          @must_supports[:elements] << {
-            path: 'telecom',
-            uscdi_only: true
-          }
-          @must_supports[:elements] << {
-            path: 'communication',
-            uscdi_only: true
-          }
-          @must_supports[:elements].each do |element|
-            path = element[:path]
-            element[:uscdi_only] = true if path.include?('telecom.') || path.include?('communication.')
-          end
         end
       end
     end


### PR DESCRIPTION
This issue was found while doing US Core v5 development.

These elements are marked as MS in US Core profiles and should NOT have the `uscdi-only` label.

Patient.telecom.system
Patient.telecom.value
Patient.telecom.use
Patient.communication.language

