### PR TITLE
FI-1928 Fix generator bug for Reference choice

### DIFF
--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_request_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/medication_request_reference_resolution_test.rb
@@ -19,6 +19,7 @@ module USCoreTestKit
 
         * MedicationRequest.encounter
         * MedicationRequest.medication[x]
+        * MedicationRequest.reportedReference
         * MedicationRequest.requester
         * MedicationRequest.subject
       )

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
@@ -150,7 +150,7 @@
     :original_path: reported[x]
   - :path: reportedReference
     :original_path: reported[x]
-    :type:
+    :types:
     - Reference
     :target_profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -2529,7 +2529,7 @@
       :original_path: reported[x]
     - :path: reportedReference
       :original_path: reported[x]
-      :type:
+      :types:
       - Reference
       :target_profiles:
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner

--- a/lib/us_core_test_kit/generated/v5.0.1/medication_request/medication_request_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/medication_request/medication_request_reference_resolution_test.rb
@@ -19,6 +19,7 @@ module USCoreTestKit
 
         * MedicationRequest.encounter
         * MedicationRequest.medication[x]
+        * MedicationRequest.reportedReference
         * MedicationRequest.requester
         * MedicationRequest.subject
       )

--- a/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
@@ -161,7 +161,7 @@
     :original_path: reported[x]
   - :path: reportedReference
     :original_path: reported[x]
-    :type:
+    :types:
     - Reference
     :target_profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -3079,7 +3079,7 @@
       :original_path: reported[x]
     - :path: reportedReference
       :original_path: reported[x]
-      :type:
+      :types:
       - Reference
       :target_profiles:
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -221,7 +221,7 @@ module USCoreTestKit
               path: "#{current_metadata[:path].delete_suffix('[x]')}#{type.code.upcase_first}",
               original_path: current_metadata[:path]
             }
-            metadata[:type] = [type.code] if save_type_code?(type)
+            metadata[:types] = [type.code] if save_type_code?(type)
             handle_type_must_support_target_profiles(type, metadata) if type.code == 'Reference'
 
             metadata


### PR DESCRIPTION
# Summary
This fix Github Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/412

What changes:
* Fix the name [:type] to [:types] in must_support_extractor
* Re-generate US Core v4 and v5

# Testing Guidance
Visual inspect medication_request/metadata
