### PR TITLE
FI-1703 reference validation

### DIFF
--- a/lib/us_core_test_kit/reference_resolution_test.rb
+++ b/lib/us_core_test_kit/reference_resolution_test.rb
@@ -74,16 +74,28 @@ module USCoreTestKit
           found_one_reference && !resolve_one_reference
         end
 
-      if metadata.must_supports[:choices].present?
-        @unresolved_references.delete_if do |reference|
-          choice_profiles = metadata.must_supports[:choices].find { |choice| choice[:target_profiles].include?(reference[:target_profile]) }
+      handle_target_profile_choices(@unresolved_references)
+      @unresolved_references
+    end
 
-          choice_profiles.present? &&
-          choice_profiles[:target_profiles].any? { |profile| @unresolved_references.none? { |element| element[:target_profile] == profile } }
+    def handle_target_profile_choices(unresolved_references)
+      return if unresolved_references.blank? || metadata.must_supports[:choices].blank?
+
+      unresolved_references.delete_if do |reference|
+        choice_profiles = metadata.must_supports[:choices].find do |choice|
+          choice[:element_path] == reference[:path] &&
+          choice[:target_profiles].include?(reference[:target_profile])
         end
-      end
 
       @unresolved_references
+        choice_profiles.present? &&
+        choice_profiles[:target_profiles].any? do |profile|
+          unresolved_references.none? do |reference|
+            reference[:path] == choice_profiles[:element_path] &&
+            reference[:target_profile] == profile
+          end
+        end
+      end
     end
 
     def validate_reference_resolution(resource, reference, target_profile)

--- a/lib/us_core_test_kit/reference_resolution_test.rb
+++ b/lib/us_core_test_kit/reference_resolution_test.rb
@@ -76,26 +76,16 @@ module USCoreTestKit
 
       handle_target_profile_choices(@unresolved_references)
       @unresolved_references
-    end
+      if metadata.must_supports[:choices].present?
+        @unresolved_references.delete_if do |reference|
+          choice_profiles = metadata.must_supports[:choices].find { |choice| choice[:target_profiles].include?(reference[:target_profile]) }
 
-    def handle_target_profile_choices(unresolved_references)
-      return if unresolved_references.blank? || metadata.must_supports[:choices].blank?
-
-      unresolved_references.delete_if do |reference|
-        choice_profiles = metadata.must_supports[:choices].find do |choice|
-          choice[:element_path] == reference[:path] &&
-          choice[:target_profiles].include?(reference[:target_profile])
-        end
-
-      @unresolved_references
-        choice_profiles.present? &&
-        choice_profiles[:target_profiles].any? do |profile|
-          unresolved_references.none? do |reference|
-            reference[:path] == choice_profiles[:element_path] &&
-            reference[:target_profile] == profile
-          end
+          choice_profiles.present? &&
+          choice_profiles[:target_profiles].any? { |profile| @unresolved_references.none? { |element| element[:target_profile] == profile } }
         end
       end
+
+      @unresolved_references
     end
 
     def validate_reference_resolution(resource, reference, target_profile)

--- a/lib/us_core_test_kit/reference_resolution_test.rb
+++ b/lib/us_core_test_kit/reference_resolution_test.rb
@@ -74,8 +74,6 @@ module USCoreTestKit
           found_one_reference && !resolve_one_reference
         end
 
-      handle_target_profile_choices(@unresolved_references)
-      @unresolved_references
       if metadata.must_supports[:choices].present?
         @unresolved_references.delete_if do |reference|
           choice_profiles = metadata.must_supports[:choices].find { |choice| choice[:target_profiles].include?(reference[:target_profile]) }
@@ -138,7 +136,19 @@ module USCoreTestKit
     def resource_is_valid_with_target_profile?(resource, target_profile)
       return true if target_profile.blank?
 
