### PR TITLE
FI-1800 Remove values from optional patternCodeablConcept

### DIFF
--- a/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
@@ -158,7 +158,6 @@
     :values:
     - problem-list-item
     - health-concern
-    - sdoh
     :type: CodeableConcept
     :contains_multiple: true
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -1104,7 +1104,6 @@
       :values:
       - problem-list-item
       - health-concern
-      - sdoh
       :type: CodeableConcept
       :contains_multiple: true
       :multiple_or: MAY
@@ -4001,7 +4000,6 @@
       :comparators: {}
       :values:
       - survey
-      - sdoh
       :type: CodeableConcept
       :contains_multiple: true
       :multiple_or: MAY
@@ -4669,7 +4667,6 @@
       :comparators: {}
       :values:
       - social-history
-      - sdoh
       :type: CodeableConcept
       :contains_multiple: true
       :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
@@ -83,7 +83,6 @@
     :comparators: {}
     :values:
     - survey
-    - sdoh
     :type: CodeableConcept
     :contains_multiple: true
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
@@ -83,7 +83,6 @@
     :comparators: {}
     :values:
     - social-history
-    - sdoh
     :type: CodeableConcept
     :contains_multiple: true
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generator/value_extractor.rb
+++ b/lib/us_core_test_kit/generator/value_extractor.rb
@@ -54,7 +54,7 @@ module USCoreTestKit
 
         profile_elements
           .select do |element|
-            element.path == profile_element.path && element.patternCodeableConcept.present?
+            element.path == profile_element.path && element.patternCodeableConcept.present? && element.min > 0
           end
           .map { |element| element.patternCodeableConcept.coding.first.code }
       end


### PR DESCRIPTION
# Summary
This PR fixes GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/356

Some US Core v5.0.1 profiles have slicing using the same concept. For example: both Observation Social History and Observation SDOH Assessment have and optional slicing on ObservationCategory sdoh.

This causes a validation error because resources from difference profiles are mixed together.

This PR changes
* Remove optional patternCodeablConcept from search definition metadata

# Testing Guidance
US Core v5.0.1 test for Observation Social History and Observation SDOH Assessment shall not search with category value sdoh. The validation tests for Observation Social History and Observation SDOH Assessment shall pass

