### PR TITLE
FI-1932 category first

### DIFF
--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -34,7 +34,7 @@ module USCoreTestKit
       end
 
       path_segments = path.split('.')
-      segment = path_segments.shift.delete_suffix('[x]').to_sym
+      segment = path_segments.shift.delete_suffix('[x]').gsub(/^class$/, 'local_class').to_sym
 
       no_elements_present =
         elements.none? do |element|

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/care_team/metadata.yml
@@ -173,3 +173,4 @@
   - Practitioner
   - Organization
   - PractitionerRole
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis/condition_encounter_diagnosis_patient_category_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis/condition_encounter_diagnosis_patient_category_search_test.rb
@@ -13,6 +13,19 @@ patient + category on the Condition resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
+This test verifies that the server supports searching by reference using
+the form `patient=[id]` as well as `patient=Patient/[id]`. The two
+different forms are expected to return the same number of results. US
+Core requires that both forms are supported by US Core responders.
+
+Because this is the first search of the sequence, resources in the
+response will be used for subsequent tests.
+
+Additionally, this test will check that GET and POST search methods
+return the same number of results. Search by POST is required by the
+FHIR R4 specification, and these tests interpret search by GET as a
+requirement of US Core v6.0.0-ballot.
+
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -24,10 +37,14 @@ none are returned, the test is skipped.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          resource_type: 'Condition',
+          first_search: true,
+        fixed_value_search: true,
+        resource_type: 'Condition',
         search_param_names: ['patient', 'category'],
         possible_status_search: true,
-        token_search_params: ['category']
+        token_search_params: ['category'],
+        test_reference_variants: true,
+        test_post_search: true
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis/condition_encounter_diagnosis_patient_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis/condition_encounter_diagnosis_patient_search_test.rb
@@ -13,19 +13,6 @@ patient on the Condition resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
-This test verifies that the server supports searching by reference using
-the form `patient=[id]` as well as `patient=Patient/[id]`. The two
-different forms are expected to return the same number of results. US
-Core requires that both forms are supported by US Core responders.
-
-Because this is the first search of the sequence, resources in the
-response will be used for subsequent tests.
-
-Additionally, this test will check that GET and POST search methods
-return the same number of results. Search by POST is required by the
-FHIR R4 specification, and these tests interpret search by GET as a
-requirement of US Core v6.0.0-ballot.
-
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -37,12 +24,9 @@ requirement of US Core v6.0.0-ballot.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          first_search: true,
-        resource_type: 'Condition',
+          resource_type: 'Condition',
         search_param_names: ['patient'],
-        possible_status_search: true,
-        test_reference_variants: true,
-        test_post_search: true
+        possible_status_search: true
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis/condition_encounter_diagnosis_provenance_revinclude_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis/condition_encounter_diagnosis_provenance_revinclude_search_test.rb
@@ -6,11 +6,11 @@ module USCoreTestKit
     class ConditionEncounterDiagnosisProvenanceRevincludeSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
-      title 'Server returns Provenance resources from Condition search by patient + revInclude:Provenance:target'
+      title 'Server returns Provenance resources from Condition search by patient + category + revInclude:Provenance:target'
       description %(
         A server SHALL be capable of supporting _revIncludes:Provenance:target.
 
-        This test will perform a search by patient + revInclude:Provenance:target and
+        This test will perform a search by patient + category + revInclude:Provenance:target and
         will pass if a Provenance resource is found in the response.
       %)
 
@@ -22,8 +22,9 @@ module USCoreTestKit
   
       def properties
         @properties ||= SearchTestProperties.new(
-          resource_type: 'Condition',
-        search_param_names: ['patient']
+          fixed_value_search: true,
+        resource_type: 'Condition',
+        search_param_names: ['patient', 'category']
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis/metadata.yml
@@ -31,6 +31,12 @@
   :expectation: MAY
 :operations: []
 :searches:
+- :expectation: SHALL
+  :names:
+  - patient
+  - category
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
 - :names:
   - patient
   :expectation: SHALL
@@ -67,12 +73,6 @@
   :names_not_must_support_or_mandatory:
   - asserted-date
   :must_support_or_mandatory: false
-- :expectation: SHALL
-  :names:
-  - patient
-  - category
-  :names_not_must_support_or_mandatory: []
-  :must_support_or_mandatory: true
 - :expectation: SHOULD
   :names:
   - patient
@@ -305,6 +305,8 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Resource
 :tests:
+- :id: us_core_v600_ballot_condition_encounter_diagnosis_patient_category_search_test
+  :file_name: condition_encounter_diagnosis_patient_category_search_test.rb
 - :id: us_core_v600_ballot_condition_encounter_diagnosis_patient_search_test
   :file_name: condition_encounter_diagnosis_patient_search_test.rb
 - :id: us_core_v600_ballot_condition_encounter_diagnosis_patient_onset_date_search_test
@@ -317,8 +319,6 @@
   :file_name: condition_encounter_diagnosis_patient_recorded_date_search_test.rb
 - :id: us_core_v600_ballot_condition_encounter_diagnosis_patient_asserted_date_search_test
   :file_name: condition_encounter_diagnosis_patient_asserted_date_search_test.rb
-- :id: us_core_v600_ballot_condition_encounter_diagnosis_patient_category_search_test
-  :file_name: condition_encounter_diagnosis_patient_category_search_test.rb
 - :id: us_core_v600_ballot_condition_encounter_diagnosis_patient_code_search_test
   :file_name: condition_encounter_diagnosis_patient_code_search_test.rb
 - :id: us_core_v600_ballot_condition_encounter_diagnosis_patient_category_encounter_search_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis_group.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_encounter_diagnosis_group.rb
@@ -1,10 +1,10 @@
+require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_category_search_test'
 require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_search_test'
 require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_onset_date_search_test'
 require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_abatement_date_search_test'
 require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_clinical_status_search_test'
 require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_recorded_date_search_test'
 require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_asserted_date_search_test'
-require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_category_search_test'
 require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_code_search_test'
 require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_patient_category_encounter_search_test'
 require_relative 'condition_encounter_diagnosis/condition_encounter_diagnosis_read_test'
@@ -32,8 +32,8 @@ This test sequence will first perform each required search associated
 with this resource. This sequence will perform searches with the
 following parameters:
 
-* patient
 * patient + category
+* patient
 
 ### Search Parameters
 The first search uses the selected patient(s) from the prior launch
@@ -84,13 +84,13 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'condition_encounter_diagnosis', 'metadata.yml'), aliases: true))
       end
   
+      test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_category_search_test
       test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_search_test
       test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_onset_date_search_test
       test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_abatement_date_search_test
       test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_clinical_status_search_test
       test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_recorded_date_search_test
       test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_asserted_date_search_test
