### PR TITLE
Remove QuestionnaireResponse from MS target profiles

### DIFF
--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -9229,7 +9229,6 @@
       - Reference
       :target_profiles:
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-survey
-      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse
   :mandatory_elements:
   - Observation.status
   - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
@@ -232,7 +232,6 @@
     - Reference
     :target_profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-survey
-    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -296,6 +296,7 @@ module USCoreTestKit
         when '5.0.1'
           add_patient_uscdi_elements
           add_document_reference_category_values
+          remove_survey_questionnaire_response
         end
       end
 
@@ -491,6 +492,17 @@ module USCoreTestKit
         slice = @must_supports[:slices].find{|slice| slice[:path] == 'category'}
 
         slice[:discriminator][:values] << 'clinical-note' if slice.present?
+      end
+
+      # FHIR-37794 Server systems are not required to support US Core QuestionnaireResponse
+      def remove_survey_questionnaire_response
+        return unless profile.type == 'Observation' &&
+          ['us-core-observation-survey', 'us-core-observation-sdoh-assessment'].include?(profile.id)
+
+        element = @must_supports[:elements].find { |element| element[:path] == 'derivedFrom' }
+        element[:target_profiles].delete_if do |url|
+          url == 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse'
+        end
       end
     end
   end


### PR DESCRIPTION
# Summary

Applies US Core Ticket FI-37794 (https://jira.hl7.org/browse/FHIR-37794)

The changes is:

Remove US Core QuestionnaireResponse as choices of target profiles for US Core Observation Survey and US Core SDOH Assessment profiles

# Testing Guidance
Verified that metadata.yml of US Core SDOH Assessment profile does not have us-core-questionnairereponse in the must-support section.

