### PR TITLE
FI-2240 Fix non-root deployment on US Core

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,21 +1,8 @@
 require 'inferno'
 
-inferno_spec = Bundler.locked_gems.specs.find { |spec| spec.name == 'inferno_core' }
-
-base_path =
-  if inferno_spec.respond_to? :stub
-    inferno_spec.stub.full_gem_path
-  elsif inferno_spec.source.is_a? Bundler::Source::Path
-    inferno_spec.source.path.to_s
-  elsif inferno_spec.source.specs.local_search('inferno_core').present?
-    inferno_spec.source.specs.local_search('inferno_core').first.full_gem_path
-  else
-    raise 'Unable to locate inferno static assets'
-  end
-
-inferno_path = File.join(base_path, 'lib', 'inferno')
-
-use Rack::Static, urls: ['/public'], root: inferno_path
+use Rack::Static,
+    urls: Inferno::Utils::StaticAssets.static_assets_map,
+    root: Inferno::Utils::StaticAssets.inferno_path
 
 Inferno::Application.finalize!
 


### PR DESCRIPTION
# Summary

A change made to the template did not get propogated to the US Core Test Kit that enables users to mount this test kit under non-root.

To replicate, you should be able to follow [these instructions](https://inferno-framework.github.io/inferno-core/deployment/host.html#base-path-configuration) to mount to a non-root path.  Previous to this fix, it would result in a blank page. 

# Testing Guidance

Follow the instructions to mount this to a non-root (e.g. http://localhost/custompath).  After this fix, it should work when you navigate there.  Prior to this fix it will just show a blank page.

