### PR TITLE
FI-1768 Unescape search value

### DIFF
--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -677,7 +677,9 @@ module USCoreTestKit
     #### RESULT CHECKING ####
 
     def check_resource_against_params(resource, params)
-      params.each do |name, search_value|
+      params.each do |name, escaped_search_value|
+        #unescape search value
+        search_value = escaped_search_value&.gsub('\\,', ',')
         paths = search_param_paths(name)
 
         match_found = false


### PR DESCRIPTION
# Summary
This PR fixes GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/314

Chang Log:
* Updates search_test to use unescaped search value when checking result against parameter
* Adds unit test

# Testing Guidance
All unit tests passed

