### PR TITLE
FI-1812 add provenance_validator for provenance-1 constraint

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -74,7 +74,7 @@ module USCoreTestKit
         end
 
         perform_additional_validation do |resource, profile_url|
-          ProvenanceValidator.validate(resource) if resource.class == FHIR::Provenance
+          ProvenanceValidator.validate(resource) if resource.instance_of?(FHIR::Provenance)
         end
       end
 
@@ -94,7 +94,7 @@ module USCoreTestKit
       end
 
       group from: :us_core_v311_capability_statement
-  
+
       group from: :us_core_v311_patient
       group from: :us_core_v311_allergy_intolerance
       group from: :us_core_v311_care_plan

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -3,6 +3,7 @@ require_relative '../../version'
 require_relative '../../custom_groups/v3.1.1/capability_statement_group'
 require_relative '../../custom_groups/v3.1.1/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
+require_relative '../../provenance_validator'
 require_relative 'patient_group'
 require_relative 'allergy_intolerance_group'
 require_relative 'care_plan_group'
@@ -56,7 +57,8 @@ module USCoreTestKit
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
-        /Observation\.effective\.ofType\(Period\): .*us-core-1:/ # Invalid invariant in US Core v3.1.1
+        /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
+        /Provenance.agent\[\d*\]: Rule provenance-1/ #Invalid invariant in US Core v5.0.1
       ].freeze
 
       def self.metadata
@@ -69,6 +71,10 @@ module USCoreTestKit
         url ENV.fetch('V311_VALIDATOR_URL', 'http://validator_service:4567')
         exclude_message do |message|
           VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
+        end
+
+        perform_additional_validation do |resource, profile_url|
+          ProvenanceValidator.validate(resource) if resource.class == FHIR::Provenance
         end
       end
 

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -94,7 +94,7 @@ module USCoreTestKit
       end
 
       group from: :us_core_v311_capability_statement
-
+  
       group from: :us_core_v311_patient
       group from: :us_core_v311_allergy_intolerance
       group from: :us_core_v311_care_plan

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -3,6 +3,7 @@ require_relative '../../version'
 require_relative '../../custom_groups/v4.0.0/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
+require_relative '../../provenance_validator'
 require_relative 'patient_group'
 require_relative 'allergy_intolerance_group'
 require_relative 'care_plan_group'
@@ -58,7 +59,8 @@ module USCoreTestKit
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
-        /Observation\.effective\.ofType\(Period\): .*us-core-1:/ # Invalid invariant in US Core v3.1.1
+        /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
+        /Provenance.agent\[\d*\]: Rule provenance-1/ #Invalid invariant in US Core v5.0.1
       ].freeze
 
       def self.metadata
@@ -71,6 +73,10 @@ module USCoreTestKit
         url ENV.fetch('V400_VALIDATOR_URL', 'http://validator_service:4567')
         exclude_message do |message|
           VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
+        end
+
+        perform_additional_validation do |resource, profile_url|
+          ProvenanceValidator.validate(resource) if resource.class == FHIR::Provenance
         end
       end
 

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -76,7 +76,7 @@ module USCoreTestKit
         end
 
         perform_additional_validation do |resource, profile_url|
-          ProvenanceValidator.validate(resource) if resource.class == FHIR::Provenance
+          ProvenanceValidator.validate(resource) if resource.instance_of?(FHIR::Provenance)
         end
       end
 

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -3,6 +3,7 @@ require_relative '../../version'
 require_relative '../../custom_groups/v5.0.1/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
+require_relative '../../provenance_validator'
 require_relative 'patient_group'
 require_relative 'allergy_intolerance_group'
 require_relative 'care_plan_group'
@@ -67,7 +68,8 @@ module USCoreTestKit
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
-        /Observation\.effective\.ofType\(Period\): .*us-core-1:/ # Invalid invariant in US Core v3.1.1
+        /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
+        /Provenance.agent\[\d*\]: Rule provenance-1/ #Invalid invariant in US Core v5.0.1
       ].freeze
 
       def self.metadata
@@ -80,6 +82,10 @@ module USCoreTestKit
         url ENV.fetch('V501_VALIDATOR_URL', 'http://validator_service:4567')
         exclude_message do |message|
           VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
+        end
+
+        perform_additional_validation do |resource, profile_url|
+          ProvenanceValidator.validate(resource) if resource.class == FHIR::Provenance
         end
       end
 

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -85,7 +85,7 @@ module USCoreTestKit
         end
 
         perform_additional_validation do |resource, profile_url|
-          ProvenanceValidator.validate(resource) if resource.class == FHIR::Provenance
+          ProvenanceValidator.validate(resource) if resource.instance_of?(FHIR::Provenance)
         end
       end
 

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -46,7 +46,7 @@ module USCoreTestKit
         end
 
         perform_additional_validation do |resource, profile_url|
