### PR TITLE
FI-1711 Fix the failure when target_profiles is nil

### DIFF
--- a/lib/us_core_test_kit/reference_resolution_test.rb
+++ b/lib/us_core_test_kit/reference_resolution_test.rb
@@ -76,10 +76,10 @@ module USCoreTestKit
 
       if metadata.must_supports[:choices].present?
         @unresolved_references.delete_if do |reference|
-          choice_profiles = metadata.must_supports[:choices].find { |choice| choice[:target_profiles].include?(reference[:target_profile]) }
+          choice_profiles = metadata.must_supports[:choices].find { |choice| choice[:target_profiles]&.include?(reference[:target_profile]) }
 
           choice_profiles.present? &&
-          choice_profiles[:target_profiles].any? { |profile| @unresolved_references.none? { |element| element[:target_profile] == profile } }
+          choice_profiles[:target_profiles]&.any? { |profile| @unresolved_references.none? { |element| element[:target_profile] == profile } }
         end
       end
 


### PR DESCRIPTION
# Summary
This is to fix Github Issue (https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/261)

reference_resolution test failed to handle v3.1.1 profiles without target_profile choices.

Changes include
* Add `&` to handle the  choices hash without target_profiles key
* Add unit test to simulate the failed test mentioned in the GitHub Issue

# Testing Guidance
All unit tests passed