-      test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_category_search_test
       test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_code_search_test
       test from: :us_core_v600_ballot_condition_encounter_diagnosis_patient_category_encounter_search_test
       test from: :us_core_v600_ballot_condition_encounter_diagnosis_read_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns/condition_problems_health_concerns_patient_category_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns/condition_problems_health_concerns_patient_category_search_test.rb
@@ -13,6 +13,19 @@ patient + category on the Condition resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
+This test verifies that the server supports searching by reference using
+the form `patient=[id]` as well as `patient=Patient/[id]`. The two
+different forms are expected to return the same number of results. US
+Core requires that both forms are supported by US Core responders.
+
+Because this is the first search of the sequence, resources in the
+response will be used for subsequent tests.
+
+Additionally, this test will check that GET and POST search methods
+return the same number of results. Search by POST is required by the
+FHIR R4 specification, and these tests interpret search by GET as a
+requirement of US Core v6.0.0-ballot.
+
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -24,10 +37,14 @@ none are returned, the test is skipped.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          resource_type: 'Condition',
+          first_search: true,
+        fixed_value_search: true,
+        resource_type: 'Condition',
         search_param_names: ['patient', 'category'],
         possible_status_search: true,
-        token_search_params: ['category']
+        token_search_params: ['category'],
+        test_reference_variants: true,
+        test_post_search: true
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns/condition_problems_health_concerns_patient_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns/condition_problems_health_concerns_patient_search_test.rb
@@ -13,19 +13,6 @@ patient on the Condition resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
-This test verifies that the server supports searching by reference using
-the form `patient=[id]` as well as `patient=Patient/[id]`. The two
-different forms are expected to return the same number of results. US
-Core requires that both forms are supported by US Core responders.
-
-Because this is the first search of the sequence, resources in the
-response will be used for subsequent tests.
-
-Additionally, this test will check that GET and POST search methods
-return the same number of results. Search by POST is required by the
-FHIR R4 specification, and these tests interpret search by GET as a
-requirement of US Core v6.0.0-ballot.
-
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -37,12 +24,9 @@ requirement of US Core v6.0.0-ballot.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          first_search: true,
-        resource_type: 'Condition',
+          resource_type: 'Condition',
         search_param_names: ['patient'],
-        possible_status_search: true,
-        test_reference_variants: true,
-        test_post_search: true
+        possible_status_search: true
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns/condition_problems_health_concerns_provenance_revinclude_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns/condition_problems_health_concerns_provenance_revinclude_search_test.rb
@@ -6,11 +6,11 @@ module USCoreTestKit
     class ConditionProblemsHealthConcernsProvenanceRevincludeSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
-      title 'Server returns Provenance resources from Condition search by patient + revInclude:Provenance:target'
+      title 'Server returns Provenance resources from Condition search by patient + category + revInclude:Provenance:target'
       description %(
         A server SHALL be capable of supporting _revIncludes:Provenance:target.
 
-        This test will perform a search by patient + revInclude:Provenance:target and
+        This test will perform a search by patient + category + revInclude:Provenance:target and
         will pass if a Provenance resource is found in the response.
       %)
 
@@ -22,8 +22,9 @@ module USCoreTestKit
   
       def properties
         @properties ||= SearchTestProperties.new(
-          resource_type: 'Condition',
-        search_param_names: ['patient']
+          fixed_value_search: true,
+        resource_type: 'Condition',
+        search_param_names: ['patient', 'category']
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns/metadata.yml
@@ -31,6 +31,12 @@
   :expectation: MAY
 :operations: []
 :searches:
+- :expectation: SHALL
+  :names:
+  - patient
+  - category
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
 - :names:
   - patient
   :expectation: SHALL
@@ -67,12 +73,6 @@
   :names_not_must_support_or_mandatory:
   - asserted-date
   :must_support_or_mandatory: false
-- :expectation: SHALL
-  :names:
-  - patient
-  - category
-  :names_not_must_support_or_mandatory: []
-  :must_support_or_mandatory: true
 - :expectation: SHOULD
   :names:
   - patient
@@ -318,6 +318,8 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Resource
 :tests:
+- :id: us_core_v600_ballot_condition_problems_health_concerns_patient_category_search_test
+  :file_name: condition_problems_health_concerns_patient_category_search_test.rb
 - :id: us_core_v600_ballot_condition_problems_health_concerns_patient_search_test
   :file_name: condition_problems_health_concerns_patient_search_test.rb
 - :id: us_core_v600_ballot_condition_problems_health_concerns_patient_onset_date_search_test
@@ -330,8 +332,6 @@
   :file_name: condition_problems_health_concerns_patient_recorded_date_search_test.rb
 - :id: us_core_v600_ballot_condition_problems_health_concerns_patient_asserted_date_search_test
   :file_name: condition_problems_health_concerns_patient_asserted_date_search_test.rb
-- :id: us_core_v600_ballot_condition_problems_health_concerns_patient_category_search_test
-  :file_name: condition_problems_health_concerns_patient_category_search_test.rb
 - :id: us_core_v600_ballot_condition_problems_health_concerns_patient_code_search_test
   :file_name: condition_problems_health_concerns_patient_code_search_test.rb
 - :id: us_core_v600_ballot_condition_problems_health_concerns_patient_category_encounter_search_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns_group.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/condition_problems_health_concerns_group.rb
@@ -1,10 +1,10 @@
+require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_category_search_test'
 require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_search_test'
 require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_onset_date_search_test'
 require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_abatement_date_search_test'
 require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_clinical_status_search_test'
 require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_recorded_date_search_test'
 require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_asserted_date_search_test'
-require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_category_search_test'
 require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_code_search_test'
 require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_patient_category_encounter_search_test'
 require_relative 'condition_problems_health_concerns/condition_problems_health_concerns_read_test'
@@ -32,8 +32,8 @@ This test sequence will first perform each required search associated
 with this resource. This sequence will perform searches with the
 following parameters:
 
-* patient
 * patient + category
+* patient
 
 ### Search Parameters
 The first search uses the selected patient(s) from the prior launch
@@ -84,13 +84,13 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'condition_problems_health_concerns', 'metadata.yml'), aliases: true))
       end
   
+      test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_category_search_test
       test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_search_test
       test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_onset_date_search_test
       test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_abatement_date_search_test
       test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_clinical_status_search_test
       test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_recorded_date_search_test
       test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_asserted_date_search_test
-      test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_category_search_test
       test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_code_search_test
       test from: :us_core_v600_ballot_condition_problems_health_concerns_patient_category_encounter_search_test
       test from: :us_core_v600_ballot_condition_problems_health_concerns_read_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/coverage/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/coverage/metadata.yml
@@ -140,3 +140,4 @@
 - :path: payor
   :resources:
   - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/document_reference/metadata.yml
@@ -310,3 +310,4 @@
   - Practitioner
   - Organization
   - PractitionerRole
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/encounter/metadata.yml
@@ -358,6 +358,7 @@
   :resources:
   - Practitioner
   - PractitionerRole
