### PR TITLE
FI-1792 Generator handle required binding slice

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/metadata.yml
@@ -86,10 +86,6 @@
 - AllergyIntolerance.patient
 - AllergyIntolerance.reaction.manifestation
 :bindings:
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
 - :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/allergyintolerance-clinical
@@ -110,26 +106,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality
   :path: criticality
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/substance-code
-  :path: reaction.substance
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: reaction.manifestation
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/reaction-event-severity
   :path: reaction.severity
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/route-codes
-  :path: reaction.exposureRoute
 :references:
 - :path: AllergyIntolerance.patient
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyheight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyheight/metadata.yml
@@ -193,25 +193,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -220,46 +204,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: Quantity
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
   :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/bodytemp/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodytemp/metadata.yml
@@ -193,25 +193,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -220,46 +204,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodytemp
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: Quantity
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
   :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyweight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyweight/metadata.yml
@@ -193,25 +193,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -220,46 +204,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodyweight
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: Quantity
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
   :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/bp/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bp/metadata.yml
@@ -213,93 +213,17 @@
 - Observation.component.value[x].code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/care_plan/metadata.yml
@@ -153,10 +153,6 @@
 - CarePlan.activity.detail.status
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status
   :path: text.status
@@ -168,38 +164,14 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-plan-intent
   :path: intent
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-plan-category
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-plan-category
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-plan-activity-outcome
-  :path: activity.outcomeCodeableConcept
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-plan-activity-kind
   :path: activity.detail.kind
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-code
-  :path: activity.detail.code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: activity.detail.reasonCode
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-plan-activity-status
   :path: activity.detail.status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medication-codes
-  :path: activity.detail.product
 :references:
 - :path: CarePlan.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/care_team/metadata.yml
@@ -87,25 +87,9 @@
 - CareTeam.participant.member
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-team-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-team-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-careteam-provider-roles
-  :path: participant.role
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: reasonCode
 :references:
 - :path: CareTeam.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/condition/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/condition/metadata.yml
@@ -145,10 +145,6 @@
 - Condition.code
 - Condition.subject
 :bindings:
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
 - :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/condition-clinical
@@ -157,34 +153,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/condition-ver-status
   :path: verificationStatus
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/condition-severity
-  :path: severity
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-stage
-  :path: stage.summary
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-stage-type
-  :path: stage.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/manifestation-or-symptom
-  :path: evidence.code
 :references:
 - :path: Condition.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/device/metadata.yml
@@ -99,10 +99,6 @@
 - Device.patient
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/udi-entry-type
   :path: udiCarrier.entryType
@@ -110,18 +106,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/device-status
   :path: status
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/device-status-reason
-  :path: statusReason
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/device-nametype
   :path: deviceName.type
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/device-kind
-  :path: type
 :references:
 - :path: Device.definition
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/metadata.yml
@@ -178,29 +178,9 @@
 - DiagnosticReport.media.link
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: conclusionCode
 :references:
 - :path: DiagnosticReport.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_note/metadata.yml
@@ -173,25 +173,9 @@
 - DiagnosticReport.media.link
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
   :path: status
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: conclusionCode
 :references:
 - :path: DiagnosticReport.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/metadata.yml
@@ -215,10 +215,6 @@
 - DocumentReference.content.attachment.contentType
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/document-reference-status
   :path: status
@@ -230,42 +226,14 @@
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
   :path: type
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category
-  :path: category
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/document-relationship-type
   :path: relatesTo.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/security-labels
-  :path: securityLabel
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/mimetypes
   :path: content.attachment.contentType
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: content.attachment.language
-- :type: Coding
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/formatcodes
-  :path: content.format
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ActCode
-  :path: context.event
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/c80-facilitycodes
-  :path: context.facilityType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/c80-practice-codes
-  :path: context.practiceSetting
 :references:
 - :path: DocumentReference.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/encounter/metadata.yml
@@ -205,17 +205,9 @@
 - Encounter.location.location
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/encounter-status
@@ -224,70 +216,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/encounter-status
   :path: statusHistory.status
-- :type: Coding
-  :strength: extensible
-  :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-  :path: class
-- :type: Coding
-  :strength: extensible
-  :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-  :path: classHistory.class
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type
-  :path: type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/service-type
-  :path: serviceType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ActPriority
-  :path: priority
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/encounter-participant-type
-  :path: participant.type
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/diagnosis-role
-  :path: diagnosis.use
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-admit-source
-  :path: hospitalization.admitSource
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v2-0092
-  :path: hospitalization.reAdmission
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/encounter-diet
-  :path: hospitalization.dietPreference
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
-  :path: hospitalization.specialCourtesy
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
-  :path: hospitalization.specialArrangement
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/encounter-discharge-disposition
-  :path: hospitalization.dischargeDisposition
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/encounter-location-status
   :path: location.status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/location-physical-type
-  :path: location.physicalType
 :references:
 - :path: Encounter.identifier.assigner
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
@@ -113,45 +113,9 @@
 - Goal.subject
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/goal-status
   :path: lifecycleStatus
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/goal-achievement
-  :path: achievementStatus
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/goal-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/goal-priority
-  :path: priority
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: description
-- :type: date
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/goal-start-event
-  :path: start
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: target.measure
-- :type: Quantity
-  :strength: example
-  :system:
-  :path: target.detail
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: outcomeCode
 :references:
 - :path: Goal.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/metadata.yml
@@ -192,69 +192,17 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: Quantity
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
   :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/heartrate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/heartrate/metadata.yml
@@ -194,69 +194,17 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: Quantity
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
   :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/immunization/metadata.yml
@@ -117,57 +117,9 @@
 - Immunization.protocolApplied.doseNumber[x]
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/immunization-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-status-reason
-  :path: statusReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx
-  :path: vaccineCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-origin
-  :path: reportOrigin
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-site
-  :path: site
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-route
-  :path: route
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/immunization-function
-  :path: performer.function
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
-  :path: subpotentReason
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-program-eligibility
-  :path: programEligibility
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-funding-source
-  :path: fundingSource
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-target-disease
-  :path: protocolApplied.targetDisease
 :references:
 - :path: Immunization.patient
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/medication_request/metadata.yml
@@ -173,77 +173,17 @@
 - MedicationRequest.substitution.allowed[x]
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/medicationrequest-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-status-reason
-  :path: statusReason
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/medicationrequest-intent
   :path: intent
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
-  :path: category
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/request-priority
   :path: priority
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes
-  :path: medication
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/performer-role
-  :path: performerType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-code
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy
-  :path: courseOfTherapyType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/additional-instruction-codes
-  :path: dosageInstruction.additionalInstruction
-- :type: boolean
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medication-as-needed-reason
-  :path: dosageInstruction.asNeeded
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/approach-site-codes
-  :path: dosageInstruction.site
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/route-codes
-  :path: dosageInstruction.route
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/administration-method-codes
-  :path: dosageInstruction.method
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/dose-rate-type
-  :path: dosageInstruction.doseAndRate.type
-- :type: boolean
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode
-  :path: substitution.allowed
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason
-  :path: substitution.reason
 :references:
 - :path: MedicationRequest.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -88,10 +88,6 @@
   - AllergyIntolerance.patient
   - AllergyIntolerance.reaction.manifestation
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
   - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/allergyintolerance-clinical
@@ -112,26 +108,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality
     :path: criticality
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/substance-code
-    :path: reaction.substance
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: reaction.manifestation
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/reaction-event-severity
     :path: reaction.severity
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/route-codes
-    :path: reaction.exposureRoute
   :references:
   - :path: AllergyIntolerance.patient
     :profiles:
@@ -306,10 +286,6 @@
   - CarePlan.activity.detail.status
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status
     :path: text.status
@@ -321,38 +297,14 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-plan-intent
     :path: intent
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-plan-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-plan-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-plan-activity-outcome
-    :path: activity.outcomeCodeableConcept
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-plan-activity-kind
     :path: activity.detail.kind
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-code
-    :path: activity.detail.code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: activity.detail.reasonCode
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-plan-activity-status
     :path: activity.detail.status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-codes
-    :path: activity.detail.product
   :references:
   - :path: CarePlan.basedOn
     :profiles:
@@ -524,25 +476,9 @@
   - CareTeam.participant.member
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-team-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-team-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-careteam-provider-roles
-    :path: participant.role
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: reasonCode
   :references:
   - :path: CareTeam.subject
     :profiles:
@@ -715,10 +651,6 @@
   - Condition.code
   - Condition.subject
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
   - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/condition-clinical
@@ -727,34 +659,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/condition-ver-status
     :path: verificationStatus
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/condition-severity
-    :path: severity
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-stage
-    :path: stage.summary
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-stage-type
-    :path: stage.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/manifestation-or-symptom
-    :path: evidence.code
   :references:
   - :path: Condition.subject
     :profiles:
@@ -883,10 +787,6 @@
   - Device.patient
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/udi-entry-type
     :path: udiCarrier.entryType
@@ -894,18 +794,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/device-status
     :path: status
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/device-status-reason
-    :path: statusReason
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/device-nametype
     :path: deviceName.type
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/device-kind
-    :path: type
   :references:
   - :path: Device.definition
     :profiles:
@@ -1097,25 +989,9 @@
   - DiagnosticReport.media.link
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
     :path: status
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: conclusionCode
   :references:
   - :path: DiagnosticReport.basedOn
     :profiles:
@@ -1338,29 +1214,9 @@
   - DiagnosticReport.media.link
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: conclusionCode
   :references:
   - :path: DiagnosticReport.basedOn
     :profiles:
@@ -1618,10 +1474,6 @@
   - DocumentReference.content.attachment.contentType
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/document-reference-status
     :path: status
@@ -1633,42 +1485,14 @@
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
     :path: type
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category
-    :path: category
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/document-relationship-type
     :path: relatesTo.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/security-labels
-    :path: securityLabel
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/mimetypes
     :path: content.attachment.contentType
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: content.attachment.language
-  - :type: Coding
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/formatcodes
-    :path: content.format
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ActCode
-    :path: context.event
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/c80-facilitycodes
-    :path: context.facilityType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/c80-practice-codes
-    :path: context.practiceSetting
   :references:
   - :path: DocumentReference.subject
     :profiles:
@@ -1915,17 +1739,9 @@
   - Encounter.location.location
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/encounter-status
@@ -1934,70 +1750,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/encounter-status
     :path: statusHistory.status
-  - :type: Coding
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-    :path: class
-  - :type: Coding
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-    :path: classHistory.class
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type
-    :path: type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/service-type
-    :path: serviceType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ActPriority
-    :path: priority
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/encounter-participant-type
-    :path: participant.type
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/diagnosis-role
-    :path: diagnosis.use
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-admit-source
-    :path: hospitalization.admitSource
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v2-0092
-    :path: hospitalization.reAdmission
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/encounter-diet
-    :path: hospitalization.dietPreference
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
-    :path: hospitalization.specialCourtesy
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
-    :path: hospitalization.specialArrangement
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/encounter-discharge-disposition
-    :path: hospitalization.dischargeDisposition
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/encounter-location-status
     :path: location.status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/location-physical-type
-    :path: location.physicalType
   :references:
   - :path: Encounter.identifier.assigner
     :profiles:
@@ -2165,45 +1921,9 @@
   - Goal.subject
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/goal-status
     :path: lifecycleStatus
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/goal-achievement
-    :path: achievementStatus
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/goal-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/goal-priority
-    :path: priority
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: description
-  - :type: date
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/goal-start-event
-    :path: start
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: target.measure
-  - :type: Quantity
-    :strength: example
-    :system:
-    :path: target.detail
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: outcomeCode
   :references:
   - :path: Goal.subject
     :profiles:
@@ -2344,57 +2064,9 @@
   - Immunization.protocolApplied.doseNumber[x]
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/immunization-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-status-reason
-    :path: statusReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx
-    :path: vaccineCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-origin
-    :path: reportOrigin
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-site
-    :path: site
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-route
-    :path: route
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/immunization-function
-    :path: performer.function
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
-    :path: subpotentReason
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-program-eligibility
-    :path: programEligibility
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-funding-source
-    :path: fundingSource
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-target-disease
-    :path: protocolApplied.targetDisease
   :references:
   - :path: Immunization.patient
     :profiles:
@@ -2616,25 +2288,13 @@
   - Location.position.latitude
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/location-status
     :path: status
-  - :type: Coding
-    :strength: preferred
-    :system: http://terminology.hl7.org/ValueSet/v2-0116
-    :path: operationalStatus
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/location-mode
     :path: mode
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
-    :path: type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-use
@@ -2643,14 +2303,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/location-physical-type
-    :path: physicalType
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/days-of-week
@@ -2715,21 +2367,9 @@
   - Medication.ingredient.item[x]
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes
-    :path: code
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medication-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-form-codes
-    :path: form
   :references:
   - :path: Medication.manufacturer
     :profiles:
@@ -2909,77 +2549,17 @@
   - MedicationRequest.substitution.allowed[x]
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medicationrequest-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-status-reason
-    :path: statusReason
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medicationrequest-intent
     :path: intent
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
-    :path: category
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/request-priority
     :path: priority
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes
-    :path: medication
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/performer-role
-    :path: performerType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-code
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy
-    :path: courseOfTherapyType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/additional-instruction-codes
-    :path: dosageInstruction.additionalInstruction
-  - :type: boolean
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-as-needed-reason
-    :path: dosageInstruction.asNeeded
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/approach-site-codes
-    :path: dosageInstruction.site
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/route-codes
-    :path: dosageInstruction.route
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/administration-method-codes
-    :path: dosageInstruction.method
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/dose-rate-type
-    :path: dosageInstruction.doseAndRate.type
-  - :type: boolean
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode
-    :path: substitution.allowed
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason
-    :path: substitution.reason
   :references:
   - :path: MedicationRequest.subject
     :profiles:
@@ -3200,61 +2780,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus
-    :path: value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -3502,69 +3030,17 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: Quantity
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
     :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -3784,61 +3260,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -4086,69 +3510,17 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: Quantity
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
     :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -4446,97 +3818,21 @@
   - Observation.component.value[x].code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -4785,69 +4081,17 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: Quantity
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
     :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -5096,25 +4340,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -5123,46 +4351,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: Quantity
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
     :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -5411,25 +4603,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -5438,46 +4614,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodytemp
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: Quantity
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
     :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -5746,93 +4886,17 @@
   - Observation.component.value[x].code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6081,25 +5145,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -6108,46 +5156,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodyweight
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: Quantity
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
     :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6397,69 +5409,17 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: Quantity
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
     :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6709,69 +5669,17 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-    :path: component.code
   - :type: Quantity
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
     :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6920,21 +5828,9 @@
   - Organization.name
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/organization-type
-    :path: type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-use
@@ -6943,14 +5839,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/contactentity-type
-    :path: contact.purpose
   :references:
   - :path: Organization.identifier.assigner
     :profiles:
@@ -7150,17 +6038,9 @@
   - Patient.link.type
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/name-use
@@ -7185,26 +6065,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/marital-status
-    :path: maritalStatus
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/patient-contactrelationship
-    :path: contact.relationship
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/administrative-gender
     :path: contact.gender
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/simple-language
-    :path: communication.language
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/link-type
@@ -7353,17 +6217,9 @@
   - Practitioner.qualification.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/name-use
@@ -7372,14 +6228,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/administrative-gender
     :path: gender
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v2-2.7-0360
-    :path: qualification.code
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: communication
   :references:
   - :path: Practitioner.identifier.assigner
     :profiles:
@@ -7489,18 +6337,6 @@
   - PractitionerRole.telecom.value
   - PractitionerRole.notAvailable.description
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provider-specialty
-    :path: specialty
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/contact-point-system
@@ -7673,57 +6509,9 @@
   - Procedure.focalDevice.manipulated
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/event-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
-    :path: statusReason
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/performer-role
-    :path: performer.function
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-outcome
-    :path: outcome
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-code
-    :path: complication
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-followup
-    :path: followUp
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/device-action
-    :path: focalDevice.action
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/device-kind
-    :path: usedCode
   :references:
   - :path: Procedure.basedOn
     :profiles:
@@ -7869,42 +6657,6 @@
   - Provenance.entity.role
   - Provenance.entity.what
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-PurposeOfUse
-    :path: reason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/provenance-activity-type
-    :path: activity
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type
-    :path: agent.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/security-role-type
-    :path: agent.role
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-    :path: agent.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/security-role-type
-    :path: agent.role
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-    :path: agent.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/security-role-type
-    :path: agent.role
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/provenance-entity-role

--- a/lib/us_core_test_kit/generated/v3.1.1/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/observation_lab/metadata.yml
@@ -164,61 +164,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/organization/metadata.yml
@@ -92,21 +92,9 @@
 - Organization.name
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/organization-type
-  :path: type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/address-use
@@ -115,14 +103,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/address-type
   :path: address.type
-- :type: string
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-  :path: address.state
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/contactentity-type
-  :path: contact.purpose
 :references:
 - :path: Organization.identifier.assigner
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/patient/metadata.yml
@@ -187,17 +187,9 @@
 - Patient.link.type
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/name-use
@@ -222,26 +214,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/address-type
   :path: address.type
-- :type: string
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-  :path: address.state
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/marital-status
-  :path: maritalStatus
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/patient-contactrelationship
-  :path: contact.relationship
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/administrative-gender
   :path: contact.gender
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/simple-language
-  :path: communication.language
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/link-type

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/metadata.yml
@@ -192,69 +192,17 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: Quantity
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
   :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/metadata.yml
