### PR TITLE
Change Patient's previous address and name test

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -6040,9 +6040,17 @@
     - :path: address.city
     - :path: address.state
     - :path: address.postalCode
-    - :path: address.period
     - :path: communication
     - :path: communication.language
+    :choices:
+    - :paths:
+      - address.period.end
+      - address.use
+      :uscdi_only: true
+    - :paths:
+      - name.period.end
+      - name.use
+      :uscdi_only: true
   :mandatory_elements:
   - Patient.identifier
   - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v3.1.1/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/patient/metadata.yml
@@ -171,9 +171,17 @@
   - :path: address.city
   - :path: address.state
   - :path: address.postalCode
-  - :path: address.period
   - :path: communication
   - :path: communication.language
+  :choices:
+  - :paths:
+    - address.period.end
+    - address.use
+    :uscdi_only: true
+  - :paths:
+    - name.period.end
+    - name.use
+    :uscdi_only: true
 :mandatory_elements:
 - Patient.identifier
 - Patient.identifier.system

--- a/lib/us_core_test_kit/generated/v3.1.1/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/patient/patient_must_support_test.rb
@@ -15,7 +15,6 @@ module USCoreTestKit
         * Patient.address
         * Patient.address.city
         * Patient.address.line
-        * Patient.address.period
         * Patient.address.postalCode
         * Patient.address.state
         * Patient.birthDate
@@ -35,6 +34,11 @@ module USCoreTestKit
         * Patient.telecom.system
         * Patient.telecom.use
         * Patient.telecom.value
+
+        For ONC USCDI requirements, each Patient must support the following additional elements:
+
+        * Patient.address.period.end or Patient.address.use
+        * Patient.name.period.end or Patient.name.use
       )
 
       id :us_core_v311_patient_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -6543,16 +6543,22 @@
     - :path: address.city
     - :path: address.state
     - :path: address.postalCode
-    - :path: address.period
     - :path: communication.language
       :uscdi_only: true
     - :path: name.suffix
       :uscdi_only: true
-    - :path: name.period.end
-      :uscdi_only: true
     - :path: telecom
       :uscdi_only: true
     - :path: communication
+      :uscdi_only: true
+    :choices:
+    - :paths:
+      - address.period.end
+      - address.use
+      :uscdi_only: true
+    - :paths:
+      - name.period.end
+      - name.use
       :uscdi_only: true
   :mandatory_elements:
   - Patient.identifier

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -176,16 +176,22 @@
   - :path: address.city
   - :path: address.state
   - :path: address.postalCode
-  - :path: address.period
   - :path: communication.language
     :uscdi_only: true
   - :path: name.suffix
     :uscdi_only: true
-  - :path: name.period.end
-    :uscdi_only: true
   - :path: telecom
     :uscdi_only: true
   - :path: communication
+    :uscdi_only: true
+  :choices:
+  - :paths:
+    - address.period.end
+    - address.use
+    :uscdi_only: true
+  - :paths:
+    - name.period.end
+    - name.use
     :uscdi_only: true
 :mandatory_elements:
 - Patient.identifier

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/patient_must_support_test.rb
@@ -15,7 +15,6 @@ module USCoreTestKit
         * Patient.address
         * Patient.address.city
         * Patient.address.line
-        * Patient.address.period
         * Patient.address.postalCode
         * Patient.address.state
         * Patient.birthDate
@@ -29,12 +28,13 @@ module USCoreTestKit
 
         For ONC USCDI requirements, each Patient must support the following additional elements:
 
+        * Patient.address.period.end or Patient.address.use
         * Patient.communication
         * Patient.communication.language
         * Patient.extension:birthsex
         * Patient.extension:ethnicity
         * Patient.extension:race
-        * Patient.name.period.end
+        * Patient.name.period.end or Patient.name.use
         * Patient.name.suffix
         * Patient.telecom
         * Patient.telecom.system

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -8780,12 +8780,9 @@
     - :path: address.city
     - :path: address.state
     - :path: address.postalCode
-    - :path: address.period
     - :path: communication.language
       :uscdi_only: true
     - :path: name.suffix
-      :uscdi_only: true
-    - :path: name.period.end
       :uscdi_only: true
     - :path: telecom
       :uscdi_only: true
@@ -8796,6 +8793,15 @@
       :uscdi_only: true
     - :path: name.use
       :fixed_value: old
+      :uscdi_only: true
+    :choices:
+    - :paths:
+      - address.period.end
+      - address.use
+      :uscdi_only: true
+    - :paths:
+      - name.period.end
+      - name.use
       :uscdi_only: true
   :mandatory_elements:
   - Patient.identifier

