### PR TITLE
FI-1679 Condition filter

### DIFF
--- a/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis_group.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis_group.rb
@@ -44,7 +44,7 @@ search. If a value cannot be found this way, the search is skipped.
 
 ### Search Validation
 Inferno will retrieve up to the first 20 bundle pages of the reply for
-Condition resources and save them for subsequent tests. Each of
+Condition resources with category `encounter-diagnosis` and save them for subsequent tests. Each of
 these resources is then checked to see if it matches the searched
 parameters in accordance with [FHIR search
 guidelines](https://www.hl7.org/fhir/search.html). The test will fail,

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns_group.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns_group.rb
@@ -44,7 +44,7 @@ search. If a value cannot be found this way, the search is skipped.
 
 ### Search Validation
 Inferno will retrieve up to the first 20 bundle pages of the reply for
-Condition resources and save them for subsequent tests. Each of
+Condition resources with category `problem-list-item | health-concern` and save them for subsequent tests. Each of
 these resources is then checked to see if it matches the searched
 parameters in accordance with [FHIR search
 guidelines](https://www.hl7.org/fhir/search.html). The test will fail,

--- a/lib/us_core_test_kit/generator/group_generator.rb
+++ b/lib/us_core_test_kit/generator/group_generator.rb
@@ -71,6 +71,20 @@ module USCoreTestKit
         group_metadata.resource
       end
 
+      def search_validation_resource_type
+        text = "#{resource_type} resources"
+        if resource_type == 'Condition' && group_metadata.reformatted_version == 'v501'
+          case profile_url
+          when 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
+            text.concat(' with category `encounter-diagnosis`')
+          when 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns'
+            text.concat(' with category `problem-list-item | health-concern`')
+          end
+        end
+
+        text
+      end
+
       def profile_name
         group_metadata.profile_name
       end
@@ -149,7 +163,7 @@ module USCoreTestKit
 
         ### Search Validation
         Inferno will retrieve up to the first 20 bundle pages of the reply for
-        #{resource_type} resources and save them for subsequent tests. Each of
+        #{search_validation_resource_type} and save them for subsequent tests. Each of
         these resources is then checked to see if it matches the searched
         parameters in accordance with [FHIR search
         guidelines](https://www.hl7.org/fhir/search.html). The test will fail,

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -106,6 +106,7 @@ module USCoreTestKit
 
       perform_comparator_searches(params, patient_id) if params_with_comparators.present?
 
+      filter_conditions(resources_returned) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
       filter_devices(resources_returned) if resource_type == 'Device'
 
       if first_search?
@@ -136,6 +137,7 @@ module USCoreTestKit
 
       post_search_resources = fetch_all_bundled_resources.select { |resource| resource.resourceType == resource_type }
 
+      filter_conditions(resources_returned) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
       filter_devices(post_search_resources) if resource_type == 'Device'
 
       get_resource_count = get_search_resources.length
@@ -155,6 +157,19 @@ module USCoreTestKit
 
       resources.select! do |resource|
         resource&.type&.coding&.any? { |coding| codes_to_include.include?(coding.code) }
+      end
+    end
+
+    def filter_conditions(resources)
+      # HL7 JIRA FHIR-37917. US Core v5.0.1 does not required patient+category.
+      # In order to distinguish which resources matches the current profile, Inferno has to manually filter
+      # the result of first search, which is searching by patient.
+      resources.select! do |resource|
+        resource.category.any? do |category|
+          category.coding.any? do |coding|
+            metadata.search_definitions[:category][:values].include? coding.code
+          end
+        end
       end
     end
 
@@ -228,7 +243,7 @@ module USCoreTestKit
 
           search_and_check_response(params_with_comparator)
 
-          fetch_all_bundled_resources.each do |resource| 
+          fetch_all_bundled_resources.each do |resource|
             check_resource_against_params(resource, params_with_comparator) if resource.resourceType == resource_type
           end
         end
@@ -246,6 +261,7 @@ module USCoreTestKit
 
       reference_with_type_resources = fetch_all_bundled_resources.select { |resource| resource.resourceType == resource_type }
 
+      filter_conditions(resources_returned) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
       filter_devices(reference_with_type_resources) if resource_type == 'Device'
 
       new_resource_count = reference_with_type_resources.count

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -137,7 +137,7 @@ module USCoreTestKit
 
       post_search_resources = fetch_all_bundled_resources.select { |resource| resource.resourceType == resource_type }
 
-      filter_conditions(resources_returned) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
+      filter_conditions(post_search_resources) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
       filter_devices(post_search_resources) if resource_type == 'Device'
 
       get_resource_count = get_search_resources.length
@@ -261,7 +261,7 @@ module USCoreTestKit
 
       reference_with_type_resources = fetch_all_bundled_resources.select { |resource| resource.resourceType == resource_type }
 
-      filter_conditions(resources_returned) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
+      filter_conditions(reference_with_type_resources) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
       filter_devices(reference_with_type_resources) if resource_type == 'Device'
 
       new_resource_count = reference_with_type_resources.count


### PR DESCRIPTION
# Summary

This PR follows the same pattern of Implantable Device. 
`returned_resources` is filtered by category code.

If server does not return Condition resources with expected category code, the first search is skipped

This PR also updated group's "Search Validation" to reflect which Condition resources are expected to be saved.

# Testing Guidance

Run US Core v5.0.1 test kit with reference server
Select Test Group 6 "Condition Encounter Diagnosis Tests"
Observe "Search Validation" description has "Condition resources with category encounter-diagnosis"
Run Test Group 6
All search tests shall pass
Select Test Group 7 "Condition Problems and Health Concerns Tests"
Observe "Search Validation" description has "Condition resources with category problem-list-item | health-concern"
Run Test Group 7
All search tests shall skip