@@ -192,69 +192,17 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: Quantity
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
   :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/practitioner/metadata.yml
@@ -89,17 +89,9 @@
 - Practitioner.qualification.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/name-use
@@ -108,14 +100,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/administrative-gender
   :path: gender
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v2-2.7-0360
-  :path: qualification.code
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: communication
 :references:
 - :path: Practitioner.identifier.assigner
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/procedure/metadata.yml
@@ -136,57 +136,9 @@
 - Procedure.focalDevice.manipulated
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/event-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
-  :path: statusReason
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/performer-role
-  :path: performer.function
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-outcome
-  :path: outcome
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-code
-  :path: complication
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-followup
-  :path: followUp
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/device-action
-  :path: focalDevice.action
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/device-kind
-  :path: usedCode
 :references:
 - :path: Procedure.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/provenance/metadata.yml
@@ -79,42 +79,6 @@
 - Provenance.entity.what
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://terminology.hl7.org/ValueSet/v3-PurposeOfUse
-  :path: reason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/provenance-activity-type
-  :path: activity
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type
-  :path: agent.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/security-role-type
-  :path: agent.role
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-  :path: agent.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/security-role-type
-  :path: agent.role
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-  :path: agent.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/security-role-type
-  :path: agent.role
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/provenance-entity-role
   :path: entity.role

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
@@ -242,97 +242,21 @@
 - Observation.component.value[x].code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/resprate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/resprate/metadata.yml
@@ -194,69 +194,17 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-vitalsignresult
-  :path: component.code
 - :type: Quantity
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
   :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/metadata.yml
@@ -160,61 +160,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus
-  :path: value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/metadata.yml
@@ -86,10 +86,6 @@
 - AllergyIntolerance.patient
 - AllergyIntolerance.reaction.manifestation
 :bindings:
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
 - :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/allergyintolerance-clinical
@@ -110,26 +106,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality
   :path: criticality
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/substance-code
-  :path: reaction.substance
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: reaction.manifestation
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/reaction-event-severity
   :path: reaction.severity
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/route-codes
-  :path: reaction.exposureRoute
 :references:
 - :path: AllergyIntolerance.patient
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
@@ -214,97 +214,17 @@
 - Observation.component.value[x].code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/bmi/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_height/metadata.yml
@@ -192,25 +192,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -219,46 +203,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_temperature/metadata.yml
@@ -192,25 +192,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -219,46 +203,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodytemp
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_weight/metadata.yml
@@ -192,25 +192,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -219,46 +203,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodyweight
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_plan/metadata.yml
@@ -154,10 +154,6 @@
 - CarePlan.activity.detail.status
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/narrative-status
   :path: text.status
@@ -169,38 +165,14 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-plan-intent
   :path: intent
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-plan-category
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-plan-category
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-plan-activity-outcome
-  :path: activity.outcomeCodeableConcept
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-plan-activity-kind
   :path: activity.detail.kind
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-code
-  :path: activity.detail.code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: activity.detail.reasonCode
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-plan-activity-status
   :path: activity.detail.status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medication-codes
-  :path: activity.detail.product
 :references:
 - :path: CarePlan.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_team/metadata.yml
@@ -89,25 +89,9 @@
 - CareTeam.participant.member
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-team-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-team-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30
-  :path: participant.role
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: reasonCode
 :references:
 - :path: CareTeam.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/condition/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/condition/metadata.yml
@@ -148,10 +148,6 @@
 - Condition.code
 - Condition.subject
 :bindings:
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
 - :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/condition-clinical
@@ -160,34 +156,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/condition-ver-status
   :path: verificationStatus
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/condition-severity
-  :path: severity
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-stage
-  :path: stage.summary
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-stage-type
-  :path: stage.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/manifestation-or-symptom
-  :path: evidence.code
 :references:
 - :path: Condition.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/device/metadata.yml
@@ -94,10 +94,6 @@
 - Device.patient
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/udi-entry-type
   :path: udiCarrier.entryType
@@ -105,18 +101,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/device-status
   :path: status
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/device-status-reason
-  :path: statusReason
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/device-nametype
   :path: deviceName.type
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/device-kind
-  :path: type
 :references:
 - :path: Device.definition
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/metadata.yml
@@ -181,29 +181,9 @@
 - DiagnosticReport.media.link
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: conclusionCode
 :references:
 - :path: DiagnosticReport.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/metadata.yml
@@ -177,25 +177,9 @@
 - DiagnosticReport.media.link
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
   :path: status
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: conclusionCode
 :references:
 - :path: DiagnosticReport.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
@@ -217,10 +217,6 @@
 - DocumentReference.content.attachment.contentType
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/document-reference-status
   :path: status
@@ -232,42 +228,14 @@
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
   :path: type
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category
-  :path: category
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/document-relationship-type
   :path: relatesTo.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/security-labels
-  :path: securityLabel
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/mimetypes
   :path: content.attachment.contentType
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: content.attachment.language
-- :type: Coding
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/formatcodes
-  :path: content.format
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ActCode
-  :path: context.event
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/c80-facilitycodes
-  :path: context.facilityType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/c80-practice-codes
-  :path: context.practiceSetting
 :references:
 - :path: DocumentReference.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
@@ -222,17 +222,9 @@
 - Encounter.location.location
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/encounter-status
@@ -241,70 +233,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/encounter-status
   :path: statusHistory.status
-- :type: Coding
-  :strength: extensible
-  :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-  :path: class
-- :type: Coding
-  :strength: extensible
-  :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-  :path: classHistory.class
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type
-  :path: type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/service-type
-  :path: serviceType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ActPriority
-  :path: priority
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/encounter-participant-type
-  :path: participant.type
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/diagnosis-role
-  :path: diagnosis.use
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-admit-source
-  :path: hospitalization.admitSource
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v2-0092
-  :path: hospitalization.reAdmission
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/encounter-diet
-  :path: hospitalization.dietPreference
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
-  :path: hospitalization.specialCourtesy
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
-  :path: hospitalization.specialArrangement
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/encounter-discharge-disposition
-  :path: hospitalization.dischargeDisposition
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/encounter-location-status
   :path: location.status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/location-physical-type
-  :path: location.physicalType
 :references:
 - :path: Encounter.identifier.assigner
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
@@ -110,45 +110,9 @@
 - Goal.subject
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/goal-status
   :path: lifecycleStatus
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/goal-achievement
-  :path: achievementStatus
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/goal-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/goal-priority
-  :path: priority
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: description
-- :type: date
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/goal-start-event
-  :path: start
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: target.measure
-- :type: Quantity
-  :strength: example
-  :system:
-  :path: target.detail
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: outcomeCode
 :references:
 - :path: Goal.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference/metadata.yml
@@ -192,25 +192,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -219,46 +203,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/heart_rate/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/immunization/metadata.yml
@@ -118,57 +118,9 @@
 - Immunization.protocolApplied.doseNumber[x]
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/immunization-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-status-reason
-  :path: statusReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6
-  :path: vaccineCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-origin
-  :path: reportOrigin
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-site
-  :path: site
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-route
-  :path: route
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/immunization-function
-  :path: performer.function
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
-  :path: subpotentReason
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-program-eligibility
-  :path: programEligibility
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-funding-source
-  :path: fundingSource
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-target-disease
-  :path: protocolApplied.targetDisease
 :references:
 - :path: Immunization.patient
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
@@ -184,77 +184,17 @@
 - MedicationRequest.substitution.allowed[x]
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/medicationrequest-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-status-reason
-  :path: statusReason
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/medicationrequest-intent
   :path: intent
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
-  :path: category
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/request-priority
   :path: priority
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4
-  :path: medication
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/performer-role
-  :path: performerType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-code
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy
-  :path: courseOfTherapyType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/additional-instruction-codes
-  :path: dosageInstruction.additionalInstruction
-- :type: boolean
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medication-as-needed-reason
-  :path: dosageInstruction.asNeeded
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/approach-site-codes
-  :path: dosageInstruction.site
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/route-codes
-  :path: dosageInstruction.route
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/administration-method-codes
-  :path: dosageInstruction.method
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/dose-rate-type
-  :path: dosageInstruction.doseAndRate.type
-- :type: boolean
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode
-  :path: substitution.allowed
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason
-  :path: substitution.reason
 :references:
 - :path: MedicationRequest.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -88,10 +88,6 @@
   - AllergyIntolerance.patient
   - AllergyIntolerance.reaction.manifestation
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
   - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/allergyintolerance-clinical
@@ -112,26 +108,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality
     :path: criticality
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/substance-code
-    :path: reaction.substance
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: reaction.manifestation
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/reaction-event-severity
     :path: reaction.severity
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/route-codes
-    :path: reaction.exposureRoute
   :references:
   - :path: AllergyIntolerance.patient
     :profiles:
@@ -307,10 +287,6 @@
   - CarePlan.activity.detail.status
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/narrative-status
     :path: text.status