-          ProvenanceValidator.validate(resource) if resource.class == FHIR::Provenance
+          ProvenanceValidator.validate(resource) if resource.instance_of?(FHIR::Provenance)
         end
       end
 

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -3,6 +3,7 @@ require_relative '../../version'
 require_relative '<%= capability_statement_file_name %>'
 require_relative '<%= clinical_notes_guidance_file_name %>'
 require_relative '../../custom_groups/data_absent_reason_group'
+require_relative '../../provenance_validator'
 <% group_file_list.each do |file_name| %>require_relative '<%= file_name %>'
 <% end %>
 module USCoreTestKit
@@ -28,7 +29,8 @@ module USCoreTestKit
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
-        /Observation\.effective\.ofType\(Period\): .*us-core-1:/ # Invalid invariant in US Core v3.1.1
+        /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
+        /Provenance.agent\[\d*\]: Rule provenance-1/ #Invalid invariant in US Core v5.0.1
       ].freeze
 
       def self.metadata
@@ -41,6 +43,10 @@ module USCoreTestKit
         url ENV.fetch('<%= validator_env_name %>', 'http://validator_service:4567')
         exclude_message do |message|
           VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
+        end
+
+        perform_additional_validation do |resource, profile_url|
+          ProvenanceValidator.validate(resource) if resource.class == FHIR::Provenance
         end
       end
 

--- a/lib/us_core_test_kit/provenance_validator.rb
+++ b/lib/us_core_test_kit/provenance_validator.rb
@@ -1,0 +1,36 @@
+module USCoreTestKit
+  class ProvenanceValidator
+    include FHIRResourceNavigation
+
+    def self.validate(...)
+      new(...).validate
+    end
+
+    attr_reader :resource, :validation_messages
+
+    def initialize(resource)
+      @resource = resource
+      @validation_messages = []
+    end
+
+    def validate
+      # Invariant provenance-1 in US Core 5 causes validation error. See FHIR-39518
+      return validation_messages unless resource.class == FHIR::Provenance
+
+      failed_provenance =
+        find_a_value_at(resource, 'agent') do |agent|
+          ['Practitioner', 'Device'].any? { |resource_type| agent.who.reference&.include?(resource_type) } &&
+          agent.onBehalfOf.nil?
+        end
+
+      if failed_provenance.present?
+        validation_messages << {
+          type: 'error',
+          message: "Rule provenance-1: 'onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device' Failed"
+        }
+      end
+
+      validation_messages
+    end
+  end
+end

--- a/lib/us_core_test_kit/provenance_validator.rb
+++ b/lib/us_core_test_kit/provenance_validator.rb
@@ -15,7 +15,7 @@ module USCoreTestKit
 
     def validate
       # Invariant provenance-1 in US Core 5 causes validation error. See FHIR-39518
-      return validation_messages unless resource.class == FHIR::Provenance
+      return validation_messages unless resource.instance_of?(FHIR::Provenance)
 
       failed_provenance =
         find_a_value_at(resource, 'agent') do |agent|

--- a/lib/us_core_test_kit/provenance_validator.rb
+++ b/lib/us_core_test_kit/provenance_validator.rb
@@ -23,10 +23,11 @@ module USCoreTestKit
           agent.onBehalfOf.nil?
         end
 
+
       if failed_provenance.present?
         validation_messages << {
           type: 'error',
-          message: "Rule provenance-1: 'onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device' Failed"
+          message: "#{resource.resourceType}/#{resource.id}: Rule provenance-1: 'onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device' Failed"
         }
       end
 

--- a/spec/us_core/provenance_validator_spec.rb
+++ b/spec/us_core/provenance_validator_spec.rb
@@ -1,9 +1,12 @@
 require_relative '../../lib/us_core_test_kit/provenance_validator'
 
 RSpec.describe USCoreTestKit::ProvenanceValidator do