--- a/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
@@ -179,12 +179,9 @@
   - :path: address.city
   - :path: address.state
   - :path: address.postalCode
-  - :path: address.period
   - :path: communication.language
     :uscdi_only: true
   - :path: name.suffix
-    :uscdi_only: true
-  - :path: name.period.end
     :uscdi_only: true
   - :path: telecom
     :uscdi_only: true
@@ -195,6 +192,15 @@
     :uscdi_only: true
   - :path: name.use
     :fixed_value: old
+    :uscdi_only: true
+  :choices:
+  - :paths:
+    - address.period.end
+    - address.use
+    :uscdi_only: true
+  - :paths:
+    - name.period.end
+    - name.use
     :uscdi_only: true
 :mandatory_elements:
 - Patient.identifier

--- a/lib/us_core_test_kit/generated/v5.0.1/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/patient/patient_must_support_test.rb
@@ -15,7 +15,6 @@ module USCoreTestKit
         * Patient.address
         * Patient.address.city
         * Patient.address.line
-        * Patient.address.period
         * Patient.address.postalCode
         * Patient.address.state
         * Patient.birthDate
@@ -29,16 +28,15 @@ module USCoreTestKit
 
         For ONC USCDI requirements, each Patient must support the following additional elements:
 
-        * Patient.address.use
+        * Patient.address.period.end or Patient.address.use
         * Patient.communication
         * Patient.communication.language
         * Patient.extension:birthsex
         * Patient.extension:ethnicity
         * Patient.extension:genderIdentity
         * Patient.extension:race
-        * Patient.name.period.end
+        * Patient.name.period.end or Patient.name.use
         * Patient.name.suffix
-        * Patient.name.use
         * Patient.telecom
         * Patient.telecom.system
         * Patient.telecom.use

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_3.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_3.rb
@@ -10,6 +10,7 @@ module USCoreTestKit
 
       def handle_special_cases
         add_must_support_choices
+        remove_patient_address_period
         remove_document_reference_custodian
       end
 
@@ -21,9 +22,31 @@ module USCoreTestKit
           choices << { paths: ['udiCarrier.carrierAIDC', 'udiCarrier.carrierHRF'] }
         when 'DocumentReference'
           choices << { paths: ['content.attachment.data', 'content.attachment.url'] }
+        when 'Patient'
+          # FHIR-40299 adds USCDI MustSupport choices for:
+          # * address.period.end and address.use,
+          # * name.period.end and name.use
+          choices << {
+            paths: ['address.period.end', 'address.use'],
+            uscdi_only: true
+          }
+
+          choices << {
+            paths: ['name.period.end', 'name.use'],
+            uscdi_only: true
+          }
         end
 
         must_supports[:choices] = choices if choices.present?
+      end
+
+      # FHIR-40299 removes Patient.address.period from MustSupport,
+      def remove_patient_address_period
+        return unless profile.type == 'Patient'
+
+        must_supports[:elements].delete_if do |element|
+          element[:path] == 'address.period'
+        end
       end
 
       # US Core clarified that server implmentation is not required to support DocumentReference.custodian (FHIR-28393)

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_5.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_5.rb
@@ -17,6 +17,7 @@ module USCoreTestKit
 
       def handle_special_cases
         add_must_support_choices
+        remove_patient_address_period
         add_patient_uscdi_elements
         add_value_set_expansion
         remove_survey_questionnaire_response
@@ -46,6 +47,10 @@ module USCoreTestKit
           must_supports[:choices] ||= []
           must_supports[:choices].concat(more_choices)
         end
+      end
+
+      def remove_patient_address_period
+        us_core_4_extractor.remove_patient_address_period
       end
 
       def add_patient_uscdi_elements


### PR DESCRIPTION
# Summary
This PR fixes GitHub Issue: https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/416

# What changed:
* Remove `address.period` from Patient MustSupport test for US Core v3, v4, and v5
* Add UCDI choices of `address.period.end or address.use` and `name.period.end or name.use` to Patient's MustSupport test for US Core v3, v4, v5

# Notice:
Patient's previous name is not a MustSupport test in US Core v3 Test Suite and it is added to (g)(10) Certification test as a manual attestation. This change adds previous name test back to US Core v3 Test Suite as a USCDI only test. And corresponding manual attestation will be deprecated. If reviewers think such change has negative effects on the whole (g)(10) test group, we could reverse the change for Patient's previous name

# Testing Guidance
Verify that in US Core v3, v4, v5 Test Suit, `address.period` is removed from Patient's MustSupport Test. The choices for previous address and previous name are added into the USCDI only section.
