### PR TITLE
FI-1739 Update MustSupport test for Patient's previous name

### DIFF
--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -11880,19 +11880,11 @@
       :uscdi_only: true
     - :path: name.suffix
       :uscdi_only: true
-    - :path: name.use
-      :fixed_value: old
-      :uscdi_only: true
     - :path: name.period.end
       :uscdi_only: true
     - :path: telecom
       :uscdi_only: true
     - :path: communication
-      :uscdi_only: true
-    :choices:
-    - :paths:
-      - name.period.end
-      - name.use
       :uscdi_only: true
   :mandatory_elements:
   - Patient.identifier

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -185,19 +185,11 @@
     :uscdi_only: true
   - :path: name.suffix
     :uscdi_only: true
-  - :path: name.use
-    :fixed_value: old
-    :uscdi_only: true
   - :path: name.period.end
     :uscdi_only: true
   - :path: telecom
     :uscdi_only: true
   - :path: communication
-    :uscdi_only: true
-  :choices:
-  - :paths:
-    - name.period.end
-    - name.use
     :uscdi_only: true
 :mandatory_elements:
 - Patient.identifier

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
@@ -34,7 +34,7 @@ module USCoreTestKit
         * Patient.extension:birthsex
         * Patient.extension:ethnicity
         * Patient.extension:race
-        * Patient.name.period.end or Patient.name.use
+        * Patient.name.period.end
         * Patient.name.suffix
         * Patient.telecom
         * Patient.telecom.system

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -17444,9 +17444,6 @@
       :uscdi_only: true
     - :path: name.suffix
       :uscdi_only: true
-    - :path: name.use
-      :fixed_value: old
-      :uscdi_only: true
     - :path: name.period.end
       :uscdi_only: true
     - :path: telecom
@@ -17456,10 +17453,8 @@
     - :path: address.use
       :fixed_value: old
       :uscdi_only: true
-    :choices:
-    - :paths:
-      - name.period.end
-      - name.use
+    - :path: name.use
+      :fixed_value: old
       :uscdi_only: true
   :mandatory_elements:
   - Patient.identifier

--- a/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
@@ -188,9 +188,6 @@
     :uscdi_only: true
   - :path: name.suffix
     :uscdi_only: true
-  - :path: name.use
-    :fixed_value: old
-    :uscdi_only: true
   - :path: name.period.end
     :uscdi_only: true
   - :path: telecom
@@ -200,10 +197,8 @@
   - :path: address.use
     :fixed_value: old
     :uscdi_only: true
-  :choices:
-  - :paths:
-    - name.period.end
-    - name.use
+  - :path: name.use
+    :fixed_value: old
     :uscdi_only: true
 :mandatory_elements:
 - Patient.identifier

--- a/lib/us_core_test_kit/generated/v5.0.1/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/patient/patient_must_support_test.rb
@@ -36,8 +36,9 @@ module USCoreTestKit
         * Patient.extension:ethnicity
         * Patient.extension:genderIdentity
         * Patient.extension:race
-        * Patient.name.period.end or Patient.name.use
+        * Patient.name.period.end
         * Patient.name.suffix
+        * Patient.name.use
         * Patient.telecom
         * Patient.telecom.system
         * Patient.telecom.use

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -375,11 +375,6 @@ module USCoreTestKit
             choices << { paths: ['location.location', 'serviceProvider'] }
           when 'MedicationRequest'
             choices << { paths: ['reportedBoolean', 'reportedReference'] }
-          when 'Patient'
-            choices << {
-              paths: ['name.period.end', 'name.use'],
-              uscdi_only: true
-            }
           end
         when '5.0.1'
           case profile.type
@@ -400,13 +395,7 @@ module USCoreTestKit
             choices << { paths: ['location.location', 'serviceProvider'] }
           when 'MedicationRequest'
             choices << { paths: ['reportedBoolean', 'reportedReference'] }
-          when 'Patient'
-            choices << {
-              paths: ['name.period.end', 'name.use'],
-              uscdi_only: true
-            }
           end
-
         end
 
         @must_supports[:choices] = choices if choices.present?
@@ -446,11 +435,6 @@ module USCoreTestKit
           uscdi_only: true
         }
         @must_supports[:elements] << {
-          path: 'name.use',
-          fixed_value: 'old',
-          uscdi_only: true
-        }
-        @must_supports[:elements] << {
           path: 'name.period.end',
           uscdi_only: true
         }
@@ -480,6 +464,11 @@ module USCoreTestKit
           }
           @must_supports[:elements] << {
             path: 'address.use',
+            fixed_value: 'old',
+            uscdi_only: true
+          }
+          @must_supports[:elements] << {
+            path: 'name.use',
             fixed_value: 'old',
             uscdi_only: true
           }


### PR DESCRIPTION
# Summary
This PR addresses GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/283

The changes includes:

US Core v4.0.0: change Patient's Previous Name MS test from "name.period.end or name.use" to "name.period.end"
US Core v5.0.1: change Patient's Previous Name MS test from "name.period.end or name.use" to "name.period.end AND name.use"

# Testing Guidance
1. Run the US Core v4.0.0 Test Kit. 
2. Expand Test 2.11 "All must support elements are provided in the Patient resources returned". 
3. Verify the "About" tab have: "Patient.name.period.end"
4. Verify the "About" tab does NOT have "Patient.name.period.end or Patient.name.use"

1. Run the US Core v5.0.1 Test Kit. 
2. Expand Test 2.11 "All must support elements are provided in the Patient resources returned". 
3. Verify the "About" tab have both "Patient.name.period.end" and "Patient.name.use"
4. Verify the "About" tab does NOT have "Patient.name.period.end or Patient.name.use"
