### PR TITLE
FI-1946 Add target_profiles for Procedure.basedOn MustSupport metadata

### DIFF
--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
@@ -10438,6 +10438,17 @@
       - Reference
       :target_profiles:
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
+    - :path: reasonCode
+      :uscdi_only: true
+    - :path: reasonReference
+      :types:
+      - Reference
+      :uscdi_only: true
+    :choices:
+    - :paths:
+      - reasonCode
+      - reasonReference
+      :uscdi_only: true
   :mandatory_elements:
   - ServiceRequest.status
   - ServiceRequest.intent

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
@@ -7513,10 +7513,6 @@
       - Observation.category
       :comparators: {}
       :values:
-      - sdoh
-      - functional-status
-      - disability-status
-      - cognitive-status
       - survey
       :type: CodeableConcept
       :contains_multiple: true

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
@@ -7513,6 +7513,10 @@
       - Observation.category
       :comparators: {}
       :values:
+      - sdoh
+      - functional-status
+      - disability-status
+      - cognitive-status
       - survey
       :type: CodeableConcept
       :contains_multiple: true

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/metadata.yml
@@ -9898,6 +9898,8 @@
     - :path: basedOn
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest
       :uscdi_only: true
   :mandatory_elements:
   - Procedure.status

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/metadata.yml
@@ -82,6 +82,10 @@
     - Observation.category
     :comparators: {}
     :values:
+    - sdoh
+    - functional-status
+    - disability-status
+    - cognitive-status
     - survey
     :type: CodeableConcept
     :contains_multiple: true

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/observation_screening_assessment/metadata.yml
@@ -82,10 +82,6 @@
     - Observation.category
     :comparators: {}
     :values:
-    - sdoh
-    - functional-status
-    - disability-status
-    - cognitive-status
     - survey
     :type: CodeableConcept
     :contains_multiple: true

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/procedure/metadata.yml
@@ -131,6 +131,8 @@
   - :path: basedOn
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest
     :uscdi_only: true
 :mandatory_elements:
 - Procedure.status

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/service_request/metadata.yml
@@ -202,6 +202,17 @@
     - Reference
     :target_profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
+  - :path: reasonCode
+    :uscdi_only: true
+  - :path: reasonReference
+    :types:
+    - Reference
+    :uscdi_only: true
+  :choices:
+  - :paths:
+    - reasonCode
+    - reasonReference
+    :uscdi_only: true
 :mandatory_elements:
 - ServiceRequest.status
 - ServiceRequest.intent

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/service_request/service_request_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/service_request/service_request_must_support_test.rb
@@ -21,6 +21,10 @@ module USCoreTestKit
         * ServiceRequest.requester
         * ServiceRequest.status
         * ServiceRequest.subject
+
+        For ONC USCDI requirements, each ServiceRequest must support the following additional elements:
+
+        * ServiceRequest.reasonCode or ServiceRequest.reasonReference
       )
 
       id :us_core_v600_ballot_service_request_must_support_test

--- a/lib/us_core_test_kit/generated/v6.0.0-ballot/service_request/service_request_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v6.0.0-ballot/service_request/service_request_reference_resolution_test.rb
@@ -17,6 +17,7 @@ module USCoreTestKit
 
         Elements which may provide external references include:
 
+        * ServiceRequest.reasonReference
         * ServiceRequest.requester
         * ServiceRequest.subject
       )

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
@@ -91,6 +91,7 @@ module USCoreTestKit
         must_supports[:elements] << {
           path: 'basedOn',
           types: ['Reference'],
+          target_profiles: ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest'],
           uscdi_only: true
         }
       end

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
@@ -36,6 +36,11 @@ module USCoreTestKit
             paths: ['reasonCode', 'reasonReference'],
             uscdi_only: true
           }
+        when 'ServiceRequest'
+          more_choices << {
+            paths: ['reasonCode', 'reasonReference'],
+            uscdi_only: true
+          }
         end
 
         if more_choices.present?
@@ -48,6 +53,7 @@ module USCoreTestKit
         add_patient_uscdi_elements
         add_medicationrequest_uscdi_elements
         add_procedure_uscdi_elements
+        add_service_request_uscdi_elements
       end
 
       def add_patient_uscdi_elements
@@ -92,6 +98,20 @@ module USCoreTestKit
           path: 'basedOn',
           types: ['Reference'],
           target_profiles: ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest'],
+          uscdi_only: true
+        }
+      end
+
+      def add_service_request_uscdi_elements
+        return unless profile.type == 'ServiceRequest'
+
+        must_supports[:elements] << {
+          path: 'reasonCode',
+          uscdi_only: true
+        }
+        must_supports[:elements] << {
+          path: 'reasonReference',
+          types: [ 'Reference' ],
           uscdi_only: true
         }
       end


### PR DESCRIPTION
# Summary
Add target_profiles for Procedure.basedOn MustSupport metadata. This is based on the Profile Specific Implementation Guidance:

*The Reason or justification for a referral or consultation is communicated through the [US Core ServiceRequest Profile](http://hl7.org/fhir/us/core/2023Jan/StructureDefinition-us-core-servicerequest.html) which can be linked to the Procedure through the `Procedure.basedOn’ element.

Add ServiceRequest.reasonCode and resonReference as USCDI requirement and MustSupport choice

# Testing Guidance

