### PR TITLE
FI-2316 Label Reference target profile as MustSupport is there is only one

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,3 +2,4 @@ REDIS_URL=redis://redis:6379/0
 V311_VALIDATOR_URL=http://validator_service:4567
 V400_VALIDATOR_URL=http://validator_service:4567
 V501_VALIDATOR_URL=http://validator_service:4567
+V610_VALIDATOR_URL=http://validator_service:4567

--- a/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/metadata.yml
@@ -82,6 +82,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: reaction
   - :path: reaction.manifestation
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
@@ -180,6 +180,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: component

--- a/lib/us_core_test_kit/generated/v4.0.0/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/bmi/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_height/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_temperature/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_weight/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_plan/metadata.yml
@@ -144,6 +144,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - CarePlan.text
 - CarePlan.text.status

--- a/lib/us_core_test_kit/generated/v4.0.0/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_team/metadata.yml
@@ -75,6 +75,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: participant
   - :path: participant.role
   - :path: participant.member

--- a/lib/us_core_test_kit/generated/v4.0.0/condition/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/condition/metadata.yml
@@ -149,6 +149,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - Condition.category
 - Condition.code

--- a/lib/us_core_test_kit/generated/v4.0.0/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/device/metadata.yml
@@ -82,6 +82,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: distinctIdentifier
 :mandatory_elements:
 - Device.udiCarrier.deviceIdentifier

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/metadata.yml
@@ -161,6 +161,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: issued
@@ -172,6 +174,8 @@
   - :path: result
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
 :mandatory_elements:
 - DiagnosticReport.status
 - DiagnosticReport.category

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/metadata.yml
@@ -155,9 +155,13 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: issued

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
@@ -185,6 +185,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: date
   - :path: author
     :types:
@@ -201,6 +203,8 @@
   - :path: context.encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: context.period
   :choices:
   - :paths:

--- a/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
@@ -176,6 +176,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: participant
   - :path: participant.type
   - :path: participant.period
@@ -200,6 +202,8 @@
   - :path: serviceProvider
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   :choices:
   - :paths:
     - reasonCode