+  - RelatedPerson
 - :path: serviceProvider
   :resources:
   - Organization

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/medication_dispense/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/medication_dispense/metadata.yml
@@ -228,3 +228,4 @@
   - Practitioner
   - Organization
   - PractitionerRole
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/medication_request/metadata.yml
@@ -320,3 +320,4 @@
   - Practitioner
   - Organization
   - PractitionerRole
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
@@ -547,6 +547,7 @@
     - Practitioner
     - Organization
     - PractitionerRole
+    - RelatedPerson
 - :name: us_core_condition_encounter_diagnosis
   :class_name: USCorev600_ballotConditionEncounterDiagnosisSequence
   :version: v6.0.0-ballot
@@ -1297,6 +1298,7 @@
   - :path: payor
     :resources:
     - Organization
+    - RelatedPerson
 - :name: us_core_implantable_device
   :class_name: USCorev600_ballotImplantableDeviceSequence
   :version: v6.0.0-ballot
@@ -2196,6 +2198,7 @@
     - Practitioner
     - Organization
     - PractitionerRole
+    - RelatedPerson
 - :name: us_core_encounter
   :class_name: USCorev600_ballotEncounterSequence
   :version: v6.0.0-ballot
@@ -2524,6 +2527,7 @@
     :resources:
     - Practitioner
     - PractitionerRole
+    - RelatedPerson
   - :path: serviceProvider
     :resources:
     - Organization
@@ -3270,6 +3274,7 @@
     - Practitioner
     - Organization
     - PractitionerRole
+    - RelatedPerson
 - :name: us_core_medicationrequest
   :class_name: USCorev600_ballotMedicationrequestSequence
   :version: v6.0.0-ballot
@@ -3568,6 +3573,7 @@
     - Practitioner
     - Organization
     - PractitionerRole
+    - RelatedPerson
 - :name: us_core_observation_lab
   :class_name: USCorev600_ballotObservationLabSequence
   :version: v6.0.0-ballot
@@ -5035,6 +5041,7 @@
     :resources:
     - Practitioner
     - Organization
+    - RelatedPerson
 - :name: us_core_heart_rate
   :class_name: USCorev600_ballotHeartRateSequence
   :version: v6.0.0-ballot
@@ -7630,6 +7637,7 @@
     :resources:
     - Practitioner
     - Organization
+    - RelatedPerson
 - :name: us_core_blood_pressure
   :class_name: USCorev600_ballotBloodPressureSequence
   :version: v6.0.0-ballot
@@ -10047,6 +10055,7 @@
     - Organization
     - Practitioner
     - PractitionerRole
+    - RelatedPerson
   - :path: agent.onBehalfOf
     :resources:
     - Organization
@@ -10442,6 +10451,7 @@
     :resources:
     - Practitioner
     - Organization
+    - RelatedPerson
 - :name: us_core_specimen
   :class_name: USCorev600_ballotSpecimenSequence
   :version: v6.0.0-ballot

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
@@ -579,6 +579,12 @@
     :expectation: MAY
   :operations: []
   :searches:
+  - :expectation: SHALL
+    :names:
+    - patient
+    - category
+    :names_not_must_support_or_mandatory: []
+    :must_support_or_mandatory: true
   - :names:
     - patient
     :expectation: SHALL
@@ -615,12 +621,6 @@
     :names_not_must_support_or_mandatory:
     - asserted-date
     :must_support_or_mandatory: false
-  - :expectation: SHALL
-    :names:
-    - patient
-    - category
-    :names_not_must_support_or_mandatory: []
-    :must_support_or_mandatory: true
   - :expectation: SHOULD
     :names:
     - patient
@@ -885,6 +885,12 @@
     :expectation: MAY
   :operations: []
   :searches:
+  - :expectation: SHALL
+    :names:
+    - patient
+    - category
+    :names_not_must_support_or_mandatory: []
+    :must_support_or_mandatory: true
   - :names:
     - patient
     :expectation: SHALL
@@ -921,12 +927,6 @@
     :names_not_must_support_or_mandatory:
     - asserted-date
     :must_support_or_mandatory: false
-  - :expectation: SHALL
-    :names:
-    - patient
-    - category
-    :names_not_must_support_or_mandatory: []
-    :must_support_or_mandatory: true
   - :expectation: SHOULD
     :names:
     - patient
@@ -4815,7 +4815,7 @@
   - :expectation: SHALL
     :names:
     - patient
-    - code
+    - category
     :names_not_must_support_or_mandatory: []
     :must_support_or_mandatory: true
   - :expectation: SHALL
@@ -4825,17 +4825,17 @@
     - date
     :names_not_must_support_or_mandatory: []
     :must_support_or_mandatory: true
+  - :expectation: SHALL
+    :names:
+    - patient
+    - code
+    :names_not_must_support_or_mandatory: []
+    :must_support_or_mandatory: true
   - :expectation: SHOULD
     :names:
     - patient
     - category
     - status
-    :names_not_must_support_or_mandatory: []
-    :must_support_or_mandatory: true
-  - :expectation: SHALL
-    :names:
-    - patient
-    - category
     :names_not_must_support_or_mandatory: []
     :must_support_or_mandatory: true
   - :expectation: SHOULD
@@ -7408,7 +7408,7 @@
   - :expectation: SHALL
     :names:
     - patient
-    - code
+    - category
     :names_not_must_support_or_mandatory: []
     :must_support_or_mandatory: true
   - :expectation: SHALL
@@ -7418,17 +7418,17 @@
     - date
     :names_not_must_support_or_mandatory: []
     :must_support_or_mandatory: true
+  - :expectation: SHALL
+    :names:
+    - patient
+    - code
+    :names_not_must_support_or_mandatory: []
+    :must_support_or_mandatory: true
   - :expectation: SHOULD
     :names:
     - patient
     - category
     - status
-    :names_not_must_support_or_mandatory: []
-    :must_support_or_mandatory: true
-  - :expectation: SHALL
-    :names:
-    - patient
-    - category
     :names_not_must_support_or_mandatory: []
     :must_support_or_mandatory: true
   - :expectation: SHOULD
@@ -7945,7 +7945,7 @@
   - :expectation: SHALL
     :names:
     - patient
-    - code
+    - category
     :names_not_must_support_or_mandatory: []
     :must_support_or_mandatory: true
   - :expectation: SHALL
@@ -7955,17 +7955,17 @@
     - date
     :names_not_must_support_or_mandatory: []
     :must_support_or_mandatory: true
+  - :expectation: SHALL
+    :names:
+    - patient
+    - code
+    :names_not_must_support_or_mandatory: []
+    :must_support_or_mandatory: true
   - :expectation: SHOULD
     :names:
     - patient
     - category
     - status
-    :names_not_must_support_or_mandatory: []
-    :must_support_or_mandatory: true
-  - :expectation: SHALL
-    :names:
-    - patient
-    - category
     :names_not_must_support_or_mandatory: []
     :must_support_or_mandatory: true
   - :expectation: SHOULD

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
@@ -9821,6 +9821,10 @@
       - Reference
     - :path: performedDateTime
       :original_path: performed[x]
