### PR TITLE
FI-1774: Support new validator

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -42,8 +42,8 @@ module USCoreTestKit
       VALIDATION_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
-        /Observation\.effective\.ofType\(Period\): vs-1:/, # Invalid invariant in FHIR v4.0.1
-        /Observation\.effective\.ofType\(Period\): us-core-1:/ # Invalid invariant in US Core v3.1.1
+        /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
+        /Observation\.effective\.ofType\(Period\): .*us-core-1:/ # Invalid invariant in US Core v3.1.1
       ].freeze
 
       def self.metadata

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -44,8 +44,8 @@ module USCoreTestKit
       VALIDATION_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
-        /Observation\.effective\.ofType\(Period\): vs-1:/, # Invalid invariant in FHIR v4.0.1
-        /Observation\.effective\.ofType\(Period\): us-core-1:/ # Invalid invariant in US Core v3.1.1
+        /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
+        /Observation\.effective\.ofType\(Period\): .*us-core-1:/ # Invalid invariant in US Core v3.1.1
       ].freeze
 
       def self.metadata

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -53,8 +53,8 @@ module USCoreTestKit
       VALIDATION_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
-        /Observation\.effective\.ofType\(Period\): vs-1:/, # Invalid invariant in FHIR v4.0.1
-        /Observation\.effective\.ofType\(Period\): us-core-1:/ # Invalid invariant in US Core v3.1.1
+        /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
+        /Observation\.effective\.ofType\(Period\): .*us-core-1:/ # Invalid invariant in US Core v3.1.1
       ].freeze
 
       def self.metadata

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -232,8 +232,10 @@ module USCoreTestKit
         target_profiles = []
 
         type.source_hash['_targetProfile']&.each do |hash|
-          element = FHIR::Element.new(hash)
-          target_profiles << type.targetProfile[index] if type_must_support_extension?(element.extension)
+          if hash.present?
+            element = FHIR::Element.new(hash)
+            target_profiles << type.targetProfile[index] if type_must_support_extension?(element.extension)
+          end
           index += 1
         end
 

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -14,8 +14,8 @@ module USCoreTestKit
       VALIDATION_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
-        /Observation\.effective\.ofType\(Period\): vs-1:/, # Invalid invariant in FHIR v4.0.1
-        /Observation\.effective\.ofType\(Period\): us-core-1:/ # Invalid invariant in US Core v3.1.1
+        /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
+        /Observation\.effective\.ofType\(Period\): .*us-core-1:/ # Invalid invariant in US Core v3.1.1
       ].freeze
 
       def self.metadata


### PR DESCRIPTION
# Summary
Updates the issue filters to support changed messages in the new validator.

# Testing Guidance
In `docker-compose.yaml`, you should get the same results if you replace the image for the `validator_service` with:
- `infernocommunity/fhir-validator-service:v2.1.0`
- `infernocommunity/fhir-validator-service:v2.2.0`