### PR TITLE
FI-1824: Add search values for some status searches

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/metadata.yml
@@ -59,7 +59,10 @@
     :full_paths:
     - AllergyIntolerance.clinicalStatus
     :comparators: {}
-    :values: []
+    :values:
+    - active
+    - inactive
+    - resolved
     :type: CodeableConcept
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/condition/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/condition/metadata.yml
@@ -108,7 +108,13 @@
     :full_paths:
     - Condition.clinicalStatus
     :comparators: {}
-    :values: []
+    :values:
+    - active
+    - recurrence
+    - relapse
+    - inactive
+    - remission
+    - resolved
     :type: CodeableConcept
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
@@ -65,7 +65,16 @@
     :full_paths:
     - Goal.lifecycleStatus
     :comparators: {}
-    :values: []
+    :values:
+    - proposed
+    - planned
+    - accepted
+    - active
+    - on-hold
+    - completed
+    - cancelled
+    - entered-in-error
+    - rejected
     :type: code
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -61,7 +61,10 @@
       :full_paths:
       - AllergyIntolerance.clinicalStatus
       :comparators: {}
-      :values: []
+      :values:
+      - active
+      - inactive
+      - resolved
       :type: CodeableConcept
       :contains_multiple: false
       :multiple_or: MAY
@@ -614,7 +617,13 @@
       :full_paths:
       - Condition.clinicalStatus
       :comparators: {}
-      :values: []
+      :values:
+      - active
+      - recurrence
+      - relapse
+      - inactive
+      - remission
+      - resolved
       :type: CodeableConcept
       :contains_multiple: false
       :multiple_or: MAY
@@ -1873,7 +1882,16 @@
       :full_paths:
       - Goal.lifecycleStatus
       :comparators: {}
-      :values: []
+      :values:
+      - proposed
+      - planned
+      - accepted
+      - active
+      - on-hold
+      - completed
+      - cancelled
+      - entered-in-error
+      - rejected
       :type: code
       :contains_multiple: false
       :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/metadata.yml
@@ -59,7 +59,10 @@
     :full_paths:
     - AllergyIntolerance.clinicalStatus
     :comparators: {}
-    :values: []
+    :values:
+    - active
+    - inactive
+    - resolved
     :type: CodeableConcept
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/condition/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/condition/metadata.yml
@@ -110,7 +110,13 @@
     :full_paths:
     - Condition.clinicalStatus
     :comparators: {}
-    :values: []
+    :values:
+    - active
+    - recurrence
+    - relapse
+    - inactive
+    - remission
+    - resolved
     :type: CodeableConcept
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
@@ -65,7 +65,16 @@
     :full_paths:
     - Goal.lifecycleStatus
     :comparators: {}
-    :values: []
+    :values:
+    - proposed
+    - planned
+    - accepted
+    - active
+    - on-hold
+    - completed
+    - cancelled
+    - entered-in-error
+    - rejected
     :type: code
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -61,7 +61,10 @@
       :full_paths:
       - AllergyIntolerance.clinicalStatus
       :comparators: {}
-      :values: []
+      :values:
+      - active
+      - inactive
+      - resolved
       :type: CodeableConcept
       :contains_multiple: false
       :multiple_or: MAY
@@ -623,7 +626,13 @@
       :full_paths:
       - Condition.clinicalStatus
       :comparators: {}
-      :values: []
+      :values:
+      - active
+      - recurrence
+      - relapse
+      - inactive
+      - remission
+      - resolved
       :type: CodeableConcept
       :contains_multiple: false
       :multiple_or: MAY
@@ -1917,7 +1926,16 @@
       :full_paths:
       - Goal.lifecycleStatus
       :comparators: {}
-      :values: []
+      :values:
+      - proposed
+      - planned
+      - accepted
+      - active
+      - on-hold
+      - completed
+      - cancelled
+      - entered-in-error
+      - rejected
       :type: code
       :contains_multiple: false
       :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/allergy_intolerance/metadata.yml
@@ -59,7 +59,10 @@
     :full_paths:
     - AllergyIntolerance.clinicalStatus
     :comparators: {}
-    :values: []
+    :values:
+    - active
+    - inactive
+    - resolved
     :type: CodeableConcept
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
@@ -215,7 +215,13 @@
     :full_paths:
     - Condition.clinicalStatus
     :comparators: {}
-    :values: []
+    :values:
+    - active
+    - recurrence
+    - relapse
+    - inactive
+    - remission
+    - resolved
     :type: CodeableConcept
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
@@ -217,7 +217,13 @@
     :full_paths:
     - Condition.clinicalStatus
     :comparators: {}
-    :values: []
+    :values:
+    - active
+    - recurrence
+    - relapse
+    - inactive
+    - remission
+    - resolved
     :type: CodeableConcept
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/goal/metadata.yml
@@ -90,7 +90,16 @@
     :full_paths:
     - Goal.lifecycleStatus
     :comparators: {}
-    :values: []
+    :values:
+    - proposed
+    - planned
+    - accepted
+    - active
+    - on-hold
+    - completed
+    - cancelled
+    - entered-in-error
+    - rejected
     :type: code
     :contains_multiple: false
     :multiple_or: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -61,7 +61,10 @@
       :full_paths:
       - AllergyIntolerance.clinicalStatus
       :comparators: {}
-      :values: []
+      :values:
+      - active
+      - inactive
+      - resolved
       :type: CodeableConcept
       :contains_multiple: false
       :multiple_or: MAY
@@ -761,7 +764,13 @@
       :full_paths:
       - Condition.clinicalStatus
       :comparators: {}
-      :values: []
+      :values:
+      - active
+      - recurrence
+      - relapse
+      - inactive
+      - remission
+      - resolved
       :type: CodeableConcept
       :contains_multiple: false
       :multiple_or: MAY
@@ -1063,7 +1072,13 @@
       :full_paths:
       - Condition.clinicalStatus
       :comparators: {}
-      :values: []
+      :values:
+      - active
+      - recurrence
+      - relapse
+      - inactive
+      - remission
+      - resolved
       :type: CodeableConcept
       :contains_multiple: false
       :multiple_or: MAY
@@ -2459,7 +2474,16 @@
       :full_paths:
       - Goal.lifecycleStatus
       :comparators: {}
-      :values: []
+      :values:
+      - proposed
+      - planned
+      - accepted
+      - active
+      - on-hold
+      - completed
+      - cancelled
+      - entered-in-error
+      - rejected
       :type: code
       :contains_multiple: false
       :multiple_or: MAY

--- a/lib/us_core_test_kit/generator/search_definition_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/search_definition_metadata_extractor.rb
@@ -120,7 +120,7 @@ module USCoreTestKit
       end
 
       def values_from_resource_metadata(paths)
-        if multiple_or_expectation == 'SHALL' || paths.include?('status')
+        if multiple_or_expectation == 'SHALL' || paths.any? { |path| path.downcase.include?('status') }
           value_extractor.values_from_resource_metadata(paths)
         else
           []


### PR DESCRIPTION
# Summary
Previous PR: #91 unintentionally removed search values from some status search parameter when the element paths is not exactly word `status` but contains `status`. Such as `clinicalStatus`

This PR fixes the bug and add search values back to metadata.

# Testing Guidance