+    - :path: basedOn
+      :types:
+      - Reference
+      :uscdi_only: true
   :mandatory_elements:
   - Procedure.status
   - Procedure.code

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result/metadata.yml
@@ -34,7 +34,7 @@
 - :expectation: SHALL
   :names:
   - patient
-  - code
+  - category
   :names_not_must_support_or_mandatory: []
   :must_support_or_mandatory: true
 - :expectation: SHALL
@@ -44,17 +44,17 @@
   - date
   :names_not_must_support_or_mandatory: []
   :must_support_or_mandatory: true
+- :expectation: SHALL
+  :names:
+  - patient
+  - code
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
 - :expectation: SHOULD
   :names:
   - patient
   - category
   - status
-  :names_not_must_support_or_mandatory: []
-  :must_support_or_mandatory: true
-- :expectation: SHALL
-  :names:
-  - patient
-  - category
   :names_not_must_support_or_mandatory: []
   :must_support_or_mandatory: true
 - :expectation: SHOULD
@@ -235,14 +235,14 @@
   - http://hl7.org/fhir/StructureDefinition/Observation
   - http://hl7.org/fhir/StructureDefinition/MolecularSequence
 :tests:
-- :id: us_core_v600_ballot_observation_clinical_result_patient_code_search_test
-  :file_name: observation_clinical_result_patient_code_search_test.rb
-- :id: us_core_v600_ballot_observation_clinical_result_patient_category_date_search_test
-  :file_name: observation_clinical_result_patient_category_date_search_test.rb
-- :id: us_core_v600_ballot_observation_clinical_result_patient_category_status_search_test
-  :file_name: observation_clinical_result_patient_category_status_search_test.rb
 - :id: us_core_v600_ballot_observation_clinical_result_patient_category_search_test
   :file_name: observation_clinical_result_patient_category_search_test.rb
+- :id: us_core_v600_ballot_observation_clinical_result_patient_category_date_search_test
+  :file_name: observation_clinical_result_patient_category_date_search_test.rb
+- :id: us_core_v600_ballot_observation_clinical_result_patient_code_search_test
+  :file_name: observation_clinical_result_patient_code_search_test.rb
+- :id: us_core_v600_ballot_observation_clinical_result_patient_category_status_search_test
+  :file_name: observation_clinical_result_patient_category_status_search_test.rb
 - :id: us_core_v600_ballot_observation_clinical_result_patient_code_date_search_test
   :file_name: observation_clinical_result_patient_code_date_search_test.rb
 - :id: us_core_v600_ballot_observation_clinical_result_read_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result/observation_clinical_result_patient_category_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result/observation_clinical_result_patient_category_search_test.rb
@@ -13,6 +13,19 @@ patient + category on the Observation resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
+This test verifies that the server supports searching by reference using
+the form `patient=[id]` as well as `patient=Patient/[id]`. The two
+different forms are expected to return the same number of results. US
+Core requires that both forms are supported by US Core responders.
+
+Because this is the first search of the sequence, resources in the
+response will be used for subsequent tests.
+
+Additionally, this test will check that GET and POST search methods
+return the same number of results. Search by POST is required by the
+FHIR R4 specification, and these tests interpret search by GET as a
+requirement of US Core v6.0.0-ballot.
+
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -24,10 +37,14 @@ none are returned, the test is skipped.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          resource_type: 'Observation',
+          first_search: true,
+        fixed_value_search: true,
+        resource_type: 'Observation',
         search_param_names: ['patient', 'category'],
         possible_status_search: true,
-        token_search_params: ['category']
+        token_search_params: ['category'],
+        test_reference_variants: true,
+        test_post_search: true
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result/observation_clinical_result_patient_code_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result/observation_clinical_result_patient_code_search_test.rb
@@ -13,19 +13,6 @@ patient + code on the Observation resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
-This test verifies that the server supports searching by reference using
-the form `patient=[id]` as well as `patient=Patient/[id]`. The two
-different forms are expected to return the same number of results. US
-Core requires that both forms are supported by US Core responders.
-
-Because this is the first search of the sequence, resources in the
-response will be used for subsequent tests.
-
-Additionally, this test will check that GET and POST search methods
-return the same number of results. Search by POST is required by the
-FHIR R4 specification, and these tests interpret search by GET as a
-requirement of US Core v6.0.0-ballot.
-
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -37,14 +24,10 @@ requirement of US Core v6.0.0-ballot.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          first_search: true,
-        fixed_value_search: true,
-        resource_type: 'Observation',
+          resource_type: 'Observation',
         search_param_names: ['patient', 'code'],
         possible_status_search: true,
-        token_search_params: ['code'],
-        test_reference_variants: true,
-        test_post_search: true
+        token_search_params: ['code']
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result/observation_clinical_result_provenance_revinclude_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result/observation_clinical_result_provenance_revinclude_search_test.rb
@@ -6,11 +6,11 @@ module USCoreTestKit
     class ObservationClinicalResultProvenanceRevincludeSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
-      title 'Server returns Provenance resources from Observation search by patient + code + revInclude:Provenance:target'
+      title 'Server returns Provenance resources from Observation search by patient + category + revInclude:Provenance:target'
       description %(
         A server SHALL be capable of supporting _revIncludes:Provenance:target.
 
-        This test will perform a search by patient + code + revInclude:Provenance:target and
+        This test will perform a search by patient + category + revInclude:Provenance:target and
         will pass if a Provenance resource is found in the response.
       %)
 
@@ -24,7 +24,7 @@ module USCoreTestKit
         @properties ||= SearchTestProperties.new(
           fixed_value_search: true,
         resource_type: 'Observation',
-        search_param_names: ['patient', 'code'],
+        search_param_names: ['patient', 'category'],
         possible_status_search: true
         )
       end

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result_group.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_clinical_result_group.rb
@@ -1,7 +1,7 @@
-require_relative 'observation_clinical_result/observation_clinical_result_patient_code_search_test'
-require_relative 'observation_clinical_result/observation_clinical_result_patient_category_date_search_test'
-require_relative 'observation_clinical_result/observation_clinical_result_patient_category_status_search_test'
 require_relative 'observation_clinical_result/observation_clinical_result_patient_category_search_test'
+require_relative 'observation_clinical_result/observation_clinical_result_patient_category_date_search_test'
+require_relative 'observation_clinical_result/observation_clinical_result_patient_code_search_test'
+require_relative 'observation_clinical_result/observation_clinical_result_patient_category_status_search_test'
 require_relative 'observation_clinical_result/observation_clinical_result_patient_code_date_search_test'
 require_relative 'observation_clinical_result/observation_clinical_result_read_test'
 require_relative 'observation_clinical_result/observation_clinical_result_provenance_revinclude_search_test'