-      resource_is_valid?(resource: resource, profile_url: target_profile)
+      # Only need to know if the resource is valid.
+      # Calling resource_is_valid? causes validation errors to be logged.
+      validator = find_validator(:default)
+
+      outcome = FHIR::OperationOutcome.new(JSON.parse(validator.validate(resource, target_profile)))
+
+      message_hashes = outcome.issue&.map { |issue| validator.message_hash_from_issue(issue, resource) } || []
+
+      message_hashes.concat(validator.additional_validation_messages(resource, target_profile))
+
+      validator.filter_messages(message_hashes)
+
+      message_hashes.none? { |message_hash| message_hash[:type] == 'error' }
     end
   end
 end

--- a/spec/us_core/reference_resolution_test_spec.rb
+++ b/spec/us_core/reference_resolution_test_spec.rb
@@ -191,36 +191,5 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
       end
     end
   end
-  describe '#handle_target_profile_choices' do
-    let(:test_class) { USCoreTestKit::USCoreV501::CareTeamReferenceResolutionTest }
-    let(:test) {test_class.new }
 
-    it 'returns empty unresolved_references if at least one of MS reference choices is provided' do
-      unresolved_references = [
-        {
-          path: 'participant.member',
-          target_profile: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'
-        }
-      ]
-      test.handle_target_profile_choices(unresolved_references)
-
-      expect(unresolved_references).to be_blank
-    end
-
-    it 'returns unresolved_references if at none MS reference choices is provided' do
-      unresolved_references = [
-        {
-          path: 'participant.member',
-          target_profile: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'
-        },
-        {
-          path: 'participant.member',
-          target_profile: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'
-        }
-      ]
-      test.handle_target_profile_choices(unresolved_references)
-
-      expect(unresolved_references).not_to be_blank
-    end
-  end
 end

--- a/spec/us_core/reference_resolution_test_spec.rb
+++ b/spec/us_core/reference_resolution_test_spec.rb
@@ -152,13 +152,13 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
         let(:reference) { resource.encounter }
 
         it 'returns true if the contained resource conforms to the target profile' do
-          allow(test).to receive(:resource_is_valid?).with(resource: contained_resource, profile_url: 'PROFILE').and_return(true)
+          allow(test).to receive(:resource_is_valid_with_target_profile?).with(contained_resource, 'PROFILE').and_return(true)
 
           expect(test.validate_reference_resolution(resource, reference, 'PROFILE')).to be(true)
         end
 
         it 'returns false if the contained resource does not conform to the target profile' do
-          allow(test).to receive(:resource_is_valid?).with(resource: contained_resource, profile_url: 'PROFILE').and_return(false)
+          allow(test).to receive(:resource_is_valid_with_target_profile?).with(contained_resource, 'PROFILE').and_return(false)
 
           expect(test.validate_reference_resolution(resource, reference, 'PROFILE')).to be(false)
         end
@@ -178,13 +178,13 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
         end
 
         it 'returns true if the referenced resource conforms to the target profile' do
-          allow(test).to receive(:resource_is_valid?).with(resource: referenced_resource, profile_url: 'PROFILE').and_return(true)
+          allow(test).to receive(:resource_is_valid_with_target_profile?).with(referenced_resource, 'PROFILE').and_return(true)
 
           expect(test.validate_reference_resolution(resource, reference, 'PROFILE')).to be(true)
         end
 
         it 'returns false if the referenced resource does not conform to the target profile' do
-          allow(test).to receive(:resource_is_valid?).with(resource: referenced_resource, profile_url: 'PROFILE').and_return(false)
+          allow(test).to receive(:resource_is_valid_with_target_profile?).with(referenced_resource, 'PROFILE').and_return(false)
 
           expect(test.validate_reference_resolution(resource, reference, 'PROFILE')).to be(false)
         end

--- a/spec/us_core/reference_resolution_test_spec.rb
+++ b/spec/us_core/reference_resolution_test_spec.rb
@@ -191,4 +191,36 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
       end
     end
   end