@@ -322,38 +298,14 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-plan-intent
     :path: intent
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-plan-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-plan-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-plan-activity-outcome
-    :path: activity.outcomeCodeableConcept
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-plan-activity-kind
     :path: activity.detail.kind
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-code
-    :path: activity.detail.code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: activity.detail.reasonCode
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-plan-activity-status
     :path: activity.detail.status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-codes
-    :path: activity.detail.product
   :references:
   - :path: CarePlan.basedOn
     :profiles:
@@ -527,25 +479,9 @@
   - CareTeam.participant.member
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-team-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-team-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30
-    :path: participant.role
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: reasonCode
   :references:
   - :path: CareTeam.subject
     :profiles:
@@ -725,10 +661,6 @@
   - Condition.code
   - Condition.subject
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
   - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/condition-clinical
@@ -737,34 +669,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/condition-ver-status
     :path: verificationStatus
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/condition-severity
-    :path: severity
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-stage
-    :path: stage.summary
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-stage-type
-    :path: stage.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/manifestation-or-symptom
-    :path: evidence.code
   :references:
   - :path: Condition.subject
     :profiles:
@@ -888,10 +792,6 @@
   - Device.patient
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/udi-entry-type
     :path: udiCarrier.entryType
@@ -899,18 +799,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/device-status
     :path: status
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/device-status-reason
-    :path: statusReason
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/device-nametype
     :path: deviceName.type
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/device-kind
-    :path: type
   :references:
   - :path: Device.definition
     :profiles:
@@ -1110,29 +1002,9 @@
   - DiagnosticReport.media.link
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: conclusionCode
   :references:
   - :path: DiagnosticReport.basedOn
     :profiles:
@@ -1354,25 +1226,9 @@
   - DiagnosticReport.media.link
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
     :path: status
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: conclusionCode
   :references:
   - :path: DiagnosticReport.basedOn
     :profiles:
@@ -1638,10 +1494,6 @@
   - DocumentReference.content.attachment.contentType
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/document-reference-status
     :path: status
@@ -1653,42 +1505,14 @@
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
     :path: type
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category
-    :path: category
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/document-relationship-type
     :path: relatesTo.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/security-labels
-    :path: securityLabel
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/mimetypes
     :path: content.attachment.contentType
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: content.attachment.language
-  - :type: Coding
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/formatcodes
-    :path: content.format
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ActCode
-    :path: context.event
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/c80-facilitycodes
-    :path: context.facilityType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/c80-practice-codes
-    :path: context.practiceSetting
   :references:
   - :path: DocumentReference.subject
     :profiles:
@@ -1953,17 +1777,9 @@
   - Encounter.location.location
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/encounter-status
@@ -1972,70 +1788,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/encounter-status
     :path: statusHistory.status
-  - :type: Coding
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-    :path: class
-  - :type: Coding
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-    :path: classHistory.class
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type
-    :path: type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/service-type
-    :path: serviceType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ActPriority
-    :path: priority
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/encounter-participant-type
-    :path: participant.type
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/diagnosis-role
-    :path: diagnosis.use
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-admit-source
-    :path: hospitalization.admitSource
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v2-0092
-    :path: hospitalization.reAdmission
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/encounter-diet
-    :path: hospitalization.dietPreference
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
-    :path: hospitalization.specialCourtesy
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
-    :path: hospitalization.specialArrangement
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/encounter-discharge-disposition
-    :path: hospitalization.dischargeDisposition
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/encounter-location-status
     :path: location.status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/location-physical-type
-    :path: location.physicalType
   :references:
   - :path: Encounter.identifier.assigner
     :profiles:
@@ -2206,45 +1962,9 @@
   - Goal.subject
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/goal-status
     :path: lifecycleStatus
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/goal-achievement
-    :path: achievementStatus
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/goal-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/goal-priority
-    :path: priority
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: description
-  - :type: date
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/goal-start-event
-    :path: start
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: target.measure
-  - :type: Quantity
-    :strength: example
-    :system:
-    :path: target.detail
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: outcomeCode
   :references:
   - :path: Goal.subject
     :profiles:
@@ -2386,57 +2106,9 @@
   - Immunization.protocolApplied.doseNumber[x]
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/immunization-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-status-reason
-    :path: statusReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6
-    :path: vaccineCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-origin
-    :path: reportOrigin
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-site
-    :path: site
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-route
-    :path: route
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/immunization-function
-    :path: performer.function
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
-    :path: subpotentReason
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-program-eligibility
-    :path: programEligibility
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-funding-source
-    :path: fundingSource
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-target-disease
-    :path: protocolApplied.targetDisease
   :references:
   - :path: Immunization.patient
     :profiles:
@@ -2601,25 +2273,13 @@
   - Location.position.latitude
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/location-status
     :path: status
-  - :type: Coding
-    :strength: preferred
-    :system: http://terminology.hl7.org/ValueSet/v2-0116
-    :path: operationalStatus
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/location-mode
     :path: mode
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
-    :path: type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-use
@@ -2628,14 +2288,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/location-physical-type
-    :path: physicalType
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/days-of-week
@@ -2700,21 +2352,9 @@
   - Medication.ingredient.item[x]
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4
-    :path: code
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medication-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-form-codes
-    :path: form
   :references:
   - :path: Medication.manufacturer
     :profiles:
@@ -2905,77 +2545,17 @@
   - MedicationRequest.substitution.allowed[x]
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medicationrequest-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-status-reason
-    :path: statusReason
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medicationrequest-intent
     :path: intent
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
-    :path: category
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/request-priority
     :path: priority
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4
-    :path: medication
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/performer-role
-    :path: performerType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-code
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy
-    :path: courseOfTherapyType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/additional-instruction-codes
-    :path: dosageInstruction.additionalInstruction
-  - :type: boolean
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-as-needed-reason
-    :path: dosageInstruction.asNeeded
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/approach-site-codes
-    :path: dosageInstruction.site
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/route-codes
-    :path: dosageInstruction.route
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/administration-method-codes
-    :path: dosageInstruction.method
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/dose-rate-type
-    :path: dosageInstruction.doseAndRate.type
-  - :type: boolean
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode
-    :path: substitution.allowed
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason
-    :path: substitution.reason
   :references:
   - :path: MedicationRequest.subject
     :profiles:
@@ -3213,61 +2793,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -3537,97 +3065,17 @@
   - Observation.component.value[x].code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -3876,69 +3324,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -4186,25 +3578,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -4213,46 +3589,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -4500,25 +3836,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -4527,46 +3847,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -4814,25 +4094,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -4841,46 +4105,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodyweight
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -5128,25 +4352,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -5155,46 +4363,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodytemp
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -5443,69 +4611,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -5754,69 +4866,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6066,69 +5122,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6377,69 +5377,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6729,97 +5673,17 @@
   - Observation.component.value[x].code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -7068,69 +5932,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -7355,65 +6163,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38
-    :path: value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -7566,21 +6318,9 @@
   - Organization.name
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/organization-type
-    :path: type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/contact-point-system
@@ -7597,14 +6337,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/contactentity-type
-    :path: contact.purpose
   :references:
   - :path: Organization.identifier.assigner
     :profiles:
@@ -7817,17 +6549,9 @@
   - Patient.link.type
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/name-use
@@ -7852,26 +6576,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/marital-status
-    :path: maritalStatus
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/patient-contactrelationship
-    :path: contact.relationship
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/administrative-gender
     :path: contact.gender
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/simple-language
-    :path: communication.language
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/link-type
@@ -8020,17 +6728,9 @@
   - Practitioner.qualification.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/name-use
@@ -8039,14 +6739,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/administrative-gender
     :path: gender
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v2-2.7-0360
-    :path: qualification.code
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: communication
   :references:
   - :path: Practitioner.identifier.assigner
     :profiles:
@@ -8154,18 +6846,6 @@
   - PractitionerRole.telecom.value
   - PractitionerRole.notAvailable.description
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.1066
-    :path: specialty
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/contact-point-system
@@ -8339,57 +7019,9 @@
   - Procedure.focalDevice.manipulated
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/event-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
-    :path: statusReason
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/performer-role
-    :path: performer.function
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-outcome
-    :path: outcome
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-code
-    :path: complication
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-followup
-    :path: followUp
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/device-action
-    :path: focalDevice.action
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/device-kind
-    :path: usedCode
   :references:
   - :path: Procedure.basedOn
     :profiles:
@@ -8539,46 +7171,6 @@
   - Provenance.entity.role
   - Provenance.entity.what
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: uri
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/resource-types
-    :path: target.type
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-PurposeOfUse
-    :path: reason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/provenance-activity-type
-    :path: activity
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type
-    :path: agent.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/security-role-type
-    :path: agent.role
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-    :path: agent.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/security-role-type
-    :path: agent.role
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-    :path: agent.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/security-role-type
-    :path: agent.role
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/provenance-entity-role