--- a/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
@@ -110,6 +110,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: target
   - :path: target.dueDate
     :original_path: target.due[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/heart_rate/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/immunization/metadata.yml
@@ -105,6 +105,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: occurrenceDateTime
     :original_path: occurrence[x]
   - :path: primarySource

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
@@ -160,9 +160,13 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: authoredOn
   - :path: requester
     :types:

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -84,6 +84,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: reaction
     - :path: reaction.manifestation
   :mandatory_elements:
@@ -280,6 +282,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - CarePlan.text
   - CarePlan.text.status
@@ -469,6 +473,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: participant
     - :path: participant.role
     - :path: participant.member
@@ -666,6 +672,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - Condition.category
   - Condition.code
@@ -790,6 +798,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: distinctIdentifier
   :mandatory_elements:
   - Device.udiCarrier.deviceIdentifier
@@ -992,6 +1002,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: issued
@@ -1003,6 +1015,8 @@
     - :path: result
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
   :mandatory_elements:
   - DiagnosticReport.status
   - DiagnosticReport.category
@@ -1215,9 +1229,13 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: issued
@@ -1473,6 +1491,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: date
     - :path: author
       :types:
@@ -1489,6 +1509,8 @@
     - :path: context.encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: context.period
     :choices:
     - :paths:
@@ -1743,6 +1765,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: participant
     - :path: participant.type
     - :path: participant.period
@@ -1767,6 +1791,8 @@
     - :path: serviceProvider
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     :choices:
     - :paths:
       - reasonCode
@@ -1974,6 +2000,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: target
     - :path: target.dueDate
       :original_path: target.due[x]
@@ -2114,6 +2142,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: occurrenceDateTime
       :original_path: occurrence[x]
     - :path: primarySource
@@ -2288,6 +2318,8 @@
     - :path: managingOrganization
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   :mandatory_elements:
   - Location.name
   - Location.position.longitude
@@ -2542,9 +2574,13 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: authoredOn
     - :path: requester
       :types:
@@ -2799,6 +2835,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -3053,6 +3091,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: component
@@ -3338,6 +3378,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -3595,6 +3637,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -3855,6 +3899,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -4115,6 +4161,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -4375,6 +4423,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -4635,6 +4685,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -4892,6 +4944,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -5150,6 +5204,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -5407,6 +5463,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -5691,6 +5749,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -5978,6 +6038,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -6227,6 +6289,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -6909,9 +6973,13 @@
     - :path: practitioner
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
     - :path: organization
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     - :path: code
     - :path: specialty
     - :path: location
@@ -7090,6 +7158,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: performedDateTime
       :original_path: performed[x]
   :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -7311,6 +7311,8 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     - :path: agent:ProvenanceAuthor.type
     - :path: agent:ProvenanceTransmitter.type
   :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v4.0.0/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/observation_lab/metadata.yml
@@ -155,6 +155,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/procedure/metadata.yml
@@ -126,6 +126,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: performedDateTime
     :original_path: performed[x]
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
@@ -70,6 +70,8 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   - :path: agent:ProvenanceAuthor.type
   - :path: agent:ProvenanceTransmitter.type
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
@@ -197,6 +197,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
@@ -162,6 +162,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/allergy_intolerance/metadata.yml
@@ -82,6 +82,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: reaction
   - :path: reaction.manifestation
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
@@ -180,6 +180,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: component

--- a/lib/us_core_test_kit/generated/v5.0.1/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/bmi/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_height/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_temperature/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_weight/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/care_plan/metadata.yml
@@ -144,6 +144,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - CarePlan.text
 - CarePlan.text.status

--- a/lib/us_core_test_kit/generated/v5.0.1/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/care_team/metadata.yml
@@ -100,6 +100,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: participant
   - :path: participant.role
   - :path: participant.member

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
@@ -252,9 +252,13 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: onsetDateTime
     :original_path: onset[x]
   - :path: abatementDateTime

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
@@ -264,6 +264,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: onsetDateTime
     :original_path: onset[x]
   - :path: abatementDateTime

--- a/lib/us_core_test_kit/generated/v5.0.1/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/device/metadata.yml
@@ -83,6 +83,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - Device.udiCarrier.deviceIdentifier
 - Device.deviceName.name

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_lab/metadata.yml
@@ -161,6 +161,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: issued
@@ -172,6 +174,8 @@
   - :path: result
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
 :mandatory_elements:
 - DiagnosticReport.status
 - DiagnosticReport.category

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
@@ -166,9 +166,13 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: issued

--- a/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
@@ -194,6 +194,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: date
   - :path: author
     :types:
@@ -210,6 +212,8 @@
   - :path: context.encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: context.period
   :choices:
   - :paths:

--- a/lib/us_core_test_kit/generated/v5.0.1/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/encounter/metadata.yml
@@ -208,6 +208,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: participant
   - :path: participant.type
   - :path: participant.period
@@ -233,6 +235,8 @@
   - :path: serviceProvider
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   :choices:
   - :paths:
     - reasonCode

--- a/lib/us_core_test_kit/generated/v5.0.1/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/goal/metadata.yml
@@ -126,6 +126,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: target
   - :path: target.dueDate
     :original_path: target.due[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/heart_rate/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/immunization/metadata.yml
@@ -105,6 +105,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: occurrenceDateTime
     :original_path: occurrence[x]
   - :path: primarySource

--- a/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
@@ -172,9 +172,13 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: authoredOn
   - :path: requester
     :types:

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -9629,6 +9629,8 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     - :path: agent:ProvenanceAuthor.type
     - :path: agent:ProvenanceTransmitter.type
   :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -84,6 +84,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: reaction
     - :path: reaction.manifestation
   :mandatory_elements:
@@ -280,6 +282,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - CarePlan.text
   - CarePlan.text.status
@@ -494,6 +498,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: participant
     - :path: participant.role
     - :path: participant.member
@@ -802,9 +808,13 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: onsetDateTime
       :original_path: onset[x]
     - :path: abatementDateTime
@@ -1120,6 +1130,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: onsetDateTime
       :original_path: onset[x]
     - :path: abatementDateTime
@@ -1260,6 +1272,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - Device.udiCarrier.deviceIdentifier
   - Device.deviceName.name
@@ -1466,9 +1480,13 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: issued
@@ -1708,6 +1726,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: issued
@@ -1719,6 +1739,8 @@
     - :path: result
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
   :mandatory_elements:
   - DiagnosticReport.status
   - DiagnosticReport.category
@@ -1969,6 +1991,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: date
     - :path: author
       :types:
@@ -1985,6 +2009,8 @@
     - :path: context.encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: context.period
     :choices:
     - :paths:
@@ -2268,6 +2294,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: participant
     - :path: participant.type
     - :path: participant.period
@@ -2293,6 +2321,8 @@
     - :path: serviceProvider
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     :choices:
     - :paths:
       - reasonCode
@@ -2518,6 +2548,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: target
     - :path: target.dueDate
       :original_path: target.due[x]
@@ -2658,6 +2690,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: occurrenceDateTime
       :original_path: occurrence[x]
     - :path: primarySource
@@ -2832,6 +2866,8 @@
     - :path: managingOrganization
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   :mandatory_elements:
   - Location.name
   - Location.position.longitude
@@ -3098,9 +3134,13 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: authoredOn
     - :path: requester
       :types:
@@ -3353,6 +3393,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -3637,6 +3679,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: performer
@@ -3899,6 +3943,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -4149,6 +4195,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: performer
@@ -4405,6 +4453,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -4662,6 +4712,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -4922,6 +4974,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -5206,6 +5260,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -5485,6 +5541,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -5709,6 +5767,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
   :mandatory_elements:
@@ -5946,6 +6006,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -6206,6 +6268,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -6466,6 +6530,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -6733,6 +6799,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: component
@@ -7006,6 +7074,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -7696,6 +7766,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -7940,6 +8012,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -8198,6 +8272,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -8455,6 +8531,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
@@ -9214,9 +9292,13 @@
     - :path: practitioner
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
     - :path: organization
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     - :path: code
     - :path: specialty
     - :path: location
@@ -9395,6 +9477,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: performedDateTime
       :original_path: performed[x]
   :mandatory_elements:
@@ -9800,6 +9884,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: authored
     - :path: author
       :types:
@@ -9940,6 +10026,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: relationship
     - :path: name
     - :path: telecom
@@ -10148,6 +10236,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: occurrencePeriod
       :original_path: occurrence[x]
     - :path: authoredOn

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_clinical_test/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_clinical_test/metadata.yml
@@ -616,6 +616,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_imaging/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_imaging/metadata.yml
@@ -155,6 +155,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_lab/metadata.yml
@@ -155,6 +155,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
@@ -210,6 +210,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: performer

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sexual_orientation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sexual_orientation/metadata.yml
@@ -156,6 +156,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
@@ -163,6 +163,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: performer

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/procedure/metadata.yml
@@ -126,6 +126,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: performedDateTime
     :original_path: performed[x]
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
@@ -70,6 +70,8 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   - :path: agent:ProvenanceAuthor.type
   - :path: agent:ProvenanceTransmitter.type
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
@@ -197,6 +197,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
@@ -176,6 +176,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: authored
   - :path: author
     :types:

--- a/lib/us_core_test_kit/generated/v5.0.1/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/related_person/metadata.yml
@@ -74,6 +74,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: relationship
   - :path: name
   - :path: telecom

--- a/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]

--- a/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
@@ -189,6 +189,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: occurrencePeriod
     :original_path: occurrence[x]
   - :path: authoredOn

--- a/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
@@ -162,6 +162,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/allergy_intolerance/metadata.yml
@@ -82,6 +82,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: reaction
   - :path: reaction.manifestation
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
@@ -180,6 +180,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: component

--- a/lib/us_core_test_kit/generated/v6.1.0/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/bmi/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_height/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_temperature/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_weight/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/care_plan/metadata.yml
@@ -144,6 +144,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - CarePlan.text.status
 - CarePlan.text.div

--- a/lib/us_core_test_kit/generated/v6.1.0/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/care_team/metadata.yml
@@ -100,6 +100,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: participant
   - :path: participant.role
   - :path: participant.member

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_encounter_diagnosis/metadata.yml
@@ -259,9 +259,13 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: onsetDateTime
     :original_path: onset[x]
   - :path: abatementDateTime

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_problems_health_concerns/metadata.yml
@@ -278,6 +278,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: onsetDateTime
     :original_path: onset[x]
   - :path: abatementDateTime

--- a/lib/us_core_test_kit/generated/v6.1.0/coverage/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/coverage/metadata.yml
@@ -87,6 +87,8 @@
   - :path: beneficiary
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: relationship
   - :path: period
   - :path: payor

--- a/lib/us_core_test_kit/generated/v6.1.0/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/device/metadata.yml
@@ -104,6 +104,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - Device.udiCarrier.deviceIdentifier
 - Device.deviceName.name

--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_lab/metadata.yml
@@ -161,6 +161,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: issued
@@ -172,6 +174,8 @@
   - :path: result
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
 :mandatory_elements:
 - DiagnosticReport.status
 - DiagnosticReport.category

--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
@@ -166,9 +166,13 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: issued

--- a/lib/us_core_test_kit/generated/v6.1.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/document_reference/metadata.yml
@@ -195,6 +195,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: date
   - :path: author
     :types:
@@ -211,6 +213,8 @@
   - :path: context.encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: context.period
   :choices:
   - :paths:

--- a/lib/us_core_test_kit/generated/v6.1.0/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/encounter/metadata.yml
@@ -208,6 +208,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: participant
   - :path: participant.type
   - :path: participant.period
@@ -233,6 +235,8 @@
   - :path: serviceProvider
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   :choices:
   - :paths:
     - reasonCode

--- a/lib/us_core_test_kit/generated/v6.1.0/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/goal/metadata.yml
@@ -126,6 +126,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: startDate
     :original_path: start[x]
   - :path: target

--- a/lib/us_core_test_kit/generated/v6.1.0/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/head_circumference/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/head_circumference_percentile/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/heart_rate/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/immunization/metadata.yml
@@ -105,6 +105,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: occurrenceDateTime
     :original_path: occurrence[x]
   - :path: primarySource

--- a/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/metadata.yml
@@ -127,6 +127,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: performer
   - :path: performer.actor
     :types:
@@ -137,6 +139,8 @@
   - :path: authorizingPrescription
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest
   - :path: type
   - :path: quantity
   - :path: whenHandedOver

--- a/lib/us_core_test_kit/generated/v6.1.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/medication_request/metadata.yml
@@ -172,9 +172,13 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: encounter
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
   - :path: authoredOn
   - :path: requester
     :types:

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -10246,6 +10246,8 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     - :path: agent:ProvenanceAuthor.type
     - :path: agent:ProvenanceTransmitter.type
   :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -84,6 +84,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: reaction
     - :path: reaction.manifestation
   :mandatory_elements:
@@ -280,6 +282,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - CarePlan.text.status
   - CarePlan.text.div
@@ -493,6 +497,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: participant
     - :path: participant.role
     - :path: participant.member
@@ -807,9 +813,13 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: onsetDateTime
       :original_path: onset[x]
     - :path: abatementDateTime
@@ -1139,6 +1149,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: onsetDateTime
       :original_path: onset[x]
     - :path: abatementDateTime
@@ -1283,6 +1295,8 @@
     - :path: beneficiary
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: relationship
     - :path: period
     - :path: payor
@@ -1448,6 +1462,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - Device.udiCarrier.deviceIdentifier
   - Device.deviceName.name
@@ -1654,9 +1670,13 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: issued
@@ -1895,6 +1915,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: issued
@@ -1906,6 +1928,8 @@
     - :path: result
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
   :mandatory_elements:
   - DiagnosticReport.status
   - DiagnosticReport.category
@@ -2157,6 +2181,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: date
     - :path: author
       :types:
@@ -2173,6 +2199,8 @@
     - :path: context.encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: context.period
     :choices:
     - :paths:
@@ -2456,6 +2484,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: participant
     - :path: participant.type
     - :path: participant.period
@@ -2481,6 +2511,8 @@
     - :path: serviceProvider
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     :choices:
     - :paths:
       - reasonCode
@@ -2706,6 +2738,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: startDate
       :original_path: start[x]
     - :path: target
@@ -2852,6 +2886,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: occurrenceDateTime
       :original_path: occurrence[x]
     - :path: primarySource
@@ -3025,6 +3061,8 @@
     - :path: managingOrganization
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   :mandatory_elements:
   - Location.name
   - Location.position.longitude
@@ -3246,6 +3284,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: performer
     - :path: performer.actor
       :types:
@@ -3256,6 +3296,8 @@
     - :path: authorizingPrescription
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest
     - :path: type
     - :path: quantity
     - :path: whenHandedOver
@@ -3501,9 +3543,13 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: encounter
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter
     - :path: authoredOn
     - :path: requester
       :types:
@@ -3772,6 +3818,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -3783,6 +3831,8 @@
     - :path: specimen
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-specimen
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -4034,6 +4084,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - Observation.status
   - Observation.code
@@ -4278,6 +4330,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - Observation.status
   - Observation.code
@@ -4530,6 +4584,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: component
     - :path: component:industry.code
     - :path: component:industry.value[x]
@@ -4770,6 +4826,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -5041,6 +5099,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: performer
@@ -5299,6 +5359,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -5561,6 +5623,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -5826,6 +5890,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -6121,6 +6187,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -6412,6 +6480,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: valueCodeableConcept
       :original_path: value[x]
   :mandatory_elements:
@@ -6647,6 +6717,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
   :mandatory_elements:
@@ -6884,6 +6956,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -7149,6 +7223,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -7414,6 +7490,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -7672,6 +7750,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: performer
@@ -7949,6 +8029,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: component
@@ -8234,6 +8316,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -8478,6 +8562,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -8741,6 +8827,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -9003,6 +9091,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: valueQuantity
@@ -9815,9 +9905,13 @@
     - :path: practitioner
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner
     - :path: organization
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     - :path: code
     - :path: specialty
     - :path: location
@@ -10000,6 +10094,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: performedDateTime
       :original_path: performed[x]
   :mandatory_elements:
@@ -10371,6 +10467,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: authored
     - :path: author
       :types:
@@ -10531,6 +10629,8 @@
     - :path: patient
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: relationship
     - :path: name
     - :path: telecom
@@ -10745,6 +10845,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: occurrencePeriod
       :original_path: occurrence[x]
     - :path: authoredOn
@@ -10917,6 +11019,8 @@
     - :path: subject
       :types:
       - Reference
+      :target_profiles:
+      - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :mandatory_elements:
   - Specimen.type
   :bindings:

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_clinical_result/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_clinical_result/metadata.yml
@@ -167,6 +167,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_lab/metadata.yml
@@ -155,6 +155,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity
@@ -166,6 +168,8 @@
   - :path: specimen
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-specimen
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/metadata.yml
@@ -185,6 +185,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: component
   - :path: component:industry.code
   - :path: component:industry.value[x]

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancyintent/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancyintent/metadata.yml
@@ -177,6 +177,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - Observation.status
 - Observation.code

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancystatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancystatus/metadata.yml
@@ -177,6 +177,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - Observation.status
 - Observation.code

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_screening_assessment/metadata.yml
@@ -166,6 +166,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: performer

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_sexual_orientation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_sexual_orientation/metadata.yml
@@ -165,6 +165,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v6.1.0/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pediatric_bmi_for_age/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pediatric_weight_for_height/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/procedure/metadata.yml
@@ -130,6 +130,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: performedDateTime
     :original_path: performed[x]
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v6.1.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/provenance/metadata.yml
@@ -70,6 +70,8 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   - :path: agent:ProvenanceAuthor.type
   - :path: agent:ProvenanceTransmitter.type
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
@@ -203,6 +203,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/questionnaire_response/metadata.yml
@@ -142,6 +142,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: authored
   - :path: author
     :types:

--- a/lib/us_core_test_kit/generated/v6.1.0/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/related_person/metadata.yml
@@ -95,6 +95,8 @@
   - :path: patient
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: relationship
   - :path: name
   - :path: telecom

--- a/lib/us_core_test_kit/generated/v6.1.0/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/respiratory_rate/metadata.yml
@@ -170,6 +170,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: valueQuantity

--- a/lib/us_core_test_kit/generated/v6.1.0/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/service_request/metadata.yml
@@ -195,6 +195,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: occurrencePeriod
     :original_path: occurrence[x]
   - :path: authoredOn

--- a/lib/us_core_test_kit/generated/v6.1.0/simple_observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/simple_observation/metadata.yml
@@ -179,6 +179,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: performer

--- a/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/metadata.yml
@@ -156,6 +156,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: valueCodeableConcept
     :original_path: value[x]
 :mandatory_elements:

--- a/lib/us_core_test_kit/generated/v6.1.0/specimen/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/specimen/metadata.yml
@@ -73,6 +73,8 @@
   - :path: subject
     :types:
     - Reference
+    :target_profiles:
+    - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :mandatory_elements:
 - Specimen.type
 :bindings:

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -275,7 +275,6 @@ module USCoreTestKit
               element = FHIR::Element.new(hash)
               target_profiles << type.targetProfile[index] if type_must_support_extension?(element.extension)
             end
-            index += 1
           end
         end
 

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -270,8 +270,7 @@ module USCoreTestKit
         if type.targetProfile&.length == 1
           target_profiles << type.targetProfile.first
         else
-          index = 0
-          type.source_hash['_targetProfile']&.each do |hash|
+          type.source_hash['_targetProfile']&.each_with_index do |hash, index|
             if hash.present?
               element = FHIR::Element.new(hash)
               target_profiles << type.targetProfile[index] if type_must_support_extension?(element.extension)

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -261,7 +261,9 @@ module USCoreTestKit
       end
 
       def handle_type_must_support_target_profiles(type, metadata)
-        return if profile.version == '3.1.1'
+        # US Core 3.1.1 profiles do not have US Core target profiles.
+        # Vital Sign proifles from FHIR R4 (version 4.0.1) do not have US Core target profiles either.
+        return if ['3.1.1', '4.0.1'].include?(profile.version)
 
         target_profiles = []
 

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -264,14 +264,20 @@ module USCoreTestKit
         index = 0
         target_profiles = []
 
-        type.source_hash['_targetProfile']&.each do |hash|
-          if hash.present?
-            element = FHIR::Element.new(hash)
-            target_profiles << type.targetProfile[index] if type_must_support_extension?(element.extension)
+        if type.targetProfile&.length == 1 && profile.version != '3.1.1'
+          target_profiles << type.targetProfile.first
+        else
+          type.source_hash['_targetProfile']&.each do |hash|
+            if hash.present?
+              element = FHIR::Element.new(hash)
+              target_profiles << type.targetProfile[index] if type_must_support_extension?(element.extension)
+            end
+            index += 1
           end
-          index += 1
         end
 
+        # remove target_profile for FHIR Base resource type.
+        target_profiles.delete_if { |reference| reference.start_with?('http://hl7.org/fhir/StructureDefinition')}
         metadata[:target_profiles] = target_profiles if target_profiles.present?
       end
 

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -261,12 +261,14 @@ module USCoreTestKit
       end
 
       def handle_type_must_support_target_profiles(type, metadata)
-        index = 0
+        return if profile.version == '3.1.1'
+
         target_profiles = []
 
-        if type.targetProfile&.length == 1 && profile.version != '3.1.1'
+        if type.targetProfile&.length == 1
           target_profiles << type.targetProfile.first
         else
+          index = 0
           type.source_hash['_targetProfile']&.each do |hash|
             if hash.present?
               element = FHIR::Element.new(hash)

--- a/lib/us_core_test_kit/reference_resolution_test.rb
+++ b/lib/us_core_test_kit/reference_resolution_test.rb
@@ -20,7 +20,7 @@ module USCoreTestKit
         unresolved_references.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |missing, hash|
           hash[missing[:path]] << missing[:target_profile]
         end
-      unresolved_reference_hash.map { |path, profiles| "#{path} element: Reference(#{profiles.join('|')})" unless profiles.first.empty?}" }
+      unresolved_reference_hash.map { |path, profiles| "#{path} element: Reference#{"(#{profiles.join('|')})" unless profiles.first.empty?}" }
     end
 
     def record_resolved_reference(reference, target_profile)

--- a/lib/us_core_test_kit/reference_resolution_test.rb
+++ b/lib/us_core_test_kit/reference_resolution_test.rb
@@ -12,7 +12,7 @@ module USCoreTestKit
 
       pass if unresolved_references(resources).length.zero?
 
-      skip "Could not resolve Must Support references #{unresolved_references_strings.join(', ')}"
+      skip "Could not resolve and validate any Must Support references for #{unresolved_references_strings.join(', ')}"
     end
 
     def unresolved_references_strings
@@ -20,7 +20,7 @@ module USCoreTestKit
         unresolved_references.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |missing, hash|
           hash[missing[:path]] << missing[:target_profile]
         end
-      unresolved_reference_hash.map { |path, profiles| "#{path}#{"(#{profiles.join('|')})" unless profiles.first.empty?}" }
+      unresolved_reference_hash.map { |path, profiles| "#{path} element: Reference(#{profiles.join('|')})" unless profiles.first.empty?}" }
     end
 
     def record_resolved_reference(reference, target_profile)

--- a/spec/us_core/reference_test_spec.rb
+++ b/spec/us_core/reference_test_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
 
         result = run(test_class, url: url)
         expect(result.result).to eq('skip')
-        expect(result.result_message).to include('performer(http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization)')
+        expect(result.result_message).to include('performer element: Reference(http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization)')
       end
     end
 
@@ -314,7 +314,7 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
 
         result = run(test_class, url: url)
         expect(result.result).to eq('skip')
-        expect(result.result_message).to eq('Could not resolve Must Support references encounter(http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter)')
+        expect(result.result_message).to include('Could not resolve and validate any Must Support references for encounter element: Reference(http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter)')
       end
     end
   end

--- a/spec/us_core/reference_test_spec.rb
+++ b/spec/us_core/reference_test_spec.rb
@@ -23,16 +23,16 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
     let(:test_class) do
       Class.new(Inferno::Entities::Test) do
         include USCoreTestKit::ReferenceResolutionTest
-  
+
         fhir_client { url 'https://example.com/fhir' }
       end
     end
-  
+
     let(:test) do
       test_class.new(scratch: {})
     end
     let(:base_url) { 'https://example.com/fhir' }
-    
+
     context 'when the reference has already been resolved' do
       let(:reference_string) { 'Encounter/123' }
       let(:resource) do
@@ -314,7 +314,7 @@ RSpec.describe USCoreTestKit::ReferenceResolutionTest do
 
         result = run(test_class, url: url)
         expect(result.result).to eq('skip')
-        expect(result.result_message).to eq('Could not resolve Must Support references encounter')
+        expect(result.result_message).to eq('Could not resolve Must Support references encounter(http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter)')
       end
     end
   end


### PR DESCRIPTION
# Summary
This fixes https://oncprojectracking.healthit.gov/support/browse/FI-2316

When there is only one target profile for a MustSupport Reference, this profile shall also be treated as MustSupport. This does not affect MustSupport test but enforced reference validation test using the correct profile.

This change exculde US Core v3.1.1 which does not have any target_profile marked, and any FHIR base profiles.

# Testing Guidance