+  describe '#handle_target_profile_choices' do
+    let(:test_class) { USCoreTestKit::USCoreV501::CareTeamReferenceResolutionTest }
+    let(:test) {test_class.new }
+
+    it 'returns empty unresolved_references if at least one of MS reference choices is provided' do
+      unresolved_references = [
+        {
+          path: 'participant.member',
+          target_profile: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'
+        }
+      ]
+      test.handle_target_profile_choices(unresolved_references)
+
+      expect(unresolved_references).to be_blank
+    end
+
+    it 'returns unresolved_references if at none MS reference choices is provided' do
+      unresolved_references = [
+        {
+          path: 'participant.member',
+          target_profile: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'
+        },
+        {
+          path: 'participant.member',
+          target_profile: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'
+        }
+      ]
+      test.handle_target_profile_choices(unresolved_references)
+
+      expect(unresolved_references).not_to be_blank
+    end
+  end
 end

--- a/spec/us_core/reference_resolution_test_spec.rb
+++ b/spec/us_core/reference_resolution_test_spec.rb
@@ -191,5 +191,4 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
       end
     end
   end
-
 end

--- a/spec/us_core/reference_test_spec.rb
+++ b/spec/us_core/reference_test_spec.rb
@@ -102,23 +102,23 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
 
       stub_request(:get, "#{url}/#{patient_ref}")
         .to_return(status: 200, body: patient.to_json)
-                
+
       stub_request(:get, "#{url}/#{practitioner_ref}")
         .to_return(status: 200, body: practitioner.to_json)
-      
+
       stub_request(:get, "#{url}/#{organization_ref}")
         .to_return(status: 200, body: organization.to_json)
     end
 
     context 'when reference read returns ok' do
-      before do           
+      before do
         stub_request(:get, "#{url}/#{encounter_ref}")
           .to_return(status: 200, body: encounter.to_json)
       end
 
       it 'passes if all MS references can be read' do
         allow_any_instance_of(reference_resolution_test)
-          .to receive(:resource_is_valid?).and_return(true)
+          .to receive(:resource_is_valid_with_target_profile?).and_return(true)
 
         result = run(reference_resolution_test, url: url)
         expect(result.result).to eq('pass')
@@ -126,8 +126,8 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
 
       it 'skips if one MS references with MS target_profiles cannot be validated' do
         allow_any_instance_of(reference_resolution_test)
-          .to receive(:resource_is_valid?).and_return(false)
-        
+          .to receive(:resource_is_valid_with_target_profile?).and_return(false)
+
         result = run(reference_resolution_test, url: url)
         expect(result.result).to eq('skip')
         expect(result.result_message).to include('performer(http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization)')
@@ -142,7 +142,7 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
 
       it 'skips if one MS references cannot be read' do
         allow_any_instance_of(reference_resolution_test)
-          .to receive(:resource_is_valid?).and_return(true)
+          .to receive(:resource_is_valid_with_target_profile?).and_return(true)
 
         result = run(reference_resolution_test, url: url)
         expect(result.result).to eq('skip')


### PR DESCRIPTION
# Summary
This is to resolve GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/240

The issue does NOT affect the testing result but could add confusion validation errors in the message area.

A Reference element may have many references. For example, DiagnosticReport.performer (for Note Exchange, v4.0.0) has 4 target references (Practitioner | Organization | PractitionerRole | CareTeam). Only the first two are Must Supported and covered by Reference validation test. 

Reference validation test need to find ONE reference that the referenced resource is valid with target profile. When the referenced resource is a CareTeam, the validation report error and test skips this reference. 

This PR changes the method `resource_is_valid_with_target_profile` to call `validator.validate` directly and parse the OperationOutcome without error logging

# Testing Guidance
Launch US Core 4.0.0 Test Kit
Run DiagnosticReport for Report and Note Exchange Test
Test 9.11 "MustSupport references within DiagnosticReport resources can be read' shall pass WITHOUT any validation error like the screenshot
![image](https://user-images.githubusercontent.com/8761175/188172793-eafa723d-bf9c-4c7c-aa64-57e7989b8fe9.png)
