### PR TITLE
Updated memory requirements and license year

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ for the US Core Implementation Guide
 ## Instructions
 
 It is highly recommended that you use [Docker](https://www.docker.com/) to run
-these tests:
+these tests.  This test kit requires at least 10 GB of memory are available to Docker.   
 
 - Clone this repo.
 - Run `setup.sh` in this repo.
@@ -21,7 +21,7 @@ Documentation](https://inferno-framework.github.io/inferno-core/getting-started.
 for more information on running Inferno.
 
 ## License
-Copyright 2022 The MITRE Corporation
+Copyright 2023 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the


### PR DESCRIPTION
# Summary
[Ticket # FI-2072](https://oncprojectracking.healthit.gov/support/browse/FI-2072)

Updated README to require 10 GB of available memory for Docker after the validator service encountered a critical OutOfMemory exception when attempting to run the test kit with only 8 GB memory.

Updated to the current year in the license of the README.  

# Testing Guidance
None