--- a/lib/us_core_test_kit/generated/v4.0.0/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/observation_lab/metadata.yml
@@ -170,61 +170,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/organization/metadata.yml
@@ -96,21 +96,9 @@
 - Organization.name
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/organization-type
-  :path: type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/contact-point-system
@@ -127,14 +115,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/address-type
   :path: address.type
-- :type: string
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-  :path: address.state
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/contactentity-type
-  :path: contact.purpose
 :references:
 - :path: Organization.identifier.assigner
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -200,17 +200,9 @@
 - Patient.link.type
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/name-use
@@ -235,26 +227,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/address-type
   :path: address.type
-- :type: string
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-  :path: address.state
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/marital-status
-  :path: maritalStatus
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/patient-contactrelationship
-  :path: contact.relationship
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/administrative-gender
   :path: contact.gender
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/simple-language
-  :path: communication.language
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/link-type

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/practitioner/metadata.yml
@@ -89,17 +89,9 @@
 - Practitioner.qualification.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/name-use
@@ -108,14 +100,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/administrative-gender
   :path: gender
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v2-2.7-0360
-  :path: qualification.code
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: communication
 :references:
 - :path: Practitioner.identifier.assigner
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/procedure/metadata.yml
@@ -137,57 +137,9 @@
 - Procedure.focalDevice.manipulated
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/event-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
-  :path: statusReason
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/performer-role
-  :path: performer.function
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-outcome
-  :path: outcome
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-code
-  :path: complication
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-followup
-  :path: followUp
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/device-action
-  :path: focalDevice.action
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/device-kind
-  :path: usedCode
 :references:
 - :path: Procedure.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
@@ -83,46 +83,6 @@
 - Provenance.entity.what
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: uri
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/resource-types
-  :path: target.type
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://terminology.hl7.org/ValueSet/v3-PurposeOfUse
-  :path: reason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/provenance-activity-type
-  :path: activity
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type
-  :path: agent.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/security-role-type
-  :path: agent.role
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-  :path: agent.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/security-role-type
-  :path: agent.role
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-  :path: agent.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/security-role-type
-  :path: agent.role
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/provenance-entity-role
   :path: entity.role

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
@@ -234,97 +234,17 @@
 - Observation.component.value[x].code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
@@ -169,65 +169,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38
-  :path: value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/allergy_intolerance/metadata.yml
@@ -86,10 +86,6 @@
 - AllergyIntolerance.patient
 - AllergyIntolerance.reaction.manifestation
 :bindings:
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
 - :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/allergyintolerance-clinical
@@ -110,26 +106,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality
   :path: criticality
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/substance-code
-  :path: reaction.substance
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: reaction.manifestation
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/reaction-event-severity
   :path: reaction.severity
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/route-codes
-  :path: reaction.exposureRoute
 :references:
 - :path: AllergyIntolerance.patient
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
@@ -214,97 +214,17 @@
 - Observation.component.value[x].code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/bmi/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_height/metadata.yml
@@ -192,25 +192,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -219,46 +203,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_temperature/metadata.yml
@@ -192,25 +192,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -219,46 +203,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodytemp
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_weight/metadata.yml
@@ -192,25 +192,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -219,46 +203,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodyweight
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/care_plan/metadata.yml
@@ -154,10 +154,6 @@
 - CarePlan.activity.detail.status
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status
   :path: text.status
@@ -169,38 +165,14 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-plan-intent
   :path: intent
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-plan-category
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-plan-category
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-plan-activity-outcome
-  :path: activity.outcomeCodeableConcept
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-plan-activity-kind
   :path: activity.detail.kind
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-code
-  :path: activity.detail.code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: activity.detail.reasonCode
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-plan-activity-status
   :path: activity.detail.status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medication-codes
-  :path: activity.detail.product
 :references:
 - :path: CarePlan.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/care_team/metadata.yml
@@ -121,25 +121,9 @@
 - CareTeam.participant.member
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/care-team-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/care-team-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30
-  :path: participant.role
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: reasonCode
 :references:
 - :path: CareTeam.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
@@ -263,10 +263,6 @@
 - Condition.code
 - Condition.subject
 :bindings:
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
 - :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/condition-clinical
@@ -275,38 +271,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/condition-ver-status
   :path: verificationStatus
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/condition-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/condition-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/condition-severity
-  :path: severity
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-stage
-  :path: stage.summary
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-stage-type
-  :path: stage.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/manifestation-or-symptom
-  :path: evidence.code
 :references:
 - :path: Condition.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
@@ -271,10 +271,6 @@
 - Condition.code
 - Condition.subject
 :bindings:
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
 - :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/condition-clinical
@@ -284,41 +280,9 @@
   :system: http://hl7.org/fhir/ValueSet/condition-ver-status
   :path: verificationStatus
 - :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/condition-category
-  :path: category
-- :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-problem-or-health-concern
   :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/condition-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/condition-severity
-  :path: severity
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-stage
-  :path: stage.summary
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-stage-type
-  :path: stage.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/manifestation-or-symptom
-  :path: evidence.code
 :references:
 - :path: Condition.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
@@ -283,6 +283,7 @@
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-problem-or-health-concern
   :path: category
+  :required_binding_slice: true
 :references:
 - :path: Condition.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/device/metadata.yml
@@ -94,10 +94,6 @@
 - Device.patient
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/udi-entry-type
   :path: udiCarrier.entryType
@@ -105,18 +101,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/device-status
   :path: status
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/device-status-reason
-  :path: statusReason
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/device-nametype
   :path: deviceName.type
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/device-kind
-  :path: type
 :references:
 - :path: Device.definition
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_lab/metadata.yml
@@ -179,29 +179,9 @@
 - DiagnosticReport.media.link
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: conclusionCode
 :references:
 - :path: DiagnosticReport.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
@@ -200,10 +200,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
   :path: status
-- :type: CodeableConcept
-  :strength: required
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category
-  :path: category
 :references:
 - :path: DiagnosticReport.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
@@ -197,29 +197,13 @@
 - DiagnosticReport.media.link
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
   :path: status
 - :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-  :path: category
-- :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category
   :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: conclusionCode
 :references:
 - :path: DiagnosticReport.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
@@ -224,10 +224,6 @@
 - DocumentReference.content.attachment
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/document-reference-status
   :path: status
@@ -240,10 +236,6 @@
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
   :path: type
 - :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/document-classcodes
-  :path: category
-- :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category
   :path: category
@@ -251,34 +243,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/document-relationship-type
   :path: relatesTo.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/security-labels
-  :path: securityLabel
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/mimetypes
   :path: content.attachment.contentType
-- :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: content.attachment.language
-- :type: Coding
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/formatcodes
-  :path: content.format
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ActCode
-  :path: context.event
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/c80-facilitycodes
-  :path: context.facilityType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/c80-practice-codes
-  :path: context.practiceSetting
 :references:
 - :path: DocumentReference.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
@@ -235,10 +235,6 @@
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
   :path: type
-- :type: CodeableConcept
-  :strength: required
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category
-  :path: category
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/document-relationship-type

--- a/lib/us_core_test_kit/generated/v5.0.1/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/encounter/metadata.yml
@@ -255,17 +255,9 @@
 - Encounter.location.location
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/encounter-status
@@ -274,70 +266,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/encounter-status
   :path: statusHistory.status
-- :type: Coding
-  :strength: extensible
-  :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-  :path: class
-- :type: Coding
-  :strength: extensible
-  :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-  :path: classHistory.class
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type
-  :path: type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/service-type
-  :path: serviceType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ActPriority
-  :path: priority
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/encounter-participant-type
-  :path: participant.type
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/diagnosis-role
-  :path: diagnosis.use
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-admit-source
-  :path: hospitalization.admitSource
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v2-0092
-  :path: hospitalization.reAdmission
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/encounter-diet
-  :path: hospitalization.dietPreference
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
-  :path: hospitalization.specialCourtesy
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
-  :path: hospitalization.specialArrangement
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-discharge-disposition
-  :path: hospitalization.dischargeDisposition
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/encounter-location-status
   :path: location.status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/location-physical-type
-  :path: location.physicalType
 :references:
 - :path: Encounter.identifier.assigner
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/goal/metadata.yml
@@ -126,45 +126,9 @@
 - Goal.subject
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/goal-status
   :path: lifecycleStatus
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/goal-achievement
-  :path: achievementStatus
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/goal-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/goal-priority
-  :path: priority
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-goal-description
-  :path: description
-- :type: date
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/goal-start-event
-  :path: start
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: target.measure
-- :type: Quantity
-  :strength: example
-  :system:
-  :path: target.detail
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/clinical-findings
-  :path: outcomeCode
 :references:
 - :path: Goal.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference/metadata.yml
@@ -192,25 +192,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -219,46 +203,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
   :path: value.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/heart_rate/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/immunization/metadata.yml