+  let(:provenance_id){'123'}
+
   describe '.validate' do
     it 'passes when agent.who is a Practitioner and agent.onBehalfOf exists' do
       resource = FHIR::Provenance.new(
+        id: provenance_id,
         agent:[
           {
             who: {
@@ -24,6 +27,7 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
 
     it 'passes when agent.who is a Device and agent.onBehalfOf exists' do
       resource = FHIR::Provenance.new(
+        id: provenance_id,
          agent:[
            {
              who: {
@@ -44,7 +48,8 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
 
     it 'passes when agent.who is not a Practitioner nor Device and agent.onBehalfOf does not exists' do
       resource = FHIR::Provenance.new(
-         agent:[
+        id: provenance_id,
+        agent:[
            {
              who: {
                reference: 'Organization/1'
@@ -61,7 +66,8 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
 
     it 'fails when agent.who is a Practitioner and agent.onBehalfOf does not exists' do
       resource = FHIR::Provenance.new(
-         agent:[
+        id: provenance_id,
+        agent:[
            {
              who: {
                reference: 'Practitioner/1'
@@ -75,12 +81,12 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
       expect(result).to be_an(Array)
       expect(result.length).to eq(1)
       expect(result.first[:type]).to eq('error')
-      expect(result.first[:message]).to include('Rule provenance-1')
+      expect(result.first[:message]).to start_with("Provenance/#{provenance_id}: Rule provenance-1")
     end
 
     it 'fails when agent.who is a Device and agent.onBehalfOf does not exists' do
       resource = FHIR::Provenance.new(
-         id: '1',
+        id: provenance_id,
          agent:[
            {
              who: {
@@ -95,7 +101,7 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
       expect(result).to be_an(Array)
       expect(result.length).to eq(1)
       expect(result.first[:type]).to eq('error')
-      expect(result.first[:message]).to start_with('Provenance/1: Rule provenance-1')
+      expect(result.first[:message]).to start_with("Provenance/#{provenance_id}: Rule provenance-1")
     end
   end
 end

--- a/spec/us_core/provenance_validator_spec.rb
+++ b/spec/us_core/provenance_validator_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
 
     it 'fails when agent.who is a Device and agent.onBehalfOf does not exists' do
       resource = FHIR::Provenance.new(
+         id: '1',
          agent:[
            {
              who: {
@@ -94,7 +95,7 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
       expect(result).to be_an(Array)
       expect(result.length).to eq(1)
       expect(result.first[:type]).to eq('error')
-      expect(result.first[:message]).to include('Rule provenance-1')
+      expect(result.first[:message]).to start_with('Provenance/1: Rule provenance-1')
     end
   end
 end

--- a/spec/us_core/provenance_validator_spec.rb
+++ b/spec/us_core/provenance_validator_spec.rb
@@ -1,0 +1,100 @@
+require_relative '../../lib/us_core_test_kit/provenance_validator'
+
+RSpec.describe USCoreTestKit::ProvenanceValidator do
+  describe '.validate' do
+    it 'passes when agent.who is a Practitioner and agent.onBehalfOf exists' do
+      resource = FHIR::Provenance.new(
+        agent:[
+          {
+            who: {
+              reference: 'Practitioner/1'
+            },
+            onBehalfOf: {
+              reference: 'Organization/1'
+            }
+          }
+        ]
+      )
+
+      result = described_class.validate(resource)
+
+      expect(result).to be_an(Array)
+      expect(result.length).to eq(0)
+    end
+
+    it 'passes when agent.who is a Device and agent.onBehalfOf exists' do
+      resource = FHIR::Provenance.new(
+         agent:[
+           {
+             who: {
+               reference: 'Device/1'
+             },
+             onBehalfOf: {
+               reference: 'Organization/1'
+             }
+           }
+         ]
+      )
+
+      result = described_class.validate(resource)
+
+      expect(result).to be_an(Array)
+      expect(result.length).to eq(0)
+    end
+
+    it 'passes when agent.who is not a Practitioner nor Device and agent.onBehalfOf does not exists' do
+      resource = FHIR::Provenance.new(
+         agent:[
+           {
+             who: {
+               reference: 'Organization/1'
+             }
+           }
+         ]
+      )
+
+      result = described_class.validate(resource)
+
+      expect(result).to be_an(Array)
+      expect(result.length).to eq(0)
+    end
+
+    it 'fails when agent.who is a Practitioner and agent.onBehalfOf does not exists' do
+      resource = FHIR::Provenance.new(
+         agent:[
+           {
+             who: {
+               reference: 'Practitioner/1'
+             }
+           }
+         ]
+      )
+
+      result = described_class.validate(resource)
+
+      expect(result).to be_an(Array)
+      expect(result.length).to eq(1)
+      expect(result.first[:type]).to eq('error')
+      expect(result.first[:message]).to include('Rule provenance-1')
+    end
+
+    it 'fails when agent.who is a Device and agent.onBehalfOf does not exists' do
+      resource = FHIR::Provenance.new(
+         agent:[
+           {
+             who: {
+               reference: 'Device/1'
+             }
+           }
+         ]
+      )
+
+      result = described_class.validate(resource)
+
+      expect(result).to be_an(Array)
+      expect(result.length).to eq(1)
+      expect(result.first[:type]).to eq('error')
+      expect(result.first[:message]).to include('Rule provenance-1')
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This PR fixes the US Core part of GitHub issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/363

This PR includes
* Remove provenance-1 error message from validator
* Add provenance_validator.rb to validation provenance-1 constraint
* Add unit test for provenance_validator

# Testing Guidance
1. Update reference server to US Core 5 data set.
2. Run US Core 5 test kit.
3. Verify that all Provenance tests pass