@@ -28,9 +28,9 @@ This test sequence will first perform each required search associated
 with this resource. This sequence will perform searches with the
 following parameters:
 
-* patient + code
-* patient + category + date
 * patient + category
+* patient + category + date
+* patient + code
 
 ### Search Parameters
 The first search uses the selected patient(s) from the prior launch
@@ -81,10 +81,10 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'observation_clinical_result', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v600_ballot_observation_clinical_result_patient_code_search_test
-      test from: :us_core_v600_ballot_observation_clinical_result_patient_category_date_search_test
-      test from: :us_core_v600_ballot_observation_clinical_result_patient_category_status_search_test
       test from: :us_core_v600_ballot_observation_clinical_result_patient_category_search_test
+      test from: :us_core_v600_ballot_observation_clinical_result_patient_category_date_search_test
+      test from: :us_core_v600_ballot_observation_clinical_result_patient_code_search_test
+      test from: :us_core_v600_ballot_observation_clinical_result_patient_category_status_search_test
       test from: :us_core_v600_ballot_observation_clinical_result_patient_code_date_search_test
       test from: :us_core_v600_ballot_observation_clinical_result_read_test
       test from: :us_core_v600_ballot_observation_clinical_result_provenance_revinclude_search_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/metadata.yml
@@ -34,7 +34,7 @@
 - :expectation: SHALL
   :names:
   - patient
-  - code
+  - category
   :names_not_must_support_or_mandatory: []
   :must_support_or_mandatory: true
 - :expectation: SHALL
@@ -44,17 +44,17 @@
   - date
   :names_not_must_support_or_mandatory: []
   :must_support_or_mandatory: true
+- :expectation: SHALL
+  :names:
+  - patient
+  - code
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
 - :expectation: SHOULD
   :names:
   - patient
   - category
   - status
-  :names_not_must_support_or_mandatory: []
-  :must_support_or_mandatory: true
-- :expectation: SHALL
-  :names:
-  - patient
-  - category
   :names_not_must_support_or_mandatory: []
   :must_support_or_mandatory: true
 - :expectation: SHOULD
@@ -253,14 +253,14 @@
   - http://hl7.org/fhir/StructureDefinition/Media
   - http://hl7.org/fhir/StructureDefinition/MolecularSequence
 :tests:
-- :id: us_core_v600_ballot_observation_screening_assessment_patient_code_search_test
-  :file_name: observation_screening_assessment_patient_code_search_test.rb
-- :id: us_core_v600_ballot_observation_screening_assessment_patient_category_date_search_test
-  :file_name: observation_screening_assessment_patient_category_date_search_test.rb
-- :id: us_core_v600_ballot_observation_screening_assessment_patient_category_status_search_test
-  :file_name: observation_screening_assessment_patient_category_status_search_test.rb
 - :id: us_core_v600_ballot_observation_screening_assessment_patient_category_search_test
   :file_name: observation_screening_assessment_patient_category_search_test.rb
+- :id: us_core_v600_ballot_observation_screening_assessment_patient_category_date_search_test
+  :file_name: observation_screening_assessment_patient_category_date_search_test.rb
+- :id: us_core_v600_ballot_observation_screening_assessment_patient_code_search_test
+  :file_name: observation_screening_assessment_patient_code_search_test.rb
+- :id: us_core_v600_ballot_observation_screening_assessment_patient_category_status_search_test
+  :file_name: observation_screening_assessment_patient_category_status_search_test.rb
 - :id: us_core_v600_ballot_observation_screening_assessment_patient_code_date_search_test
   :file_name: observation_screening_assessment_patient_code_date_search_test.rb
 - :id: us_core_v600_ballot_observation_screening_assessment_read_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/metadata.yml
@@ -280,3 +280,4 @@
   :resources:
   - Practitioner
   - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/observation_screening_assessment_patient_category_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/observation_screening_assessment_patient_category_search_test.rb
@@ -13,6 +13,19 @@ patient + category on the Observation resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
+This test verifies that the server supports searching by reference using
+the form `patient=[id]` as well as `patient=Patient/[id]`. The two
+different forms are expected to return the same number of results. US
+Core requires that both forms are supported by US Core responders.
+
+Because this is the first search of the sequence, resources in the
+response will be used for subsequent tests.
+
+Additionally, this test will check that GET and POST search methods
+return the same number of results. Search by POST is required by the
+FHIR R4 specification, and these tests interpret search by GET as a
+requirement of US Core v6.0.0-ballot.
+
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -24,10 +37,15 @@ none are returned, the test is skipped.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          resource_type: 'Observation',
+          first_search: true,
+        fixed_value_search: true,
+        resource_type: 'Observation',
         search_param_names: ['patient', 'category'],
+        saves_delayed_references: true,
         possible_status_search: true,
-        token_search_params: ['category']
+        token_search_params: ['category'],
+        test_reference_variants: true,
+        test_post_search: true
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/observation_screening_assessment_patient_code_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/observation_screening_assessment_patient_code_search_test.rb
@@ -13,19 +13,6 @@ patient + code on the Observation resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
-This test verifies that the server supports searching by reference using
-the form `patient=[id]` as well as `patient=Patient/[id]`. The two
-different forms are expected to return the same number of results. US
-Core requires that both forms are supported by US Core responders.
-
-Because this is the first search of the sequence, resources in the
-response will be used for subsequent tests.
-
-Additionally, this test will check that GET and POST search methods
-return the same number of results. Search by POST is required by the
-FHIR R4 specification, and these tests interpret search by GET as a
-requirement of US Core v6.0.0-ballot.
-
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -37,15 +24,10 @@ requirement of US Core v6.0.0-ballot.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          first_search: true,
-        fixed_value_search: true,
-        resource_type: 'Observation',
+          resource_type: 'Observation',
         search_param_names: ['patient', 'code'],
-        saves_delayed_references: true,
         possible_status_search: true,
-        token_search_params: ['code'],
-        test_reference_variants: true,
-        test_post_search: true
+        token_search_params: ['code']
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/observation_screening_assessment_provenance_revinclude_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/observation_screening_assessment_provenance_revinclude_search_test.rb
@@ -6,11 +6,11 @@ module USCoreTestKit
     class ObservationScreeningAssessmentProvenanceRevincludeSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
-      title 'Server returns Provenance resources from Observation search by patient + code + revInclude:Provenance:target'
+      title 'Server returns Provenance resources from Observation search by patient + category + revInclude:Provenance:target'
       description %(
         A server SHALL be capable of supporting _revIncludes:Provenance:target.
 
-        This test will perform a search by patient + code + revInclude:Provenance:target and
+        This test will perform a search by patient + category + revInclude:Provenance:target and
         will pass if a Provenance resource is found in the response.
       %)
 