@@ -118,57 +118,9 @@
 - Immunization.protocolApplied.doseNumber[x]
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/immunization-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-status-reason
-  :path: statusReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6
-  :path: vaccineCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-origin
-  :path: reportOrigin
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-site
-  :path: site
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-route
-  :path: route
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/immunization-function
-  :path: performer.function
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
-  :path: subpotentReason
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-program-eligibility
-  :path: programEligibility
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-funding-source
-  :path: fundingSource
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/immunization-target-disease
-  :path: protocolApplied.targetDisease
 :references:
 - :path: Immunization.patient
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
@@ -202,10 +202,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/medicationrequest-intent
   :path: intent
-- :type: CodeableConcept
-  :strength: required
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
-  :path: category
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/request-priority

--- a/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
@@ -195,25 +195,13 @@
 - MedicationRequest.substitution.allowed[x]
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/medicationrequest-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-status-reason
-  :path: statusReason
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/medicationrequest-intent
   :path: intent
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
-  :path: category
 - :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
@@ -222,54 +210,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/request-priority
   :path: priority
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4
-  :path: medication
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/performer-role
-  :path: performerType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-code
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy
-  :path: courseOfTherapyType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/additional-instruction-codes
-  :path: dosageInstruction.additionalInstruction
-- :type: boolean
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medication-as-needed-reason
-  :path: dosageInstruction.asNeeded
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/approach-site-codes
-  :path: dosageInstruction.site
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/route-codes
-  :path: dosageInstruction.route
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/administration-method-codes
-  :path: dosageInstruction.method
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/dose-rate-type
-  :path: dosageInstruction.doseAndRate.type
-- :type: boolean
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode
-  :path: substitution.allowed
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason
-  :path: substitution.reason
 :references:
 - :path: MedicationRequest.subject
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -1481,10 +1481,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
     :path: status
-  - :type: CodeableConcept
-    :strength: required
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category
-    :path: category
   :references:
   - :path: DiagnosticReport.basedOn
     :profiles:
@@ -1993,10 +1989,6 @@
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
     :path: type
-  - :type: CodeableConcept
-    :strength: required
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category
-    :path: category
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/document-relationship-type
@@ -3104,10 +3096,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medicationrequest-intent
     :path: intent
-  - :type: CodeableConcept
-    :strength: required
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
-    :path: category
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/request-priority
@@ -9732,10 +9720,6 @@
   - QuestionnaireResponse.authored
   - QuestionnaireResponse.item.linkId
   :bindings:
-  - :type: Coding
-    :strength: required
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-tags
-    :path: meta.tag
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/questionnaire-answers-status
@@ -10070,10 +10054,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/request-intent
     :path: intent
-  - :type: CodeableConcept
-    :strength: required
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-servicerequest-category
-    :path: category
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/request-priority

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -88,10 +88,6 @@
   - AllergyIntolerance.patient
   - AllergyIntolerance.reaction.manifestation
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
   - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/allergyintolerance-clinical
@@ -112,26 +108,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality
     :path: criticality
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/substance-code
-    :path: reaction.substance
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: reaction.manifestation
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/reaction-event-severity
     :path: reaction.severity
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/route-codes
-    :path: reaction.exposureRoute
   :references:
   - :path: AllergyIntolerance.patient
     :profiles:
@@ -307,10 +287,6 @@
   - CarePlan.activity.detail.status
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status
     :path: text.status
@@ -322,38 +298,14 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-plan-intent
     :path: intent
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-plan-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-plan-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-plan-activity-outcome
-    :path: activity.outcomeCodeableConcept
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-plan-activity-kind
     :path: activity.detail.kind
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-code
-    :path: activity.detail.code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: activity.detail.reasonCode
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-plan-activity-status
     :path: activity.detail.status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-codes
-    :path: activity.detail.product
   :references:
   - :path: CarePlan.basedOn
     :profiles:
@@ -559,25 +511,9 @@
   - CareTeam.participant.member
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/care-team-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/care-team-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30
-    :path: participant.role
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: reasonCode
   :references:
   - :path: CareTeam.subject
     :profiles:
@@ -873,10 +809,6 @@
   - Condition.code
   - Condition.subject
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
   - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/condition-clinical
@@ -885,38 +817,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/condition-ver-status
     :path: verificationStatus
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/condition-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/condition-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/condition-severity
-    :path: severity
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-stage
-    :path: stage.summary
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-stage-type
-    :path: stage.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/manifestation-or-symptom
-    :path: evidence.code
   :references:
   - :path: Condition.subject
     :profiles:
@@ -1216,10 +1116,6 @@
   - Condition.code
   - Condition.subject
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
   - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/condition-clinical
@@ -1229,41 +1125,9 @@
     :system: http://hl7.org/fhir/ValueSet/condition-ver-status
     :path: verificationStatus
   - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/condition-category
-    :path: category
-  - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-problem-or-health-concern
     :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/condition-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/condition-severity
-    :path: severity
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-stage
-    :path: stage.summary
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-stage-type
-    :path: stage.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/manifestation-or-symptom
-    :path: evidence.code
   :references:
   - :path: Condition.subject
     :profiles:
@@ -1387,10 +1251,6 @@
   - Device.patient
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/udi-entry-type
     :path: udiCarrier.entryType
@@ -1398,18 +1258,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/device-status
     :path: status
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/device-status-reason
-    :path: statusReason
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/device-nametype
     :path: deviceName.type
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/device-kind
-    :path: type
   :references:
   - :path: Device.definition
     :profiles:
@@ -1625,29 +1477,13 @@
   - DiagnosticReport.media.link
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
     :path: status
   - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-    :path: category
-  - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category
     :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: conclusionCode
   :references:
   - :path: DiagnosticReport.basedOn
     :profiles:
@@ -1873,29 +1709,9 @@
   - DiagnosticReport.media.link
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/diagnostic-report-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: conclusionCode
   :references:
   - :path: DiagnosticReport.basedOn
     :profiles:
@@ -2165,10 +1981,6 @@
   - DocumentReference.content.attachment
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/document-reference-status
     :path: status
@@ -2181,10 +1993,6 @@
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
     :path: type
   - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/document-classcodes
-    :path: category
-  - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category
     :path: category
@@ -2192,34 +2000,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/document-relationship-type
     :path: relatesTo.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/security-labels
-    :path: securityLabel
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/mimetypes
     :path: content.attachment.contentType
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: content.attachment.language
-  - :type: Coding
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/formatcodes
-    :path: content.format
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ActCode
-    :path: context.event
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/c80-facilitycodes
-    :path: context.facilityType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/c80-practice-codes
-    :path: context.practiceSetting
   :references:
   - :path: DocumentReference.subject
     :profiles:
@@ -2515,17 +2299,9 @@
   - Encounter.location.location
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/encounter-status
@@ -2534,70 +2310,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/encounter-status
     :path: statusHistory.status
-  - :type: Coding
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-    :path: class
-  - :type: Coding
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-ActEncounterCode
-    :path: classHistory.class
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type
-    :path: type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/service-type
-    :path: serviceType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ActPriority
-    :path: priority
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/encounter-participant-type
-    :path: participant.type
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/diagnosis-role
-    :path: diagnosis.use
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-admit-source
-    :path: hospitalization.admitSource
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v2-0092
-    :path: hospitalization.reAdmission
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/encounter-diet
-    :path: hospitalization.dietPreference
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
-    :path: hospitalization.specialCourtesy
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
-    :path: hospitalization.specialArrangement
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-discharge-disposition
-    :path: hospitalization.dischargeDisposition
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/encounter-location-status
     :path: location.status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/location-physical-type
-    :path: location.physicalType
   :references:
   - :path: Encounter.identifier.assigner
     :profiles:
@@ -2786,45 +2502,9 @@
   - Goal.subject
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/goal-status
     :path: lifecycleStatus
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/goal-achievement
-    :path: achievementStatus
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/goal-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/goal-priority
-    :path: priority
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-goal-description
-    :path: description
-  - :type: date
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/goal-start-event
-    :path: start
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: target.measure
-  - :type: Quantity
-    :strength: example
-    :system:
-    :path: target.detail
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/clinical-findings
-    :path: outcomeCode
   :references:
   - :path: Goal.subject
     :profiles:
@@ -2966,57 +2646,9 @@
   - Immunization.protocolApplied.doseNumber[x]
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/immunization-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-status-reason
-    :path: statusReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6
-    :path: vaccineCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-origin
-    :path: reportOrigin
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-site
-    :path: site
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-route
-    :path: route
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/immunization-function
-    :path: performer.function
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
-    :path: subpotentReason
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-program-eligibility
-    :path: programEligibility
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-funding-source
-    :path: fundingSource
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/immunization-target-disease
-    :path: protocolApplied.targetDisease
   :references:
   - :path: Immunization.patient
     :profiles:
@@ -3181,25 +2813,13 @@
   - Location.position.latitude
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/location-status
     :path: status
-  - :type: Coding
-    :strength: preferred
-    :system: http://terminology.hl7.org/ValueSet/v2-0116
-    :path: operationalStatus
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/location-mode
     :path: mode
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
-    :path: type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-use
@@ -3208,14 +2828,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/location-physical-type
-    :path: physicalType
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/days-of-week
@@ -3280,21 +2892,9 @@
   - Medication.ingredient.item[x]
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4
-    :path: code
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medication-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-form-codes
-    :path: form
   :references:
   - :path: Medication.manufacturer
     :profiles:
@@ -3496,25 +3096,13 @@
   - MedicationRequest.substitution.allowed[x]
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medicationrequest-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-status-reason
-    :path: statusReason
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medicationrequest-intent
     :path: intent
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
-    :path: category
   - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
@@ -3523,54 +3111,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/request-priority
     :path: priority
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4
-    :path: medication
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/performer-role
-    :path: performerType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-code
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy
-    :path: courseOfTherapyType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/additional-instruction-codes
-    :path: dosageInstruction.additionalInstruction
-  - :type: boolean
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-as-needed-reason
-    :path: dosageInstruction.asNeeded
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/approach-site-codes
-    :path: dosageInstruction.site
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/route-codes
-    :path: dosageInstruction.route
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/administration-method-codes
-    :path: dosageInstruction.method
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/dose-rate-type
-    :path: dosageInstruction.doseAndRate.type
-  - :type: boolean
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode
-    :path: substitution.allowed
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason
-    :path: substitution.reason
   :references:
   - :path: MedicationRequest.subject
     :profiles:
@@ -3806,61 +3346,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -4155,65 +3643,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-common-sdoh-assessments
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -4465,69 +3897,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -4767,65 +4143,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -5079,69 +4399,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -5389,25 +4653,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -5416,46 +4664,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodytemp
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -5704,69 +4912,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6056,97 +5208,17 @@
   - Observation.component.value[x].code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6371,65 +5443,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38
-    :path: value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6649,61 +5665,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-sexual-orientation
-    :path: value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -6951,25 +5915,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -6978,46 +5926,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -7265,25 +6173,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -7292,46 +6184,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodylength
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -7580,69 +6432,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -7912,97 +6708,17 @@
   - Observation.component.value[x].code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: component.value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -8228,61 +6944,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -8969,61 +7633,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-test-codes
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-codes
-    :path: component.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -9272,69 +7884,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -9584,69 +8140,13 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
     :path: value.comparator
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -9894,25 +8394,9 @@
   - Observation.component.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/observation-status
     :path: status
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/observation-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: code
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/quantity-comparator
@@ -9921,46 +8405,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/ucum-bodyweight
     :path: value.code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: interpretation
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/observation-methods
-    :path: method
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-    :path: referenceRange.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-    :path: referenceRange.appliesTo
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-    :path: component.code
-  - :type: Quantity
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-    :path: component.value
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-    :path: component.dataAbsentReason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-    :path: component.interpretation
   :references:
   - :path: Observation.basedOn
     :profiles:
@@ -10113,21 +8557,9 @@
   - Organization.name
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/organization-type
-    :path: type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/contact-point-system
@@ -10144,14 +8576,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/contactentity-type
-    :path: contact.purpose
   :references:
   - :path: Organization.identifier.assigner
     :profiles:
@@ -10373,17 +8797,9 @@
   - Patient.link.type
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/name-use
@@ -10408,26 +8824,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/marital-status
-    :path: maritalStatus
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/patient-contactrelationship
-    :path: contact.relationship
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/administrative-gender
     :path: contact.gender
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/simple-language
-    :path: communication.language
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/link-type
@@ -10606,17 +9006,9 @@
   - Practitioner.qualification.code
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/identifier-use
     :path: identifier.use
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/identifier-type
-    :path: identifier.type
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/name-use
@@ -10637,22 +9029,10 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/address-type
     :path: address.type
-  - :type: string
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-    :path: address.state
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/administrative-gender
     :path: gender
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v2-2.7-0360
-    :path: qualification.code
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: communication
   :references:
   - :path: Practitioner.identifier.assigner
     :profiles:
@@ -10760,18 +9140,6 @@
   - PractitionerRole.telecom.value
   - PractitionerRole.notAvailable.description
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role
-    :path: code
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.1066
-    :path: specialty
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/contact-point-system
@@ -10944,57 +9312,9 @@
   - Procedure.focalDevice.manipulated
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/event-status
     :path: status
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
-    :path: statusReason
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-category
-    :path: category
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/performer-role
-    :path: performer.function
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-outcome
-    :path: outcome
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/condition-code
-    :path: complication
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-followup
-    :path: followUp
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/device-action
-    :path: focalDevice.action
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/device-kind
-    :path: usedCode
   :references:
   - :path: Procedure.basedOn
     :profiles:
@@ -11143,46 +9463,6 @@
   - Provenance.entity.role
   - Provenance.entity.what
   :bindings:
-  - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: uri
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/resource-types
-    :path: target.type
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://terminology.hl7.org/ValueSet/v3-PurposeOfUse
-    :path: reason
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/provenance-activity-type
-    :path: activity
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type
-    :path: agent.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/security-role-type
-    :path: agent.role
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-    :path: agent.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/security-role-type
-    :path: agent.role
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-    :path: agent.type
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/security-role-type
-    :path: agent.role
   - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/provenance-entity-role
@@ -11452,29 +9732,13 @@
   - QuestionnaireResponse.item.linkId
   :bindings:
   - :type: Coding
-    :strength: extensible
-    :system: http://hl7.org/fhir/ValueSet/security-labels
-    :path: meta.security
-  - :type: Coding
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/common-tags
-    :path: meta.tag
-  - :type: Coding
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-tags
     :path: meta.tag
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/questionnaire-answers-status
     :path: status
-  - :type: boolean
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/questionnaire-answers
-    :path: item.answer.value
   :references:
   - :path: QuestionnaireResponse.basedOn
     :profiles:
@@ -11595,21 +9859,9 @@
   - RelatedPerson.communication.language
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype
-    :path: relationship
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/administrative-gender
     :path: gender
-  - :type: CodeableConcept
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: communication.language
   :references:
   - :path: RelatedPerson.patient
     :profiles:
@@ -11810,10 +10062,6 @@
   - ServiceRequest.subject
   :bindings:
   - :type: code
-    :strength: preferred
-    :system: http://hl7.org/fhir/ValueSet/languages
-    :path: language
-  - :type: code
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/request-status
     :path: status
@@ -11822,10 +10070,6 @@
     :system: http://hl7.org/fhir/ValueSet/request-intent
     :path: intent
   - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/servicerequest-category
-    :path: category
-  - :type: CodeableConcept
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-servicerequest-category
     :path: category
@@ -11833,34 +10077,6 @@
     :strength: required
     :system: http://hl7.org/fhir/ValueSet/request-priority
     :path: priority
-  - :type: CodeableConcept
-    :strength: extensible
-    :system: http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code
-    :path: code
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/servicerequest-orderdetail
-    :path: orderDetail
-  - :type: boolean
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/medication-as-needed-reason
-    :path: asNeeded
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/participant-role
-    :path: performerType
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
-    :path: locationCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/procedure-reason
-    :path: reasonCode
-  - :type: CodeableConcept
-    :strength: example
-    :system: http://hl7.org/fhir/ValueSet/body-site
-    :path: bodySite
   :references:
   - :path: ServiceRequest.basedOn
     :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -1128,6 +1128,7 @@
     :strength: required
     :system: http://hl7.org/fhir/us/core/ValueSet/us-core-problem-or-health-concern
     :path: category
+    :required_binding_slice: true
   :references:
   - :path: Condition.subject
     :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_clinical_test/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_clinical_test/metadata.yml
@@ -631,61 +631,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-test-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_imaging/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_imaging/metadata.yml
@@ -170,61 +170,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_lab/metadata.yml
@@ -170,61 +170,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
@@ -239,65 +239,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-common-sdoh-assessments
-  :path: code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sexual_orientation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sexual_orientation/metadata.yml
@@ -164,61 +164,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-sexual-orientation
-  :path: value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
@@ -184,65 +184,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/organization/metadata.yml
@@ -96,21 +96,9 @@
 - Organization.name
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/organization-type
-  :path: type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/contact-point-system
@@ -127,14 +115,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/address-type
   :path: address.type
-- :type: string
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-  :path: address.state
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/contactentity-type
-  :path: contact.purpose
 :references:
 - :path: Organization.identifier.assigner
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
@@ -209,17 +209,9 @@
 - Patient.link.type
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/name-use
@@ -244,26 +236,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/address-type
   :path: address.type
