### PR TITLE
FI-1764 Remove DocumentReference.custodian from MustSupport

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_must_support_test.rb
@@ -22,7 +22,6 @@ module USCoreTestKit
         * DocumentReference.context
         * DocumentReference.context.encounter
         * DocumentReference.context.period
-        * DocumentReference.custodian
         * DocumentReference.date
         * DocumentReference.identifier
         * DocumentReference.status

--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/document_reference_reference_resolution_test.rb
@@ -15,7 +15,6 @@ module USCoreTestKit
 
         * DocumentReference.author
         * DocumentReference.context.encounter
-        * DocumentReference.custodian
         * DocumentReference.subject
       )
 

--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/metadata.yml
@@ -233,9 +233,6 @@
   - :path: author
     :types:
     - Reference
-  - :path: custodian
-    :types:
-    - Reference
   - :path: content
   - :path: content.attachment
   - :path: content.attachment.contentType

--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -4645,9 +4645,6 @@
     - :path: author
       :types:
       - Reference
-    - :path: custodian
-      :types:
-      - Reference
     - :path: content
     - :path: content.attachment
     - :path: content.attachment.contentType

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -355,7 +355,7 @@ module USCoreTestKit
         end
       end
 
-      # US Core clarified that server implmentation is not required to support DocumentReference.custodian
+      # US Core clarified that server implmentation is not required to support DocumentReference.custodian (FHIR-28393)
       def remove_document_reference_custodian
         if profile.type == 'DocumentReference'
           @must_supports[:elements].delete_if do |element|

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -291,6 +291,8 @@ module USCoreTestKit
         add_must_support_choices
 
         case profile.version
+        when '3.1.1'
+          remove_document_reference_custodian
         when '4.0.0'
           add_device_distinct_identifier
           add_patient_uscdi_elements
@@ -349,6 +351,15 @@ module USCoreTestKit
         if profile.type == 'Device'
           @must_supports[:elements].delete_if do |element|
             ['udiCarrier.carrierAIDC', 'udiCarrier.carrierHRF'].include?(element[:path])
+          end
+        end
+      end
+
+      # US Core clarified that server implmentation is not required to support DocumentReference.custodian
+      def remove_document_reference_custodian
+        if profile.type == 'DocumentReference'
+          @must_supports[:elements].delete_if do |element|
+            element[:path] == 'custodian'
           end
         end
       end

--- a/spec/us_core/reference_test_spec.rb
+++ b/spec/us_core/reference_test_spec.rb
@@ -149,10 +149,6 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
             reference: "Practitioner/#{practitioner.id}"
           }
         ],
-        custodian:
-        {
-          reference: "Practitioner/#{practitioner.id}"
-        },
         context: {
           encounter: {
             reference: "Encounter/#{encounter.id}"
@@ -188,8 +184,8 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
     end
 
     it 'skips if one of MS references does not have reference value' do
-      document_reference.custodian = FHIR::Reference.new(
-        display: 'Example Custodian'
+      document_reference.subject = FHIR::Reference.new(
+        display: 'Example Patient'
       )
 
       allow_any_instance_of(test_class)


### PR DESCRIPTION
# Summary
This PR removes DocumentReference.custodian from MustSupport test. This is based on the US Core 3.1.1 patch using FHIR-28393. This patch is approved by CGP.

This PR also fixed a bug that generator failed due to `nil` value in the _targetProfile extensions.

# Testing Guidance
Verifies that DocumentReference.custodian does not shown in the DocumentReference's MustSupport test

