### PR TITLE
Add search parameter expression match to must support base path

### DIFF
--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -11314,9 +11314,8 @@
     - patient
     - code
     - date
-    :names_not_must_support_or_mandatory:
-    - date
-    :must_support_or_mandatory: false
+    :names_not_must_support_or_mandatory: []
+    :must_support_or_mandatory: true
   - :expectation: SHALL
     :names:
     - patient
@@ -11328,9 +11327,8 @@
     - patient
     - category
     - date
-    :names_not_must_support_or_mandatory:
-    - date
-    :must_support_or_mandatory: false
+    :names_not_must_support_or_mandatory: []
+    :must_support_or_mandatory: true
   :search_definitions:
     :patient:
       :paths:

--- a/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
@@ -49,9 +49,8 @@
   - patient
   - code
   - date
-  :names_not_must_support_or_mandatory:
-  - date
-  :must_support_or_mandatory: false
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
 - :expectation: SHALL
   :names:
   - patient
@@ -63,9 +62,8 @@
   - patient
   - category
   - date
-  :names_not_must_support_or_mandatory:
-  - date
-  :must_support_or_mandatory: false
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
 :search_definitions:
   :patient:
     :paths:

--- a/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/smokingstatus_patient_category_date_search_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/smokingstatus_patient_category_date_search_test.rb
@@ -18,8 +18,6 @@ none are returned, the test is skipped.
       )
 
       id :us_core_v400_smokingstatus_patient_category_date_search_test
-      optional
-  
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -12328,17 +12328,15 @@
     - patient
     - category
     - date
-    :names_not_must_support_or_mandatory:
-    - date
-    :must_support_or_mandatory: false
+    :names_not_must_support_or_mandatory: []
+    :must_support_or_mandatory: true
   - :expectation: SHOULD
     :names:
     - patient
     - code
     - date
-    :names_not_must_support_or_mandatory:
-    - date
-    :must_support_or_mandatory: false
+    :names_not_must_support_or_mandatory: []
+    :must_support_or_mandatory: true
   - :expectation: SHALL
     :names:
     - patient

--- a/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
@@ -42,17 +42,15 @@
   - patient
   - category
   - date
-  :names_not_must_support_or_mandatory:
-  - date
-  :must_support_or_mandatory: false
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
 - :expectation: SHOULD
   :names:
   - patient
   - code
   - date
-  :names_not_must_support_or_mandatory:
-  - date
-  :must_support_or_mandatory: false
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
 - :expectation: SHALL
   :names:
   - patient

--- a/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/smokingstatus_patient_category_date_search_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/smokingstatus_patient_category_date_search_test.rb
@@ -18,8 +18,6 @@ none are returned, the test is skipped.
       )
 
       id :us_core_v501_smokingstatus_patient_category_date_search_test
-      optional
-  
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generator/group_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/group_metadata_extractor.rb
@@ -70,9 +70,13 @@ module USCoreTestKit
 
             any_must_support_slices = must_supports[:slices].any? do |slice|
               # only handle type slices because that is all we need for now
+              # for a slice like Observation.effective[x]:effectiveDateTime, the search parameter's expression could be
+              # either Observation.effective or Observation.effectiveDateTime.
               if slice[:discriminator] && slice[:discriminator][:type] == 'type'
                 full_must_support_path = "#{resource}.#{slice[:path].sub('[x]', slice[:discriminator][:code])}"
-                full_paths.include?(full_must_support_path)
+                base_must_support_path = "#{resource}.#{slice[:path].sub('[x]', '')}"
+
+                full_paths.intersection([full_must_support_path,base_must_support_path]).present?
               else
                 false
               end


### PR DESCRIPTION
# Summary
This PR address a slide line issue found while investigating in GitHub issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/262

Update the group_metadata_extractor so that the slice path `Observation.effective[x]:effectiveDateTime` can match to search parameters with expression `Observation.effective` or `Observation.effectiveDateTime`.

# Testing Guidance
in US Core v4.0.0 and v5.0.1, The Observation search by patient+category+code shows as a mandatory test.