-- :type: string
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-  :path: address.state
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/marital-status
-  :path: maritalStatus
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/patient-contactrelationship
-  :path: contact.relationship
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/administrative-gender
   :path: contact.gender
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/simple-language
-  :path: communication.language
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/link-type

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/practitioner/metadata.yml
@@ -113,17 +113,9 @@
 - Practitioner.qualification.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/identifier-use
   :path: identifier.use
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/identifier-type
-  :path: identifier.type
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/name-use
@@ -144,22 +136,10 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/address-type
   :path: address.type
-- :type: string
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
-  :path: address.state
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/administrative-gender
   :path: gender
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v2-2.7-0360
-  :path: qualification.code
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: communication
 :references:
 - :path: Practitioner.identifier.assigner
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/procedure/metadata.yml
@@ -136,57 +136,9 @@
 - Procedure.focalDevice.manipulated
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/event-status
   :path: status
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
-  :path: statusReason
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/performer-role
-  :path: performer.function
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-outcome
-  :path: outcome
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/condition-code
-  :path: complication
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-followup
-  :path: followUp
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/device-action
-  :path: focalDevice.action
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/device-kind
-  :path: usedCode
 :references:
 - :path: Procedure.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
@@ -82,46 +82,6 @@
 - Provenance.entity.what
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: uri
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/resource-types
-  :path: target.type
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://terminology.hl7.org/ValueSet/v3-PurposeOfUse
-  :path: reason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/provenance-activity-type
-  :path: activity
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type
-  :path: agent.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/security-role-type
-  :path: agent.role
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-  :path: agent.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/security-role-type
-  :path: agent.role
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/provenance-agent-type
-  :path: agent.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/security-role-type
-  :path: agent.role
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/provenance-entity-role
   :path: entity.role

--- a/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
@@ -234,97 +234,17 @@
 - Observation.component.value[x].code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: component.value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
@@ -200,10 +200,6 @@
 - QuestionnaireResponse.authored
 - QuestionnaireResponse.item.linkId
 :bindings:
-- :type: Coding
-  :strength: required
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-tags
-  :path: meta.tag
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/questionnaire-answers-status

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
@@ -201,29 +201,13 @@
 - QuestionnaireResponse.item.linkId
 :bindings:
 - :type: Coding
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/security-labels
-  :path: meta.security
-- :type: Coding
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/common-tags
-  :path: meta.tag
-- :type: Coding
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-tags
   :path: meta.tag
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/questionnaire-answers-status
   :path: status
-- :type: boolean
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/questionnaire-answers
-  :path: item.answer.value
 :references:
 - :path: QuestionnaireResponse.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/related_person/metadata.yml
@@ -84,21 +84,9 @@
 - RelatedPerson.communication.language
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype
-  :path: relationship
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/administrative-gender
   :path: gender
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: communication.language
 :references:
 - :path: RelatedPerson.patient
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/metadata.yml
@@ -193,69 +193,13 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/observation-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: code
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/quantity-comparator
   :path: value.comparator
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
-  :path: component.code
-- :type: Quantity
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
-  :path: component.value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
@@ -201,10 +201,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/request-intent
   :path: intent
-- :type: CodeableConcept
-  :strength: required
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-servicerequest-category
-  :path: category
 - :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/request-priority

--- a/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
@@ -194,10 +194,6 @@
 - ServiceRequest.subject
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/request-status
   :path: status
@@ -206,10 +202,6 @@
   :system: http://hl7.org/fhir/ValueSet/request-intent
   :path: intent
 - :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/servicerequest-category
-  :path: category
-- :type: CodeableConcept
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-servicerequest-category
   :path: category
@@ -217,34 +209,6 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/request-priority
   :path: priority
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code
-  :path: code
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/servicerequest-orderdetail
-  :path: orderDetail
-- :type: boolean
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/medication-as-needed-reason
-  :path: asNeeded
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/participant-role
-  :path: performerType
-- :type: CodeableConcept
-  :strength: example
-  :system: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
-  :path: locationCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/procedure-reason
-  :path: reasonCode
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
 :references:
 - :path: ServiceRequest.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
@@ -169,65 +169,9 @@
 - Observation.component.code
 :bindings:
 - :type: code
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/languages
-  :path: language
-- :type: code
   :strength: required
   :system: http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status
   :path: status
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/observation-category
-  :path: category
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes
-  :path: code
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38
-  :path: value
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: interpretation
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/body-site
-  :path: bodySite
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-methods
-  :path: method
-- :type: CodeableConcept
-  :strength: preferred
-  :system: http://hl7.org/fhir/ValueSet/referencerange-meaning
-  :path: referenceRange.type
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/referencerange-appliesto
-  :path: referenceRange.appliesTo
-- :type: CodeableConcept
-  :strength: example
-  :system: http://hl7.org/fhir/ValueSet/observation-codes
-  :path: component.code
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/data-absent-reason
-  :path: component.dataAbsentReason
-- :type: CodeableConcept
-  :strength: extensible
-  :system: http://hl7.org/fhir/ValueSet/observation-interpretation
-  :path: component.interpretation
 :references:
 - :path: Observation.basedOn
   :profiles:

--- a/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
@@ -27,14 +27,14 @@ module USCoreTestKit
         end
       end
 
-      def element_has_option_binding_slice(element)
+      def element_has_optional_binding_slice(element)
         element.sliceName.present? && element.min == 0
       end
 
       def profile_elements_with_bindings
         profile_elements
           .select { |element| element.binding.present? && element.binding.strength == 'required'}
-          .reject { |element| element_has_fixed_value?(element) || element_has_option_binding_slice(element) }
+          .reject { |element| element_has_fixed_value?(element) || element_has_optional_binding_slice(element) }
       end
 
 

--- a/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
@@ -33,15 +33,23 @@ module USCoreTestKit
           .reject { |element| element_has_fixed_value? element }
       end
 
+      def is_required_binding_slice(profile_element)
+        profile_element.sliceName.present? && profile_element.min > 0
+      end
+
       def element_terminology_bindings
         profile_elements_with_bindings.map do |element|
-          {
+          binding = {
             type: element.type.first.code,
             strength: element.binding.strength,
             # Goal.target.detail has an unbound binding
             system: element.binding.valueSet&.split('|')&.first,
             path: element.path.gsub('[x]', '').gsub("#{resource}.", '')
           }
+
+          binding[:required_binding_slice] = true if is_required_binding_slice(element)
+
+          binding
         end
       end
 

--- a/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
@@ -27,14 +27,14 @@ module USCoreTestKit
         end
       end
 
-      def element_has_optional_binding_slice(element)
+      def element_has_optional_binding_slice?(element)
         element.sliceName.present? && element.min == 0
       end
 
       def profile_elements_with_bindings
         profile_elements
           .select { |element| element.binding.present? && element.binding.strength == 'required'}
-          .reject { |element| element_has_fixed_value?(element) || element_has_optional_binding_slice(element) }
+          .reject { |element| element_has_fixed_value?(element) || element_has_optional_binding_slice?(element) }
       end
 
 

--- a/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
@@ -29,7 +29,7 @@ module USCoreTestKit
 
       def profile_elements_with_bindings
         profile_elements
-          .select { |element| element.binding.present? }
+          .select { |element| element.binding.present? && element.binding.strength == 'required'}
           .reject { |element| element_has_fixed_value? element }
       end
 

--- a/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/terminology_binding_metadata_extractor.rb
@@ -27,15 +27,17 @@ module USCoreTestKit
         end
       end
 
+      def element_has_option_binding_slice(element)
+        element.sliceName.present? && element.min == 0
+      end
+
       def profile_elements_with_bindings
         profile_elements
           .select { |element| element.binding.present? && element.binding.strength == 'required'}
-          .reject { |element| element_has_fixed_value? element }
+          .reject { |element| element_has_fixed_value?(element) || element_has_option_binding_slice(element) }
       end
 
-      def is_required_binding_slice(profile_element)
-        profile_element.sliceName.present? && profile_element.min > 0
-      end
+
 
       def element_terminology_bindings
         profile_elements_with_bindings.map do |element|
@@ -47,7 +49,9 @@ module USCoreTestKit
             path: element.path.gsub('[x]', '').gsub("#{resource}.", '')
           }
 
-          binding[:required_binding_slice] = true if is_required_binding_slice(element)
+          if element.sliceName.present? && element.min > 0
+            binding[:required_binding_slice] = true
+          end
 
           binding
         end


### PR DESCRIPTION
# Summary
This is part of fix for GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/361.

This PR changes:
* Remove binding definition from generated metadata unless the binding strength is `required`. ONC (g)(10) Test Kit only validates `required` binding
* Add `required_binding_slice` if the binding strength is `required` and the binding is in a slice with min cardinality > 0. In US Core 5.0.1, there is one element has such attribute: Condition.category:us-core for US Core Condition Problems and Health Concerns Profile

# Testing Guidance
Visual Inspection of metadata

