### PR TITLE
Add V501 validator to env for completeness.

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 JS_HOST=""
 V311_VALIDATOR_URL=http://validator_service:4567
 V400_VALIDATOR_URL=http://validator_service:4567
+V501_VALIDATOR_URL=http://validator_service:4567
 REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
# Summary

This just adds an explicit validator url for v501 as an environment variable.  It defaulted to the same spot, but this helps discoverability of this env variable and makes it consistent with the other versions.

Used here: https://github.com/inferno-framework/us-core-test-kit/blob/2063f6c1e719a291f5f63c54b28912e03d5ee765/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb#L67

# Testing Guidance

Just launch and make sure that this doesn't brake validation.