@@ -24,7 +24,7 @@ module USCoreTestKit
         @properties ||= SearchTestProperties.new(
           fixed_value_search: true,
         resource_type: 'Observation',
-        search_param_names: ['patient', 'code'],
+        search_param_names: ['patient', 'category'],
         possible_status_search: true
         )
       end

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment_group.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment_group.rb
@@ -1,7 +1,7 @@
-require_relative 'observation_screening_assessment/observation_screening_assessment_patient_code_search_test'
-require_relative 'observation_screening_assessment/observation_screening_assessment_patient_category_date_search_test'
-require_relative 'observation_screening_assessment/observation_screening_assessment_patient_category_status_search_test'
 require_relative 'observation_screening_assessment/observation_screening_assessment_patient_category_search_test'
+require_relative 'observation_screening_assessment/observation_screening_assessment_patient_category_date_search_test'
+require_relative 'observation_screening_assessment/observation_screening_assessment_patient_code_search_test'
+require_relative 'observation_screening_assessment/observation_screening_assessment_patient_category_status_search_test'
 require_relative 'observation_screening_assessment/observation_screening_assessment_patient_code_date_search_test'
 require_relative 'observation_screening_assessment/observation_screening_assessment_read_test'
 require_relative 'observation_screening_assessment/observation_screening_assessment_provenance_revinclude_search_test'
@@ -28,9 +28,9 @@ This test sequence will first perform each required search associated
 with this resource. This sequence will perform searches with the
 following parameters:
 
-* patient + code
-* patient + category + date
 * patient + category
+* patient + category + date
+* patient + code
 
 ### Search Parameters
 The first search uses the selected patient(s) from the prior launch
@@ -81,10 +81,10 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'observation_screening_assessment', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v600_ballot_observation_screening_assessment_patient_code_search_test
-      test from: :us_core_v600_ballot_observation_screening_assessment_patient_category_date_search_test
-      test from: :us_core_v600_ballot_observation_screening_assessment_patient_category_status_search_test
       test from: :us_core_v600_ballot_observation_screening_assessment_patient_category_search_test
+      test from: :us_core_v600_ballot_observation_screening_assessment_patient_category_date_search_test
+      test from: :us_core_v600_ballot_observation_screening_assessment_patient_code_search_test
+      test from: :us_core_v600_ballot_observation_screening_assessment_patient_category_status_search_test
       test from: :us_core_v600_ballot_observation_screening_assessment_patient_code_date_search_test
       test from: :us_core_v600_ballot_observation_screening_assessment_read_test
       test from: :us_core_v600_ballot_observation_screening_assessment_provenance_revinclude_search_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/procedure/metadata.yml
@@ -128,6 +128,10 @@
     - Reference
   - :path: performedDateTime
     :original_path: performed[x]
+  - :path: basedOn
+    :types:
+    - Reference
+    :uscdi_only: true
 :mandatory_elements:
 - Procedure.status
 - Procedure.code

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/procedure/procedure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/procedure/procedure_must_support_test.rb
@@ -16,6 +16,10 @@ module USCoreTestKit
         * Procedure.performedDateTime
         * Procedure.status
         * Procedure.subject
+
+        For ONC USCDI requirements, each Procedure must support the following additional elements:
+
+        * Procedure.basedOn
       )
 
       id :us_core_v600_ballot_procedure_must_support_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/procedure/procedure_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/procedure/procedure_reference_resolution_test.rb
@@ -17,6 +17,7 @@ module USCoreTestKit
 
         Elements which may provide external references include:
 
+        * Procedure.basedOn
         * Procedure.subject
       )
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/provenance/metadata.yml
@@ -155,6 +155,7 @@
   - Organization
   - Practitioner
   - PractitionerRole
+  - RelatedPerson
 - :path: agent.onBehalfOf
   :resources:
   - Organization

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/related_person/metadata.yml
@@ -107,14 +107,14 @@
   :profiles:
   - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :tests:
+- :id: us_core_v600_ballot_related_person_read_test
+  :file_name: related_person_read_test.rb
 - :id: us_core_v600_ballot_related_person_patient_search_test
   :file_name: related_person_patient_search_test.rb
 - :id: us_core_v600_ballot_related_person__id_search_test
   :file_name: related_person_id_search_test.rb
 - :id: us_core_v600_ballot_related_person_name_search_test
   :file_name: related_person_name_search_test.rb
-- :id: us_core_v600_ballot_related_person_read_test
-  :file_name: related_person_read_test.rb
 - :id: us_core_v600_ballot_related_person_provenance_revinclude_search_test
   :file_name: related_person_provenance_revinclude_search_test.rb
 - :id: us_core_v600_ballot_related_person_validation_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/related_person/related_person_read_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/related_person/related_person_read_test.rb
@@ -19,7 +19,7 @@ module USCoreTestKit
       end
 
       run do
-        perform_read_test(all_scratch_resources)
+        perform_read_test(scratch.dig(:references, 'RelatedPerson'))
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/related_person_group.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/related_person_group.rb
@@ -1,7 +1,7 @@
+require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_patient_search_test'
 require_relative 'related_person/related_person_id_search_test'
 require_relative 'related_person/related_person_name_search_test'
-require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_provenance_revinclude_search_test'
 require_relative 'related_person/related_person_validation_test'
 require_relative 'related_person/related_person_must_support_test'
@@ -77,10 +77,10 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'related_person', 'metadata.yml'), aliases: true))
       end
   
+      test from: :us_core_v600_ballot_related_person_read_test
       test from: :us_core_v600_ballot_related_person_patient_search_test
       test from: :us_core_v600_ballot_related_person__id_search_test
       test from: :us_core_v600_ballot_related_person_name_search_test
-      test from: :us_core_v600_ballot_related_person_read_test
       test from: :us_core_v600_ballot_related_person_provenance_revinclude_search_test
       test from: :us_core_v600_ballot_related_person_validation_test
       test from: :us_core_v600_ballot_related_person_must_support_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/service_request/metadata.yml
@@ -310,3 +310,4 @@
   :resources:
   - Practitioner
   - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/metadata.yml
@@ -34,7 +34,7 @@
 - :expectation: SHALL
   :names:
   - patient
-  - code
+  - category
   :names_not_must_support_or_mandatory: []
   :must_support_or_mandatory: true
 - :expectation: SHALL
@@ -44,17 +44,17 @@
   - date
   :names_not_must_support_or_mandatory: []
   :must_support_or_mandatory: true
+- :expectation: SHALL
+  :names:
+  - patient
+  - code
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
 - :expectation: SHOULD
   :names:
   - patient
   - category
   - status
-  :names_not_must_support_or_mandatory: []
-  :must_support_or_mandatory: true
-- :expectation: SHALL
-  :names:
-  - patient
-  - category
   :names_not_must_support_or_mandatory: []
   :must_support_or_mandatory: true
 - :expectation: SHOULD
@@ -251,14 +251,14 @@
   - http://hl7.org/fhir/StructureDefinition/Media
   - http://hl7.org/fhir/StructureDefinition/MolecularSequence
 :tests:
-- :id: us_core_v600_ballot_simple_observation_patient_code_search_test
-  :file_name: simple_observation_patient_code_search_test.rb
-- :id: us_core_v600_ballot_simple_observation_patient_category_date_search_test
-  :file_name: simple_observation_patient_category_date_search_test.rb
-- :id: us_core_v600_ballot_simple_observation_patient_category_status_search_test
-  :file_name: simple_observation_patient_category_status_search_test.rb
 - :id: us_core_v600_ballot_simple_observation_patient_category_search_test
   :file_name: simple_observation_patient_category_search_test.rb
+- :id: us_core_v600_ballot_simple_observation_patient_category_date_search_test
+  :file_name: simple_observation_patient_category_date_search_test.rb
+- :id: us_core_v600_ballot_simple_observation_patient_code_search_test
+  :file_name: simple_observation_patient_code_search_test.rb
+- :id: us_core_v600_ballot_simple_observation_patient_category_status_search_test
+  :file_name: simple_observation_patient_category_status_search_test.rb
 - :id: us_core_v600_ballot_simple_observation_patient_code_date_search_test
   :file_name: simple_observation_patient_code_date_search_test.rb
 - :id: us_core_v600_ballot_simple_observation_read_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/metadata.yml
@@ -278,3 +278,4 @@
   :resources:
   - Practitioner
   - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/simple_observation_patient_category_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/simple_observation_patient_category_search_test.rb
@@ -13,6 +13,19 @@ patient + category on the Observation resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
+This test verifies that the server supports searching by reference using
+the form `patient=[id]` as well as `patient=Patient/[id]`. The two
+different forms are expected to return the same number of results. US
+Core requires that both forms are supported by US Core responders.
+
+Because this is the first search of the sequence, resources in the
+response will be used for subsequent tests.
+
+Additionally, this test will check that GET and POST search methods
+return the same number of results. Search by POST is required by the
+FHIR R4 specification, and these tests interpret search by GET as a
+requirement of US Core v6.0.0-ballot.
+
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -24,10 +37,15 @@ none are returned, the test is skipped.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          resource_type: 'Observation',
+          first_search: true,
+        fixed_value_search: true,
+        resource_type: 'Observation',
         search_param_names: ['patient', 'category'],
+        saves_delayed_references: true,
         possible_status_search: true,
-        token_search_params: ['category']
+        token_search_params: ['category'],
+        test_reference_variants: true,
+        test_post_search: true
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/simple_observation_patient_code_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/simple_observation_patient_code_search_test.rb
@@ -13,19 +13,6 @@ patient + code on the Observation resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
-This test verifies that the server supports searching by reference using
-the form `patient=[id]` as well as `patient=Patient/[id]`. The two
-different forms are expected to return the same number of results. US
-Core requires that both forms are supported by US Core responders.
-
-Because this is the first search of the sequence, resources in the
-response will be used for subsequent tests.
-
-Additionally, this test will check that GET and POST search methods
-return the same number of results. Search by POST is required by the
-FHIR R4 specification, and these tests interpret search by GET as a
-requirement of US Core v6.0.0-ballot.
-
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 
       )
@@ -37,15 +24,10 @@ requirement of US Core v6.0.0-ballot.
   
       def self.properties
         @properties ||= SearchTestProperties.new(
-          first_search: true,
-        fixed_value_search: true,
-        resource_type: 'Observation',
+          resource_type: 'Observation',
         search_param_names: ['patient', 'code'],
-        saves_delayed_references: true,
         possible_status_search: true,
-        token_search_params: ['code'],
-        test_reference_variants: true,
-        test_post_search: true
+        token_search_params: ['code']
         )
       end
 

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/simple_observation_provenance_revinclude_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation/simple_observation_provenance_revinclude_search_test.rb
@@ -6,11 +6,11 @@ module USCoreTestKit
     class SimpleObservationProvenanceRevincludeSearchTest < Inferno::Test
       include USCoreTestKit::SearchTest
 
-      title 'Server returns Provenance resources from Observation search by patient + code + revInclude:Provenance:target'
+      title 'Server returns Provenance resources from Observation search by patient + category + revInclude:Provenance:target'
       description %(
         A server SHALL be capable of supporting _revIncludes:Provenance:target.
 
-        This test will perform a search by patient + code + revInclude:Provenance:target and
+        This test will perform a search by patient + category + revInclude:Provenance:target and
         will pass if a Provenance resource is found in the response.
       %)
 
@@ -24,7 +24,7 @@ module USCoreTestKit
         @properties ||= SearchTestProperties.new(
           fixed_value_search: true,
         resource_type: 'Observation',
-        search_param_names: ['patient', 'code'],
+        search_param_names: ['patient', 'category'],
         possible_status_search: true
         )
       end

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation_group.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/simple_observation_group.rb
@@ -1,7 +1,7 @@
-require_relative 'simple_observation/simple_observation_patient_code_search_test'
-require_relative 'simple_observation/simple_observation_patient_category_date_search_test'
-require_relative 'simple_observation/simple_observation_patient_category_status_search_test'
 require_relative 'simple_observation/simple_observation_patient_category_search_test'
+require_relative 'simple_observation/simple_observation_patient_category_date_search_test'
+require_relative 'simple_observation/simple_observation_patient_code_search_test'
+require_relative 'simple_observation/simple_observation_patient_category_status_search_test'
 require_relative 'simple_observation/simple_observation_patient_code_date_search_test'
 require_relative 'simple_observation/simple_observation_read_test'
 require_relative 'simple_observation/simple_observation_provenance_revinclude_search_test'
@@ -28,9 +28,9 @@ This test sequence will first perform each required search associated
 with this resource. This sequence will perform searches with the
 following parameters:
 
-* patient + code
-* patient + category + date
 * patient + category
+* patient + category + date
+* patient + code
 
 ### Search Parameters
 The first search uses the selected patient(s) from the prior launch
@@ -81,10 +81,10 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'simple_observation', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v600_ballot_simple_observation_patient_code_search_test
-      test from: :us_core_v600_ballot_simple_observation_patient_category_date_search_test
-      test from: :us_core_v600_ballot_simple_observation_patient_category_status_search_test
       test from: :us_core_v600_ballot_simple_observation_patient_category_search_test
+      test from: :us_core_v600_ballot_simple_observation_patient_category_date_search_test
+      test from: :us_core_v600_ballot_simple_observation_patient_code_search_test
+      test from: :us_core_v600_ballot_simple_observation_patient_category_status_search_test
       test from: :us_core_v600_ballot_simple_observation_patient_code_date_search_test
       test from: :us_core_v600_ballot_simple_observation_read_test
       test from: :us_core_v600_ballot_simple_observation_provenance_revinclude_search_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/us_core_test_suite.rb
