### PR TITLE
FI-2212 Fix _include search for MedicationDispense

### DIFF
--- a/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/medication_dispense_patient_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/medication_dispense_patient_search_test.rb
@@ -13,9 +13,9 @@ patient on the MedicationDispense resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
-If any MedicationRequest resources use external references to
+If any MedicationDispense resources use external references to
 Medications, the search will be repeated with
-`_include=MedicationRequest:medication`.
+`_include=MedicationDispense:medication`.
 
 This test verifies that the server supports searching by reference using
 the form `patient=[id]` as well as `patient=Patient/[id]`. The two

--- a/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/medication_dispense_patient_status_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/medication_dispense_patient_status_search_test.rb
@@ -13,9 +13,9 @@ patient + status on the MedicationDispense resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
-If any MedicationRequest resources use external references to
+If any MedicationDispense resources use external references to
 Medications, the search will be repeated with
-`_include=MedicationRequest:medication`.
+`_include=MedicationDispense:medication`.
 
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 

--- a/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/medication_dispense_patient_status_type_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/medication_dispense_patient_status_type_search_test.rb
@@ -13,9 +13,9 @@ patient + status + type on the MedicationDispense resource. This test
 will pass if resources are returned and match the search criteria. If
 none are returned, the test is skipped.
 
-If any MedicationRequest resources use external references to
+If any MedicationDispense resources use external references to
 Medications, the search will be repeated with
-`_include=MedicationRequest:medication`.
+`_include=MedicationDispense:medication`.
 
 [US Core Server CapabilityStatement](http://hl7.org/fhir/us/core//CapabilityStatement-us-core-server.html)
 

--- a/lib/us_core_test_kit/generator/search_test_generator.rb
+++ b/lib/us_core_test_kit/generator/search_test_generator.rb
@@ -257,9 +257,9 @@ module USCoreTestKit
         return '' unless test_medication_inclusion?
 
         <<~MEDICATION_INCLUSION_DESCRIPTION
-        If any MedicationRequest resources use external references to
+        If any #{resource_type} resources use external references to
         Medications, the search will be repeated with
-        `_include=MedicationRequest:medication`.
+        `_include=#{resource_type}:medication`.
         MEDICATION_INCLUSION_DESCRIPTION
       end
 

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -547,7 +547,7 @@ module USCoreTestKit
       end
 
       valid_resource_types = [resource_type, 'OperationOutcome'].concat(additional_resource_types)
-      valid_resource_types << 'Medication' if resource_type == 'MedicationRequest'
+      valid_resource_types << 'Medication' if test_medication_inclusion?
 
       invalid_resource_types =
         resources.reject { |entry| valid_resource_types.include? entry.resourceType }

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -398,7 +398,7 @@ module USCoreTestKit
 
       return if requests_with_external_references.blank?
 
-      search_params = params.merge(_include: 'MedicationRequest:medication')
+      search_params = params.merge(_include: "#{resource_type}:medication")
 
       search_and_check_response(search_params)
 

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -547,7 +547,7 @@ module USCoreTestKit
       end
 
       valid_resource_types = [resource_type, 'OperationOutcome'].concat(additional_resource_types)
-      valid_resource_types << 'Medication' if test_medication_inclusion?
+      valid_resource_types << 'Medication' if ['MedicationRequest', 'MedicationDispense'].include?(resource_type)
 
       invalid_resource_types =
         resources.reject { |entry| valid_resource_types.include? entry.resourceType }


### PR DESCRIPTION
# Summary
This PR fixes GitHub Issue: 
https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/460, and
https://github.com/inferno-framework/us-core-test-kit/issues/131

Change Log:
* Update generator using "resource_type" variable instead of constant "MedicationRequest" in test description.
* Update search_test using "resource_type" variable instead of constant "MedicationRequest" when adding _include search parameter

# Testing Guidance

