### PR TITLE
add questionnaire-response back

### DIFF
--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
@@ -1,0 +1,288 @@
+---
+:name: us_core_questionnaireresponse
+:class_name: USCorev501QuestionnaireresponseSequence
+:version: v5.0.1
+:reformatted_version: v501
+:resource: QuestionnaireResponse
+:profile_url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse
+:profile_name: US Core QuestionnaireResponse Profile
+:profile_version: 5.0.1
+:title: QuestionnaireResponse
+:short_description: Verify support for the server capabilities required by the US
+  Core QuestionnaireResponse Profile.
+:interactions:
+- :code: create
+  :expectation: MAY
+- :code: search-type
+  :expectation: SHALL
+- :code: read
+  :expectation: SHALL
+- :code: vread
+  :expectation: SHOULD
+- :code: update
+  :expectation: MAY
+- :code: patch
+  :expectation: MAY
+- :code: delete
+  :expectation: MAY
+- :code: history-instance
+  :expectation: SHOULD
+- :code: history-type
+  :expectation: MAY
+:operations: []
+:searches:
+- :names:
+  - patient
+  :expectation: SHALL
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
+- :names:
+  - _id
+  :expectation: SHALL
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
+- :expectation: SHOULD
+  :names:
+  - patient
+  - authored
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
+- :expectation: SHOULD
+  :names:
+  - patient
+  - _tag
+  - authored
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
+- :expectation: SHOULD
+  :names:
+  - patient
+  - status
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
+- :expectation: SHOULD
+  :names:
+  - patient
+  - _tag
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
+- :expectation: SHOULD
+  :names:
+  - patient
+  - questionnaire
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
+:search_definitions:
+  :_id:
+    :paths:
+    - id
+    :full_paths:
+    - QuestionnaireResponse.id
+    :comparators: {}
+    :values: []
+    :type: http://hl7.org/fhirpath/System.String
+    :contains_multiple: false
+    :multiple_or: MAY
+  :patient:
+    :paths:
+    - subject
+    :full_paths:
+    - QuestionnaireResponse.subject
+    :comparators: {}
+    :values: []
+    :type: Reference
+    :contains_multiple: false
+    :multiple_or: MAY
+  :authored:
+    :paths:
+    - authored
+    :full_paths:
+    - QuestionnaireResponse.authored
+    :comparators:
+      :eq: MAY
+      :ne: MAY
+      :gt: SHALL
+      :ge: SHALL
+      :lt: SHALL
+      :le: SHALL
+      :sa: MAY
+      :eb: MAY
+      :ap: MAY
+    :values: []
+    :type: dateTime
+    :contains_multiple: false
+    :multiple_or: MAY
+  :_tag:
+    :paths:
+    - meta.tag
+    :full_paths:
+    - QuestionnaireResponse.meta.tag
+    :comparators: {}
+    :values: []
+    :type: Coding
+    :contains_multiple: true
+    :multiple_or: MAY
+  :status:
+    :paths:
+    - status
+    :full_paths:
+    - QuestionnaireResponse.status
+    :comparators: {}
+    :values:
+    - in-progress
+    - completed
+    - amended
+    - entered-in-error
+    - stopped
+    :type: code
+    :contains_multiple: false
+    :multiple_or: SHALL
+  :questionnaire:
+    :paths:
+    - questionnaire
+    :full_paths:
+    - QuestionnaireResponse.questionnaire
+    :comparators: {}
+    :values: []
+    :type: canonical
+    :contains_multiple: false
+    :multiple_or: MAY
+:include_params: []
+:revincludes:
+- Provenance:target
+:required_concepts: []
+:must_supports:
+  :extensions:
+  - :id: QuestionnaireResponse.questionnaire.extension:questionnaireDisplay
+    :url: http://hl7.org/fhir/StructureDefinition/display
+  - :id: QuestionnaireResponse.questionnaire.extension:url
+    :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-extension-questionnaire-uri
+  :slices:
+  - :name: QuestionnaireResponse.meta.tag:sdoh
+    :path: meta.tag
+    :discriminator:
+      :type: patternCoding
+      :path: ''
+      :code: sdoh
+      :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-tags
+  :elements:
+  - :path: meta
+  - :path: meta.tag
+  - :path: identifier
+  - :path: questionnaire
+  - :path: status
+  - :path: subject
+    :types:
+    - Reference
+  - :path: authored
+  - :path: author
+    :types:
+    - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
+  - :path: item
+  - :path: item.linkId
+  - :path: item.text
+  - :path: item.answer
+  - :path: item.answer.valueDecimal
+    :original_path: item.answer.value[x]
+  - :path: item.answer.valueString
+    :original_path: item.answer.value[x]
+  - :path: item.answer.valueCoding
+    :original_path: item.answer.value[x]
+  - :path: item.answer.item
+  - :path: item.item
+:mandatory_elements:
+- QuestionnaireResponse.meta.tag.code
+- QuestionnaireResponse.questionnaire
+- QuestionnaireResponse.status
+- QuestionnaireResponse.subject
+- QuestionnaireResponse.authored
+- QuestionnaireResponse.item.linkId
+:bindings:
+- :type: Coding
+  :strength: extensible
+  :system: http://hl7.org/fhir/ValueSet/security-labels
+  :path: meta.security
+- :type: Coding
+  :strength: example
+  :system: http://hl7.org/fhir/ValueSet/common-tags
+  :path: meta.tag
+- :type: Coding
+  :strength: required
+  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-tags
+  :path: meta.tag
+- :type: code
+  :strength: preferred
+  :system: http://hl7.org/fhir/ValueSet/languages
+  :path: language
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/questionnaire-answers-status
+  :path: status
+- :type: boolean
+  :strength: example
+  :system: http://hl7.org/fhir/ValueSet/questionnaire-answers
+  :path: item.answer.value
+:references:
+- :path: QuestionnaireResponse.basedOn
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/CarePlan
+  - http://hl7.org/fhir/StructureDefinition/ServiceRequest
+- :path: QuestionnaireResponse.partOf
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/Observation
+  - http://hl7.org/fhir/StructureDefinition/Procedure
+- :path: QuestionnaireResponse.subject
+  :profiles:
+  - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
+- :path: QuestionnaireResponse.encounter
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/Encounter
+- :path: QuestionnaireResponse.author
+  :profiles:
+  - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
+  - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
+  - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
+  - http://hl7.org/fhir/StructureDefinition/PractitionerRole
+  - http://hl7.org/fhir/StructureDefinition/Device
+  - http://hl7.org/fhir/us/core/StructureDefinition/us-core-relatedperson
+- :path: QuestionnaireResponse.source
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/Patient
+  - http://hl7.org/fhir/StructureDefinition/Practitioner
+  - http://hl7.org/fhir/StructureDefinition/PractitionerRole
+  - http://hl7.org/fhir/StructureDefinition/RelatedPerson
+:tests:
+- :id: us_core_v501_questionnaire_response_patient_search_test
+  :file_name: questionnaire_response_patient_search_test.rb
+- :id: us_core_v501_questionnaire_response__id_search_test
+  :file_name: questionnaire_response_id_search_test.rb
+- :id: us_core_v501_questionnaire_response_patient_authored_search_test
+  :file_name: questionnaire_response_patient_authored_search_test.rb
+- :id: us_core_v501_questionnaire_response_patient__tag_authored_search_test
+  :file_name: questionnaire_response_patient_tag_authored_search_test.rb
+- :id: us_core_v501_questionnaire_response_patient_status_search_test
+  :file_name: questionnaire_response_patient_status_search_test.rb
+- :id: us_core_v501_questionnaire_response_patient__tag_search_test
+  :file_name: questionnaire_response_patient_tag_search_test.rb
+- :id: us_core_v501_questionnaire_response_patient_questionnaire_search_test
+  :file_name: questionnaire_response_patient_questionnaire_search_test.rb
+- :id: us_core_v501_questionnaire_response_read_test
+  :file_name: questionnaire_response_read_test.rb
+- :id: us_core_v501_questionnaire_response_provenance_revinclude_search_test
+  :file_name: questionnaire_response_provenance_revinclude_search_test.rb
+- :id: us_core_v501_questionnaire_response_validation_test
+  :file_name: questionnaire_response_validation_test.rb
+- :id: us_core_v501_questionnaire_response_must_support_test
+  :file_name: questionnaire_response_must_support_test.rb
+- :id: us_core_v501_questionnaire_response_reference_resolution_test
+  :file_name: questionnaire_response_reference_resolution_test.rb
+:id: us_core_v501_questionnaire_response
+:file_name: questionnaire_response_group.rb
+:delayed_references:
+- :path: author
+  :resources:
+  - Practitioner
+  - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_id_search_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_id_search_test.rb
@@ -1,0 +1,42 @@
+require_relative '../../../search_test'
+require_relative '../../../generator/group_metadata'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponseIdSearchTest < Inferno::Test
+      include USCoreTestKit::SearchTest
+
+      title 'Server returns valid results for QuestionnaireResponse search by _id'
+      description %(
+A server SHALL support searching by
+_id on the QuestionnaireResponse resource. This test
+will pass if resources are returned and match the search criteria. If
+none are returned, the test is skipped.
+
+[US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
+
+      )
+
+      id :us_core_v501_questionnaire_response__id_search_test
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          resource_type: 'QuestionnaireResponse',
+        search_param_names: ['_id'],
+        possible_status_search: true
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        run_search_test
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_must_support_test.rb
@@ -1,0 +1,56 @@
+require_relative '../../../must_support_test'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponseMustSupportTest < Inferno::Test
+      include USCoreTestKit::MustSupportTest
+
+      title 'All must support elements are provided in the QuestionnaireResponse resources returned'
+      description %(
+        US Core Responders SHALL be capable of populating all data elements as
+        part of the query results as specified by the US Core Server Capability
+        Statement. This test will look through the QuestionnaireResponse resources
+        found previously for the following must support elements:
+
+        * QuestionnaireResponse.author
+        * QuestionnaireResponse.authored
+        * QuestionnaireResponse.identifier
+        * QuestionnaireResponse.item
+        * QuestionnaireResponse.item.answer
+        * QuestionnaireResponse.item.answer.item
+        * QuestionnaireResponse.item.answer.valueCoding
+        * QuestionnaireResponse.item.answer.valueDecimal
+        * QuestionnaireResponse.item.answer.valueString
+        * QuestionnaireResponse.item.item
+        * QuestionnaireResponse.item.linkId
+        * QuestionnaireResponse.item.text
+        * QuestionnaireResponse.meta
+        * QuestionnaireResponse.meta.tag
+        * QuestionnaireResponse.meta.tag:sdoh
+        * QuestionnaireResponse.questionnaire
+        * QuestionnaireResponse.questionnaire.extension:questionnaireDisplay
+        * QuestionnaireResponse.questionnaire.extension:url
+        * QuestionnaireResponse.status
+        * QuestionnaireResponse.subject
+      )
+
+      id :us_core_v501_questionnaire_response_must_support_test
+
+      def resource_type
+        'QuestionnaireResponse'
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        perform_must_support_test(all_scratch_resources)
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_authored_search_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_authored_search_test.rb
@@ -1,0 +1,49 @@
+require_relative '../../../search_test'
+require_relative '../../../generator/group_metadata'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponsePatientAuthoredSearchTest < Inferno::Test
+      include USCoreTestKit::SearchTest
+
+      title 'Server returns valid results for QuestionnaireResponse search by patient + authored'
+      description %(
+A server SHOULD support searching by
+patient + authored on the QuestionnaireResponse resource. This test
+will pass if resources are returned and match the search criteria. If
+none are returned, the test is skipped.
+
+[US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
+
+      )
+
+      id :us_core_v501_questionnaire_response_patient_authored_search_test
+      optional
+  
+      input :patient_ids,
+        title: 'Patient IDs',
+        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+  
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          resource_type: 'QuestionnaireResponse',
+        search_param_names: ['patient', 'authored'],
+        possible_status_search: true,
+        params_with_comparators: ['authored']
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        run_search_test
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_questionnaire_search_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_questionnaire_search_test.rb
@@ -1,0 +1,48 @@
+require_relative '../../../search_test'
+require_relative '../../../generator/group_metadata'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponsePatientQuestionnaireSearchTest < Inferno::Test
+      include USCoreTestKit::SearchTest
+
+      title 'Server returns valid results for QuestionnaireResponse search by patient + questionnaire'
+      description %(
+A server SHOULD support searching by
+patient + questionnaire on the QuestionnaireResponse resource. This test
+will pass if resources are returned and match the search criteria. If
+none are returned, the test is skipped.
+
+[US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
+
+      )
+
+      id :us_core_v501_questionnaire_response_patient_questionnaire_search_test
+      optional
+  
+      input :patient_ids,
+        title: 'Patient IDs',
+        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+  
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          resource_type: 'QuestionnaireResponse',
+        search_param_names: ['patient', 'questionnaire'],
+        possible_status_search: true
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        run_search_test
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_search_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_search_test.rb
@@ -1,0 +1,63 @@
+require_relative '../../../search_test'
+require_relative '../../../generator/group_metadata'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponsePatientSearchTest < Inferno::Test
+      include USCoreTestKit::SearchTest
+
+      title 'Server returns valid results for QuestionnaireResponse search by patient'
+      description %(
+A server SHALL support searching by
+patient on the QuestionnaireResponse resource. This test
+will pass if resources are returned and match the search criteria. If
+none are returned, the test is skipped.
+
+This test verifies that the server supports searching by reference using
+the form `patient=[id]` as well as `patient=Patient/[id]`. The two
+different forms are expected to return the same number of results. US
+Core requires that both forms are supported by US Core responders.
+
+Because this is the first search of the sequence, resources in the
+response will be used for subsequent tests.
+
+Additionally, this test will check that GET and POST search methods
+return the same number of results. Search by POST is required by the
+FHIR R4 specification, and these tests interpret search by GET as a
+requirement of US Core v5.0.1.
+
+[US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
+
+      )
+
+      id :us_core_v501_questionnaire_response_patient_search_test
+      input :patient_ids,
+        title: 'Patient IDs',
+        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+  
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          first_search: true,
+        resource_type: 'QuestionnaireResponse',
+        search_param_names: ['patient'],
+        saves_delayed_references: true,
+        possible_status_search: true,
+        test_reference_variants: true,
+        test_post_search: true
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        run_search_test
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_status_search_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_status_search_test.rb
@@ -1,0 +1,48 @@
+require_relative '../../../search_test'
+require_relative '../../../generator/group_metadata'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponsePatientStatusSearchTest < Inferno::Test
+      include USCoreTestKit::SearchTest
+
+      title 'Server returns valid results for QuestionnaireResponse search by patient + status'
+      description %(
+A server SHOULD support searching by
+patient + status on the QuestionnaireResponse resource. This test
+will pass if resources are returned and match the search criteria. If
+none are returned, the test is skipped.
+
+[US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
+
+      )
+
+      id :us_core_v501_questionnaire_response_patient_status_search_test
+      optional
+  
+      input :patient_ids,
+        title: 'Patient IDs',
+        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+  
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          resource_type: 'QuestionnaireResponse',
+        search_param_names: ['patient', 'status'],
+        multiple_or_search_params: ['status']
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        run_search_test
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_tag_authored_search_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_tag_authored_search_test.rb
@@ -1,0 +1,50 @@
+require_relative '../../../search_test'
+require_relative '../../../generator/group_metadata'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponsePatientTagAuthoredSearchTest < Inferno::Test
+      include USCoreTestKit::SearchTest
+
+      title 'Server returns valid results for QuestionnaireResponse search by patient + _tag + authored'
+      description %(
+A server SHOULD support searching by
+patient + _tag + authored on the QuestionnaireResponse resource. This test
+will pass if resources are returned and match the search criteria. If
+none are returned, the test is skipped.
+
+[US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
+
+      )
+
+      id :us_core_v501_questionnaire_response_patient__tag_authored_search_test
+      optional
+  
+      input :patient_ids,
+        title: 'Patient IDs',
+        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+  
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          resource_type: 'QuestionnaireResponse',
+        search_param_names: ['patient', '_tag', 'authored'],
+        possible_status_search: true,
+        token_search_params: ['_tag'],
+        params_with_comparators: ['authored']
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        run_search_test
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_tag_search_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_patient_tag_search_test.rb
@@ -1,0 +1,49 @@
+require_relative '../../../search_test'
+require_relative '../../../generator/group_metadata'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponsePatientTagSearchTest < Inferno::Test
+      include USCoreTestKit::SearchTest
+
+      title 'Server returns valid results for QuestionnaireResponse search by patient + _tag'
+      description %(
+A server SHOULD support searching by
+patient + _tag on the QuestionnaireResponse resource. This test
+will pass if resources are returned and match the search criteria. If
+none are returned, the test is skipped.
+
+[US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
+
+      )
+
+      id :us_core_v501_questionnaire_response_patient__tag_search_test
+      optional
+  
+      input :patient_ids,
+        title: 'Patient IDs',
+        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+  
+      def self.properties
+        @properties ||= SearchTestProperties.new(
+          resource_type: 'QuestionnaireResponse',
+        search_param_names: ['patient', '_tag'],
+        possible_status_search: true,
+        token_search_params: ['_tag']
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        run_search_test
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_provenance_revinclude_search_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_provenance_revinclude_search_test.rb
@@ -1,0 +1,52 @@
+require_relative '../../../search_test'
+require_relative '../../../generator/group_metadata'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponseProvenanceRevincludeSearchTest < Inferno::Test
+      include USCoreTestKit::SearchTest
+
+      title 'Server returns Provenance resources from QuestionnaireResponse search by patient + revInclude:Provenance:target'
+      description %(
+        A server SHALL be capable of supporting _revIncludes:Provenance:target.
+
+        This test will perform a search by patient + revInclude:Provenance:target and
+        will pass if a Provenance resource is found in the response.
+      %)
+
+      id :us_core_v501_questionnaire_response_provenance_revinclude_search_test
+  
+      input :patient_ids,
+        title: 'Patient IDs',
+        description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'
+  
+      def properties
+        @properties ||= SearchTestProperties.new(
+          resource_type: 'QuestionnaireResponse',
+        search_param_names: ['patient'],
+        possible_status_search: true
+        )
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def self.provenance_metadata
+        @provenance_metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, '..', 'provenance', 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      def scratch_provenance_resources
+        scratch[:provenance_resources] ||= {}
+      end
+
+      run do
+        run_provenance_revinclude_search_test
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_read_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_read_test.rb
@@ -1,0 +1,26 @@
+require_relative '../../../read_test'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponseReadTest < Inferno::Test
+      include USCoreTestKit::ReadTest
+
+      title 'Server returns correct QuestionnaireResponse resource from QuestionnaireResponse read interaction'
+      description 'A server SHALL support the QuestionnaireResponse read interaction.'
+
+      id :us_core_v501_questionnaire_response_read_test
+
+      def resource_type
+        'QuestionnaireResponse'
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        perform_read_test(all_scratch_resources)
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_reference_resolution_test.rb
@@ -1,0 +1,39 @@
+require_relative '../../../reference_resolution_test'
+require_relative '../resource_list'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponseReferenceResolutionTest < Inferno::Test
+      include USCoreTestKit::ReferenceResolutionTest
+      include ResourceList
+
+      title 'MustSupport references within QuestionnaireResponse resources can be read'
+      description %(
+        This test will attempt to read external references provided within elements
+        marked as 'MustSupport', if any are available.  Elements which may provide
+        external references include:
+
+        * QuestionnaireResponse.author
+        * QuestionnaireResponse.subject
+      )
+
+      id :us_core_v501_questionnaire_response_reference_resolution_test
+
+      def resource_type
+        'QuestionnaireResponse'
+      end
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'metadata.yml')))
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        perform_reference_resolution_test(scratch_resources[:all])
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_validation_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/questionnaire_response_validation_test.rb
@@ -1,0 +1,40 @@
+require_relative '../../../validation_test'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponseValidationTest < Inferno::Test
+      include USCoreTestKit::ValidationTest
+
+      id :us_core_v501_questionnaire_response_validation_test
+      title 'QuestionnaireResponse resources returned during previous tests conform to the US Core QuestionnaireResponse Profile'
+      description %(
+This test verifies resources returned from the first search conform to
+the [US Core QuestionnaireResponse Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse).
+Systems must demonstrate at least one valid example in order to pass this test.
+
+It verifies the presence of mandatory elements and that elements with
+required bindings contain appropriate values. CodeableConcept element
+bindings will fail if none of their codings have a code/system belonging
+to the bound ValueSet. Quantity, Coding, and code element bindings will
+fail if their code/system are not found in the valueset.
+
+      )
+      output :dar_code_found, :dar_extension_found
+
+      def resource_type
+        'QuestionnaireResponse'
+      end
+
+      def scratch_resources
+        scratch[:questionnaire_response_resources] ||= {}
+      end
+
+      run do
+        perform_validation_test(scratch_resources[:all] || [],
+                                'http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse',
+                                '5.0.1',
+                                skip_if_empty: true)
+      end
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response_group.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response_group.rb
@@ -1,0 +1,99 @@
+require_relative 'questionnaire_response/questionnaire_response_patient_search_test'
+require_relative 'questionnaire_response/questionnaire_response_id_search_test'
+require_relative 'questionnaire_response/questionnaire_response_patient_authored_search_test'
+require_relative 'questionnaire_response/questionnaire_response_patient_tag_authored_search_test'
+require_relative 'questionnaire_response/questionnaire_response_patient_status_search_test'
+require_relative 'questionnaire_response/questionnaire_response_patient_tag_search_test'
+require_relative 'questionnaire_response/questionnaire_response_patient_questionnaire_search_test'
+require_relative 'questionnaire_response/questionnaire_response_read_test'
+require_relative 'questionnaire_response/questionnaire_response_provenance_revinclude_search_test'
+require_relative 'questionnaire_response/questionnaire_response_validation_test'
+require_relative 'questionnaire_response/questionnaire_response_must_support_test'
+require_relative 'questionnaire_response/questionnaire_response_reference_resolution_test'
+
+module USCoreTestKit
+  module USCoreV501
+    class QuestionnaireResponseGroup < Inferno::TestGroup
+      title 'QuestionnaireResponse Tests'
+      short_description 'Verify support for the server capabilities required by the US Core QuestionnaireResponse Profile.'
+      description %(
+  # Background
+
+The US Core QuestionnaireResponse sequence verifies that the system under test is
+able to provide correct responses for QuestionnaireResponse queries. These queries
+must contain resources conforming to the US Core QuestionnaireResponse Profile as
+specified in the US Core v5.0.1 Implementation Guide.
+
+# Testing Methodology
+## Searching
+This test sequence will first perform each required search associated
+with this resource. This sequence will perform searches with the
+following parameters:
+
+* patient
+* _id
+
+### Search Parameters
+The first search uses the selected patient(s) from the prior launch
+sequence. Any subsequent searches will look for its parameter values
+from the results of the first search. For example, the `identifier`
+search in the patient sequence is performed by looking for an existing
+`Patient.identifier` from any of the resources returned in the `_id`
+search. If a value cannot be found this way, the search is skipped.
+
+### Search Validation
+Inferno will retrieve up to the first 20 bundle pages of the reply for
+QuestionnaireResponse resources and save them for subsequent tests. Each of
+these resources is then checked to see if it matches the searched
+parameters in accordance with [FHIR search
+guidelines](https://www.hl7.org/fhir/search.html). The test will fail,
+for example, if a Patient search for `gender=male` returns a `female`
+patient.
+
+
+## Must Support
+Each profile contains elements marked as "must support". This test
+sequence expects to see each of these elements at least once. If at
+least one cannot be found, the test will fail. The test will look
+through the QuestionnaireResponse resources found in the first test for these
+elements.
+
+## Profile Validation
+Each resource returned from the first search is expected to conform to
+the [US Core QuestionnaireResponse Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse). Each element is checked against
+teminology binding and cardinality requirements.
+
+Elements with a required binding are validated against their bound
+ValueSet. If the code/system in the element is not part of the ValueSet,
+then the test will fail.
+
+## Reference Validation
+At least one instance of each external reference in elements marked as
+"must support" within the resources provided by the system must resolve.
+The test will attempt to read each reference found and will fail if no
+read succeeds.
+
+      )
+
+      id :us_core_v501_questionnaire_response
+      run_as_group
+
+      def self.metadata
+        @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'questionnaire_response', 'metadata.yml')))
+      end
+  
+      test from: :us_core_v501_questionnaire_response_patient_search_test
+      test from: :us_core_v501_questionnaire_response__id_search_test
+      test from: :us_core_v501_questionnaire_response_patient_authored_search_test
+      test from: :us_core_v501_questionnaire_response_patient__tag_authored_search_test
+      test from: :us_core_v501_questionnaire_response_patient_status_search_test
+      test from: :us_core_v501_questionnaire_response_patient__tag_search_test
+      test from: :us_core_v501_questionnaire_response_patient_questionnaire_search_test
+      test from: :us_core_v501_questionnaire_response_read_test
+      test from: :us_core_v501_questionnaire_response_provenance_revinclude_search_test
+      test from: :us_core_v501_questionnaire_response_validation_test
+      test from: :us_core_v501_questionnaire_response_must_support_test
+      test from: :us_core_v501_questionnaire_response_reference_resolution_test
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -37,6 +37,7 @@ require_relative 'pediatric_bmi_for_age_group'
 require_relative 'head_circumference_percentile_group'
 require_relative 'body_weight_group'
 require_relative 'procedure_group'
+require_relative 'questionnaire_response_group'
 require_relative 'service_request_group'
 require_relative 'organization_group'
 require_relative 'practitioner_group'
@@ -120,6 +121,7 @@ module USCoreTestKit
       group from: :us_core_v501_head_circumference_percentile
       group from: :us_core_v501_body_weight
       group from: :us_core_v501_procedure
+      group from: :us_core_v501_questionnaire_response
       group from: :us_core_v501_service_request
       group from: :us_core_v501_organization
       group from: :us_core_v501_practitioner

--- a/lib/us_core_test_kit/generator/special_cases.rb
+++ b/lib/us_core_test_kit/generator/special_cases.rb
@@ -4,8 +4,7 @@ module USCoreTestKit
       RESOURCES_TO_EXCLUDE = [
         'Location',
         'Medication',
-        'PractitionerRole',
-        'QuestionnaireResponse'
+        'PractitionerRole'
       ].freeze
 
       PROFILES_TO_EXCLUDE = [


### PR DESCRIPTION
# Summary
This PR add US Core QuestionnaireResponse test back to US Core 5.0.1 Test Kit.

Don't merge this PR till ONC confirms test procedure for QuestionnaireResponse

# Testing Guidance
Launch US Core 5.0.1 Test Kit
Verify that Questionnaire Response test group exists