@@ -42,11 +42,11 @@ require_relative 'pediatric_bmi_for_age_group'
 require_relative 'head_circumference_percentile_group'
 require_relative 'body_weight_group'
 require_relative 'procedure_group'
-require_relative 'related_person_group'
 require_relative 'service_request_group'
 require_relative 'organization_group'
 require_relative 'practitioner_group'
 require_relative 'provenance_group'
+require_relative 'related_person_group'
 require_relative 'specimen_group'
 
 module USCoreTestKit
@@ -148,11 +148,11 @@ module USCoreTestKit
       group from: :us_core_v600_ballot_head_circumference_percentile
       group from: :us_core_v600_ballot_body_weight
       group from: :us_core_v600_ballot_procedure
-      group from: :us_core_v600_ballot_related_person
       group from: :us_core_v600_ballot_service_request
       group from: :us_core_v600_ballot_organization
       group from: :us_core_v600_ballot_practitioner
       group from: :us_core_v600_ballot_provenance
+      group from: :us_core_v600_ballot_related_person
       group from: :us_core_v600_ballot_specimen
       group from: :us_core_v400_clinical_notes_guidance
       group from: :us_core_311_data_absent_reason

--- a/lib/us_core_test_kit/generator/group_metadata.rb
+++ b/lib/us_core_test_kit/generator/group_metadata.rb
@@ -31,12 +31,13 @@ module USCoreTestKit
 
       NON_USCDI_RESOURCES = {
         'Encounter' => ['v311', 'v400'],
-        'Location' => ['v311', 'v400', 'v501'],
-        'Organization' => ['v311', 'v400', 'v501'],
-        'Practitioner' => ['v311', 'v400', 'v501'],
-        'PractitionerRole' => ['v311', 'v400', 'v501'],
-        'Provenance' => ['v311', 'v400', 'v501'],
-        'RelatedPerson' => ['v501']
+        'Location' => ['v311', 'v400', 'v501', 'v600_ballot'],
+        'Organization' => ['v311', 'v400', 'v501', 'v600_ballot'],
+        'Practitioner' => ['v311', 'v400', 'v501', 'v600_ballot'],
+        'PractitionerRole' => ['v311', 'v400', 'v501', 'v600_ballot'],
+        'Provenance' => ['v311', 'v400', 'v501', 'v600_ballot'],
+        'RelatedPerson' => ['v501', 'v600_ballot'],
+        'Specimen' => ['v600_ballot']
       }.freeze
 
 

--- a/lib/us_core_test_kit/generator/group_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/group_metadata_extractor.rb
@@ -95,7 +95,7 @@ module USCoreTestKit
 
       ### BEGIN SPECIAL CASES ###
 
-      CATEGORY_FIRST_PROFILES_VERSION_ALL = [
+      ALL_VERSION_CATEGORY_FIRST_PROFILES = [
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
@@ -110,17 +110,14 @@ module USCoreTestKit
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-simple-observation'
       ]
 
-      CATEGORY_FIRST_PROFILES_VERSION_EXCLUDE = {
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis' => [ 'v501' ],
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns' => [ 'v501' ]
+      VERSION_SPECIFIC_CATEGORY_FIRST_PROFILES = {
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis' => [ 'v600_ballot' ],
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns' => [ 'v600_ballot' ]
       }
 
       def category_first_profile?
-        CATEGORY_FIRST_PROFILES_VERSION_ALL.include?(profile_url) ||
-        (
-          CATEGORY_FIRST_PROFILES_VERSION_EXCLUDE.key?(profile_url) &&
-          !CATEGORY_FIRST_PROFILES_VERSION_EXCLUDE[profile_url].include?(reformatted_version)
-        )
+        ALL_VERSION_CATEGORY_FIRST_PROFILES.include?(profile_url) ||
+        VERSION_SPECIFIC_CATEGORY_FIRST_PROFILES[profile_url]&.include?(reformatted_version)
       end
 
       def first_search_params

--- a/lib/us_core_test_kit/generator/group_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/group_metadata_extractor.rb
@@ -107,8 +107,14 @@ module USCoreTestKit
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-survey'
       ]
 
+      CATEGORY_FIRST_PROFILES_VERSION_EXCLUDE = {
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis' => [ 'v501' ],
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns' => [ 'v501' ]
+      }
+
       def category_first_profile?
-        CATEGORY_FIRST_PROFILES.include?(profile_url)
+        CATEGORY_FIRST_PROFILES.include?(profile_url) ||
+        !CATEGORY_FIRST_PROFILES_VERSION_EXCLUDE[profile_url]&.include?(reformatted_version)
       end
 
       def first_search_params

--- a/lib/us_core_test_kit/generator/group_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/group_metadata_extractor.rb
@@ -95,16 +95,19 @@ module USCoreTestKit
 
       ### BEGIN SPECIAL CASES ###
 
-      CATEGORY_FIRST_PROFILES = [
+      CATEGORY_FIRST_PROFILES_VERSION_ALL = [
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-result',
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-test',
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-imaging',
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-screening-assessment',
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-sdoh-assessment',
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-social-history',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-survey'
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-survey',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-simple-observation'
       ]
 
       CATEGORY_FIRST_PROFILES_VERSION_EXCLUDE = {
@@ -113,8 +116,11 @@ module USCoreTestKit
       }
 
       def category_first_profile?
-        CATEGORY_FIRST_PROFILES.include?(profile_url) ||
-        !CATEGORY_FIRST_PROFILES_VERSION_EXCLUDE[profile_url]&.include?(reformatted_version)
+        CATEGORY_FIRST_PROFILES_VERSION_ALL.include?(profile_url) ||
+        (
+          CATEGORY_FIRST_PROFILES_VERSION_EXCLUDE.key?(profile_url) &&
+          !CATEGORY_FIRST_PROFILES_VERSION_EXCLUDE[profile_url].include?(reformatted_version)
+        )
       end
 
       def first_search_params

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
@@ -48,6 +48,7 @@ module USCoreTestKit
       def add_uscdi_elements
         add_patient_uscdi_elements
         add_medicationrequest_uscdi_elements
+        add_procedure_uscdi_elements
       end
 
       def add_patient_uscdi_elements
@@ -81,6 +82,16 @@ module USCoreTestKit
         must_supports[:elements] << {
           path: 'reasonReference',
           types: [ 'Reference' ],
+          uscdi_only: true
+        }
+      end
+
+      def add_procedure_uscdi_elements
+        return unless profile.type == 'Procedure'
+
+        must_supports[:elements] << {
+          path: 'basedOn',
+          types: ['Reference'],
           uscdi_only: true
         }
       end


### PR DESCRIPTION
# Summary
The PR include these changes:
* Assign category search as the first search for both US Core Category profiles
* Assign category search as the first search for some US Core Obervation profiles
* Fix the Coverage.class name collision issue by using local_class as the path name
* Add Procedure.basedOn as USCDI only elements
* Update delayed resources to match US Core v6

# Testing Guidance

