### PR TITLE
FI-2313 MS Slice Subelement Support

### DIFF
--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -28,21 +28,17 @@ module USCoreTestKit
         end
 
         return elements.find { |el| yield(el) } if block_given?
-
         return elements.first
       end
 
-      
-
       path_segments = path.split(/(?<!hl7)\./)
 
-      segment = path_segments.shift.delete_suffix('[x]').gsub(/^class$/, 'local_class').to_sym
+      segment = path_segments.shift.delete_suffix('[x]').gsub(/^class$/, 'local_class').gsub(/\[x\]:/, ':').to_sym
       no_elements_present =
         elements.none? do |element|
         child = get_next_value(element, segment)
         child.present? || child == false
       end
-
       return nil if no_elements_present
 
       remaining_path = path_segments.join('.')
@@ -54,7 +50,6 @@ module USCoreTestKit
           else
             find_a_value_at(child, remaining_path, include_dar: include_dar)
           end
-
         return element_found if element_found.present? || element_found == false
       end
 
@@ -66,16 +61,85 @@ module USCoreTestKit
       if extension_url.present?
         element.url == extension_url ? element : nil
       elsif property.to_s.include?(':') && !property.to_s.include?('url')
-        #Filter slice for the entry that matches the specific sliceName
-        element_name = property.to_s.split(':')[0].gsub(/^class$/, 'local_class')
-        slice_name = property.to_s.split(':')[1].gsub(/^class$/, 'local_class')
-        slices = element.send(element_name)
-        slices.find {|slice| find_a_value_at(slice, 'type.coding.code') == slice_name}
+        slice = find_slice_via_discriminator(element, property)
+        slice
       else
         element.send(property)
       end
     rescue NoMethodError
       nil
+    end
+
+    def find_slice_via_discriminator(element, property)
+      element_name = property.to_s.split(':')[0].gsub(/^class$/, 'local_class')
+      slice_name = property.to_s.split(':')[1].gsub(/^class$/, 'local_class')
+      if metadata.present?
+        slice_by_name = metadata.must_supports[:slices].find{ |slice| slice[:slice_name] == slice_name }
+        discriminator = slice_by_name[:discriminator]
+        slices = Array.wrap(element.send(element_name))
+        slices.find do |slice|
+          case discriminator[:type]
+          when 'patternCodeableConcept'
+            slice_value = discriminator[:path].present? ? slice.send("#{discriminator[:path]}").coding : slice.coding
+            slice_value.any? { |coding| coding.code == discriminator[:code] && coding.system == discriminator[:system] }
+          when 'patternCoding'
+            slice_value = discriminator[:path].present? ? slice.send(discriminator[:path]) : slice
+            slice_value.code == discriminator[:code] && slice_value.system == discriminator[:system]
+          when 'patternIdentifier'
+            slice.identifier.system == discriminator[:system]
+          when 'value'
+            values = discriminator[:values].map { |value| value.merge(path: value[:path].split('.')) }
+            verify_slice_by_values(slice, values)
+          when 'type'
+            case discriminator[:code]
+            when 'Date'
+              begin
+                Date.parse(slice)
+              rescue ArgumentError
+                false
+              end
+            when 'DateTime'
+              begin
+                DateTime.parse(slice)
+              rescue ArgumentError
+                false
+              end
+            when 'String'
+              slice.is_a? String
+            else
+              slice.is_a? FHIR.const_get(discriminator[:code])
+            end
+          when 'requiredBinding'
+            slice_value = discriminator[:path].present? ? slice.send("#{discriminator[:path]}").coding : slice.coding
+            slice_value {|coding| discriminator[:values].include?(coding.code) }
+          end
+        end
+      else
+        #TODO: Error handling for if this file doesn't have access to metadata for some reason (begin/rescue with StandardError?)
+      end
+    end
+
+    def verify_slice_by_values(element, value_definitions)
+      path_prefixes = value_definitions.map { |value_definition| value_definition[:path].first }.uniq
+      path_prefixes.all? do |path_prefix|
+        value_definitions_for_path =
+          value_definitions
+            .select { |value_definition| value_definition[:path].first == path_prefix }
+            .each { |value_definition| value_definition[:path].shift }
+        find_a_value_at(element, path_prefix) do |el_found|
+          child_element_value_definitions, current_element_value_definitions =
+            value_definitions_for_path.partition { |value_definition| value_definition[:path].present? }
+
+          current_element_values_match =
+            current_element_value_definitions
+              .all? { |value_definition| value_definition[:value] == el_found }
+
+          child_element_values_match =
+            child_element_value_definitions.present? ?
+              verify_slice_by_values(el_found, child_element_value_definitions) : true
+          current_element_values_match && child_element_values_match
+        end
+      end
     end
   end
 end

--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -20,7 +20,7 @@ module USCoreTestKit
       return nil if element.nil?
 
       elements = Array.wrap(element)
-
+      path = (path.include?(':') && !path.include?('url')) ? path.gsub(/:.*\./, '.') : path
       if path.empty?
         unless include_dar
           elements = elements.reject do |el|

--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -33,7 +33,9 @@ module USCoreTestKit
         return elements.first
       end
 
+
       path_segments = path.split(/(?<!hl7)\./)
+
       segment = path_segments.shift.delete_suffix('[x]').gsub(/^class$/, 'local_class').to_sym
 
       no_elements_present =

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyheight/bodyheight_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyheight/bodyheight_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v311_bodyheight_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyheight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyheight/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: subject
@@ -169,11 +171,11 @@
     - Reference
   - :path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v3.1.1/bodytemp/bodytemp_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodytemp/bodytemp_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v311_bodytemp_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/bodytemp/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodytemp/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: subject
@@ -169,11 +171,11 @@
     - Reference
   - :path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyweight/bodyweight_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyweight/bodyweight_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v311_bodyweight_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyweight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyweight/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: subject
@@ -169,11 +171,11 @@
     - Reference
   - :path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v3.1.1/bp/bp_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bp/bp_must_support_test.rb
@@ -23,7 +23,6 @@ module USCoreTestKit
         * Observation.component.value[x]
         * Observation.component:DiastolicBP
         * Observation.component:DiastolicBP.code
-        * Observation.component:DiastolicBP.dataAbsentReason
         * Observation.component:DiastolicBP.value[x]
         * Observation.component:DiastolicBP.value[x].code
         * Observation.component:DiastolicBP.value[x].system
@@ -31,7 +30,6 @@ module USCoreTestKit
         * Observation.component:DiastolicBP.value[x].value
         * Observation.component:SystolicBP
         * Observation.component:SystolicBP.code
-        * Observation.component:SystolicBP.dataAbsentReason
         * Observation.component:SystolicBP.value[x]
         * Observation.component:SystolicBP.value[x].code
         * Observation.component:SystolicBP.value[x].system

--- a/lib/us_core_test_kit/generated/v3.1.1/bp/bp_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/bp/bp_must_support_test.rb
@@ -13,20 +13,30 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.component
         * Observation.component.code
         * Observation.component.value[x]
-        * Observation.component.value[x].code
-        * Observation.component.value[x].system
-        * Observation.component.value[x].unit
-        * Observation.component.value[x].value
         * Observation.component:DiastolicBP
+        * Observation.component:DiastolicBP.code
+        * Observation.component:DiastolicBP.dataAbsentReason
+        * Observation.component:DiastolicBP.value[x]
+        * Observation.component:DiastolicBP.value[x].code
+        * Observation.component:DiastolicBP.value[x].system
+        * Observation.component:DiastolicBP.value[x].unit
+        * Observation.component:DiastolicBP.value[x].value
         * Observation.component:SystolicBP
+        * Observation.component:SystolicBP.code
+        * Observation.component:SystolicBP.dataAbsentReason
+        * Observation.component:SystolicBP.value[x]
+        * Observation.component:SystolicBP.value[x].code
+        * Observation.component:SystolicBP.value[x].system
+        * Observation.component:SystolicBP.value[x].unit
+        * Observation.component:SystolicBP.value[x].value
         * Observation.effective[x]
         * Observation.status
         * Observation.subject

--- a/lib/us_core_test_kit/generated/v3.1.1/bp/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bp/metadata.yml
@@ -195,7 +195,6 @@
     :fixed_value: http://unitsofmeasure.org
   - :path: component:SystolicBP.value[x].code
     :fixed_value: mm[Hg]
-  - :path: component:SystolicBP.dataAbsentReason
   - :path: component:DiastolicBP.code
   - :path: component:DiastolicBP.value[x]
   - :path: component:DiastolicBP.value[x].value
@@ -204,7 +203,6 @@
     :fixed_value: http://unitsofmeasure.org
   - :path: component:DiastolicBP.value[x].code
     :fixed_value: mm[Hg]
-  - :path: component:DiastolicBP.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v3.1.1/bp/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bp/metadata.yml
@@ -141,7 +141,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -150,7 +151,8 @@
         :value: vital-signs
       - :path: coding.system
         :value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.component:SystolicBP
+  - :slice_id: Observation.component:SystolicBP
+    :slice_name: SystolicBP
     :path: component
     :discriminator:
       :type: value
@@ -159,7 +161,8 @@
         :value: 8480-6
       - :path: code.coding.system
         :value: http://loinc.org
-  - :name: Observation.component:DiastolicBP
+  - :slice_id: Observation.component:DiastolicBP
+    :slice_name: DiastolicBP
     :path: component
     :discriminator:
       :type: value
@@ -171,10 +174,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: subject
@@ -182,14 +185,26 @@
     - Reference
   - :path: effective[x]
   - :path: component
-  - :path: component.value[x].system
-    :fixed_value: http://unitsofmeasure.org
-  - :path: component.value[x].code
-    :fixed_value: mm[Hg]
   - :path: component.code
   - :path: component.value[x]
-  - :path: component.value[x].value
-  - :path: component.value[x].unit
+  - :path: component:SystolicBP.code
+  - :path: component:SystolicBP.value[x]
+  - :path: component:SystolicBP.value[x].value
+  - :path: component:SystolicBP.value[x].unit
+  - :path: component:SystolicBP.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:SystolicBP.value[x].code
+    :fixed_value: mm[Hg]
+  - :path: component:SystolicBP.dataAbsentReason
+  - :path: component:DiastolicBP.code
+  - :path: component:DiastolicBP.value[x]
+  - :path: component:DiastolicBP.value[x].value
+  - :path: component:DiastolicBP.value[x].unit
+  - :path: component:DiastolicBP.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:DiastolicBP.value[x].code
+    :fixed_value: mm[Hg]
+  - :path: component:DiastolicBP.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v3.1.1/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/care_plan/metadata.yml
@@ -126,7 +126,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: CarePlan.category:AssessPlan
+  - :slice_id: CarePlan.category:AssessPlan
+    :slice_name: AssessPlan
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/metadata.yml
@@ -146,7 +146,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: DiagnosticReport.category:LaboratorySlice
+  - :slice_id: DiagnosticReport.category:LaboratorySlice
+    :slice_name: LaboratorySlice
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
@@ -104,7 +104,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Goal.target.due[x]:dueDate
+  - :slice_id: Goal.target.due[x]:dueDate
+    :slice_name: dueDate
     :path: target.due[x]
     :discriminator:
       :type: type

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/head_circumference_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v311_head_circumference_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8289-1
@@ -170,11 +172,11 @@
     - Reference
   - :path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v3.1.1/heartrate/heartrate_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/heartrate/heartrate_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v311_heartrate_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/heartrate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/heartrate/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: subject
@@ -169,11 +171,11 @@
     - Reference
   - :path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "/min"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -262,7 +262,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: CarePlan.category:AssessPlan
+    - :slice_id: CarePlan.category:AssessPlan
+      :slice_name: AssessPlan
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -1191,7 +1192,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: DiagnosticReport.category:LaboratorySlice
+    - :slice_id: DiagnosticReport.category:LaboratorySlice
+      :slice_name: LaboratorySlice
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -1922,7 +1924,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Goal.target.due[x]:dueDate
+    - :slice_id: Goal.target.due[x]:dueDate
+      :slice_name: dueDate
       :path: target.due[x]
       :discriminator:
         :type: type
@@ -2778,7 +2781,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueCodeableConcept
+    - :slice_id: Observation.value[x]:valueCodeableConcept
+      :slice_name: valueCodeableConcept
       :path: value[x]
       :discriminator:
         :type: type
@@ -2998,12 +3002,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -3015,10 +3021,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 77606-2
@@ -3027,11 +3033,11 @@
       - Reference
     - :path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -3255,7 +3261,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:Laboratory
+    - :slice_id: Observation.category:Laboratory
+      :slice_name: Laboratory
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -3478,12 +3485,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -3495,10 +3504,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 59576-9
@@ -3507,11 +3516,11 @@
       - Reference
     - :path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -3737,26 +3746,30 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.component:FlowRate
+    - :slice_id: Observation.component:FlowRate
+      :slice_name: FlowRate
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 3151-8
         :system: http://loinc.org
-    - :name: Observation.component:Concentration
+    - :slice_id: Observation.component:Concentration
+      :slice_name: Concentration
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 3150-0
         :system: http://loinc.org
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -3765,7 +3778,8 @@
           :value: vital-signs
         - :path: coding.system
           :value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.code.coding:PulseOx
+    - :slice_id: Observation.code.coding:PulseOx
+      :slice_name: PulseOx
       :path: code.coding
       :discriminator:
         :type: value
@@ -3777,43 +3791,51 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: code.coding
-    - :path: code.coding.system
+    - :path: code.coding:PulseOx.system
       :fixed_value: http://loinc.org
-    - :path: code.coding.code
+    - :path: code.coding:PulseOx.code
       :fixed_value: 59408-5
     - :path: subject
       :types:
       - Reference
     - :path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
     - :path: component
     - :path: component.code
-    - :path: component.code.coding.code
-      :fixed_value: 3151-8
-    - :path: component.value[x].system
-      :fixed_value: http://unitsofmeasure.org
-    - :path: component.value[x].code
-      :fixed_value: L/min
-    - :path: component.code.coding.code
-      :fixed_value: 3150-0
     - :path: component.value[x]
-    - :path: component.value[x].value
-    - :path: component.value[x].unit
-    - :path: component.value[x].code
+    - :path: component:FlowRate.code.coding.code
+      :fixed_value: 3151-8
+    - :path: component:FlowRate.value[x]
+    - :path: component:FlowRate.value[x].value
+    - :path: component:FlowRate.value[x].unit
+    - :path: component:FlowRate.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:FlowRate.value[x].code
+      :fixed_value: L/min
+    - :path: component:FlowRate.dataAbsentReason
+    - :path: component:Concentration.code.coding.code
+      :fixed_value: 3150-0
+    - :path: component:Concentration.value[x]
+    - :path: component:Concentration.value[x].value
+    - :path: component:Concentration.value[x].unit
+    - :path: component:Concentration.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:Concentration.value[x].code
       :fixed_value: "%"
+    - :path: component:Concentration.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -4049,12 +4071,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4066,10 +4090,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8289-1
@@ -4078,11 +4102,11 @@
       - Reference
     - :path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -4307,12 +4331,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4324,10 +4350,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: subject
@@ -4335,11 +4361,11 @@
       - Reference
     - :path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -4570,12 +4596,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4587,10 +4615,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: subject
@@ -4598,11 +4626,11 @@
       - Reference
     - :path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -4833,7 +4861,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4842,7 +4871,8 @@
           :value: vital-signs
         - :path: coding.system
           :value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.component:SystolicBP
+    - :slice_id: Observation.component:SystolicBP
+      :slice_name: SystolicBP
       :path: component
       :discriminator:
         :type: value
@@ -4851,7 +4881,8 @@
           :value: 8480-6
         - :path: code.coding.system
           :value: http://loinc.org
-    - :name: Observation.component:DiastolicBP
+    - :slice_id: Observation.component:DiastolicBP
+      :slice_name: DiastolicBP
       :path: component
       :discriminator:
         :type: value
@@ -4863,10 +4894,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: subject
@@ -4874,14 +4905,26 @@
       - Reference
     - :path: effective[x]
     - :path: component
-    - :path: component.value[x].system
-      :fixed_value: http://unitsofmeasure.org
-    - :path: component.value[x].code
-      :fixed_value: mm[Hg]
     - :path: component.code
     - :path: component.value[x]
-    - :path: component.value[x].value
-    - :path: component.value[x].unit
+    - :path: component:SystolicBP.code
+    - :path: component:SystolicBP.value[x]
+    - :path: component:SystolicBP.value[x].value
+    - :path: component:SystolicBP.value[x].unit
+    - :path: component:SystolicBP.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:SystolicBP.value[x].code
+      :fixed_value: mm[Hg]
+    - :path: component:SystolicBP.dataAbsentReason
+    - :path: component:DiastolicBP.code
+    - :path: component:DiastolicBP.value[x]
+    - :path: component:DiastolicBP.value[x].value
+    - :path: component:DiastolicBP.value[x].unit
+    - :path: component:DiastolicBP.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:DiastolicBP.value[x].code
+      :fixed_value: mm[Hg]
+    - :path: component:DiastolicBP.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -5112,12 +5155,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5129,10 +5174,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: subject
@@ -5140,11 +5185,11 @@
       - Reference
     - :path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -5375,12 +5420,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5392,10 +5439,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: subject
@@ -5403,11 +5450,11 @@
       - Reference
     - :path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "/min"
   :mandatory_elements:
   - Observation.status
@@ -5635,12 +5682,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5652,10 +5701,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: subject
@@ -5663,11 +5712,11 @@
       - Reference
     - :path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "/min"
   :mandatory_elements:
   - Observation.status
@@ -5823,7 +5872,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Organization.identifier:NPI
+    - :slice_id: Organization.identifier:NPI
+      :slice_name: NPI
       :path: identifier
       :discriminator:
         :type: patternIdentifier
@@ -6223,7 +6273,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Practitioner.identifier:NPI
+    - :slice_id: Practitioner.identifier:NPI
+      :slice_name: NPI
       :path: identifier
       :discriminator:
         :type: patternIdentifier
@@ -6644,14 +6695,16 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Provenance.agent:ProvenanceAuthor
+    - :slice_id: Provenance.agent:ProvenanceAuthor
+      :slice_name: ProvenanceAuthor
       :path: agent
       :discriminator:
         :type: patternCodeableConcept
         :path: type
         :code: author
         :system: http://terminology.hl7.org/CodeSystem/provenance-participant-type
-    - :name: Provenance.agent:ProvenanceTransmitter
+    - :slice_id: Provenance.agent:ProvenanceTransmitter
+      :slice_name: ProvenanceTransmitter
       :path: agent
       :discriminator:
         :type: patternCodeableConcept
@@ -6671,9 +6724,9 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
-    - :path: agent.type.coding.code
+    - :path: agent:ProvenanceAuthor.type.coding.code
       :fixed_value: author
-    - :path: agent.type.coding.code
+    - :path: agent:ProvenanceTransmitter.type.coding.code
       :fixed_value: transmitter
   :mandatory_elements:
   - Provenance.target

--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -3825,7 +3825,6 @@
       :fixed_value: http://unitsofmeasure.org
     - :path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component:FlowRate.dataAbsentReason
     - :path: component:Concentration.code.coding.code
       :fixed_value: 3150-0
     - :path: component:Concentration.value[x]
@@ -3835,7 +3834,6 @@
       :fixed_value: http://unitsofmeasure.org
     - :path: component:Concentration.value[x].code
       :fixed_value: "%"
-    - :path: component:Concentration.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -4915,7 +4913,6 @@
       :fixed_value: http://unitsofmeasure.org
     - :path: component:SystolicBP.value[x].code
       :fixed_value: mm[Hg]
-    - :path: component:SystolicBP.dataAbsentReason
     - :path: component:DiastolicBP.code
     - :path: component:DiastolicBP.value[x]
     - :path: component:DiastolicBP.value[x].value
@@ -4924,7 +4921,6 @@
       :fixed_value: http://unitsofmeasure.org
     - :path: component:DiastolicBP.value[x].code
       :fixed_value: mm[Hg]
-    - :path: component:DiastolicBP.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category

--- a/lib/us_core_test_kit/generated/v3.1.1/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/observation_lab/metadata.yml
@@ -140,7 +140,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:Laboratory
+  - :slice_id: Observation.category:Laboratory
+    :slice_name: Laboratory
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v3.1.1/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/organization/metadata.yml
@@ -68,7 +68,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Organization.identifier:NPI
+  - :slice_id: Organization.identifier:NPI
+    :slice_name: NPI
     :path: identifier
     :discriminator:
       :type: patternIdentifier

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 59576-9
@@ -170,11 +172,11 @@
     - Reference
   - :path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/pediatric_bmi_for_age_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/pediatric_bmi_for_age_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v311_pediatric_bmi_for_age_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 77606-2
@@ -170,11 +172,11 @@
     - Reference
   - :path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/pediatric_weight_for_height_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/pediatric_weight_for_height_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v311_pediatric_weight_for_height_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/practitioner/metadata.yml
@@ -68,7 +68,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Practitioner.identifier:NPI
+  - :slice_id: Practitioner.identifier:NPI
+    :slice_name: NPI
     :path: identifier
     :discriminator:
       :type: patternIdentifier

--- a/lib/us_core_test_kit/generated/v3.1.1/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/provenance/metadata.yml
@@ -38,14 +38,16 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Provenance.agent:ProvenanceAuthor
+  - :slice_id: Provenance.agent:ProvenanceAuthor
+    :slice_name: ProvenanceAuthor
     :path: agent
     :discriminator:
       :type: patternCodeableConcept
       :path: type
       :code: author
       :system: http://terminology.hl7.org/CodeSystem/provenance-participant-type
-  - :name: Provenance.agent:ProvenanceTransmitter
+  - :slice_id: Provenance.agent:ProvenanceTransmitter
+    :slice_name: ProvenanceTransmitter
     :path: agent
     :discriminator:
       :type: patternCodeableConcept
@@ -65,9 +67,9 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
-  - :path: agent.type.coding.code
+  - :path: agent:ProvenanceAuthor.type.coding.code
     :fixed_value: author
-  - :path: agent.type.coding.code
+  - :path: agent:ProvenanceTransmitter.type.coding.code
     :fixed_value: transmitter
 :mandatory_elements:
 - Provenance.target

--- a/lib/us_core_test_kit/generated/v3.1.1/provenance/provenance_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/provenance/provenance_must_support_test.rb
@@ -15,10 +15,11 @@ module USCoreTestKit
         * Provenance.agent
         * Provenance.agent.onBehalfOf
         * Provenance.agent.type
-        * Provenance.agent.type.coding.code
         * Provenance.agent.who
         * Provenance.agent:ProvenanceAuthor
+        * Provenance.agent:ProvenanceAuthor.type.coding.code
         * Provenance.agent:ProvenanceTransmitter
+        * Provenance.agent:ProvenanceTransmitter.type.coding.code
         * Provenance.recorded
         * Provenance.target
       )

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
@@ -221,7 +221,6 @@
     :fixed_value: http://unitsofmeasure.org
   - :path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component:FlowRate.dataAbsentReason
   - :path: component:Concentration.code.coding.code
     :fixed_value: 3150-0
   - :path: component:Concentration.value[x]
@@ -231,7 +230,6 @@
     :fixed_value: http://unitsofmeasure.org
   - :path: component:Concentration.value[x].code
     :fixed_value: "%"
-  - :path: component:Concentration.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
@@ -142,26 +142,30 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.component:FlowRate
+  - :slice_id: Observation.component:FlowRate
+    :slice_name: FlowRate
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 3151-8
       :system: http://loinc.org
-  - :name: Observation.component:Concentration
+  - :slice_id: Observation.component:Concentration
+    :slice_name: Concentration
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 3150-0
       :system: http://loinc.org
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -170,7 +174,8 @@
         :value: vital-signs
       - :path: coding.system
         :value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.code.coding:PulseOx
+  - :slice_id: Observation.code.coding:PulseOx
+    :slice_name: PulseOx
     :path: code.coding
     :discriminator:
       :type: value
@@ -182,43 +187,51 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: code.coding
-  - :path: code.coding.system
+  - :path: code.coding:PulseOx.system
     :fixed_value: http://loinc.org
-  - :path: code.coding.code
+  - :path: code.coding:PulseOx.code
     :fixed_value: 59408-5
   - :path: subject
     :types:
     - Reference
   - :path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
   - :path: component
   - :path: component.code
-  - :path: component.code.coding.code
-    :fixed_value: 3151-8
-  - :path: component.value[x].system
-    :fixed_value: http://unitsofmeasure.org
-  - :path: component.value[x].code
-    :fixed_value: L/min
-  - :path: component.code.coding.code
-    :fixed_value: 3150-0
   - :path: component.value[x]
-  - :path: component.value[x].value
-  - :path: component.value[x].unit
-  - :path: component.value[x].code
+  - :path: component:FlowRate.code.coding.code
+    :fixed_value: 3151-8
+  - :path: component:FlowRate.value[x]
+  - :path: component:FlowRate.value[x].value
+  - :path: component:FlowRate.value[x].unit
+  - :path: component:FlowRate.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:FlowRate.value[x].code
+    :fixed_value: L/min
+  - :path: component:FlowRate.dataAbsentReason
+  - :path: component:Concentration.code.coding.code
+    :fixed_value: 3150-0
+  - :path: component:Concentration.value[x]
+  - :path: component:Concentration.value[x].value
+  - :path: component:Concentration.value[x].unit
+  - :path: component:Concentration.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:Concentration.value[x].code
     :fixed_value: "%"
+  - :path: component:Concentration.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -27,7 +27,6 @@ module USCoreTestKit
         * Observation.component.value[x]
         * Observation.component:Concentration
         * Observation.component:Concentration.code.coding.code
-        * Observation.component:Concentration.dataAbsentReason
         * Observation.component:Concentration.value[x]
         * Observation.component:Concentration.value[x].code
         * Observation.component:Concentration.value[x].system
@@ -35,7 +34,6 @@ module USCoreTestKit
         * Observation.component:Concentration.value[x].value
         * Observation.component:FlowRate
         * Observation.component:FlowRate.code.coding.code
-        * Observation.component:FlowRate.dataAbsentReason
         * Observation.component:FlowRate.value[x]
         * Observation.component:FlowRate.value[x].code
         * Observation.component:FlowRate.value[x].system

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -13,34 +13,43 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.code.coding
-        * Observation.code.coding.code
-        * Observation.code.coding.system
         * Observation.code.coding:PulseOx
+        * Observation.code.coding:PulseOx.code
+        * Observation.code.coding:PulseOx.system
         * Observation.component
         * Observation.component.code
-        * Observation.component.code.coding.code
         * Observation.component.value[x]
-        * Observation.component.value[x].code
-        * Observation.component.value[x].system
-        * Observation.component.value[x].unit
-        * Observation.component.value[x].value
         * Observation.component:Concentration
+        * Observation.component:Concentration.code.coding.code
+        * Observation.component:Concentration.dataAbsentReason
+        * Observation.component:Concentration.value[x]
+        * Observation.component:Concentration.value[x].code
+        * Observation.component:Concentration.value[x].system
+        * Observation.component:Concentration.value[x].unit
+        * Observation.component:Concentration.value[x].value
         * Observation.component:FlowRate
+        * Observation.component:FlowRate.code.coding.code
+        * Observation.component:FlowRate.dataAbsentReason
+        * Observation.component:FlowRate.value[x]
+        * Observation.component:FlowRate.value[x].code
+        * Observation.component:FlowRate.value[x].system
+        * Observation.component:FlowRate.value[x].unit
+        * Observation.component:FlowRate.value[x].value
         * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v311_pulse_oximetry_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/resprate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/resprate/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: subject
@@ -169,11 +171,11 @@
     - Reference
   - :path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "/min"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v3.1.1/resprate/resprate_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/resprate/resprate_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v311_resprate_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/metadata.yml
@@ -139,7 +139,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueCodeableConcept
+  - :slice_id: Observation.value[x]:valueCodeableConcept
+    :slice_name: valueCodeableConcept
     :path: value[x]
     :discriminator:
       :type: type

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_must_support_test.rb
@@ -13,21 +13,30 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.component
         * Observation.component.code
-        * Observation.component.code.coding.code
         * Observation.component.valueQuantity
-        * Observation.component.valueQuantity.code
-        * Observation.component.valueQuantity.system
-        * Observation.component.valueQuantity.unit
-        * Observation.component.valueQuantity.value
         * Observation.component:diastolic
+        * Observation.component:diastolic.code.coding.code
+        * Observation.component:diastolic.dataAbsentReason
+        * Observation.component:diastolic.valueQuantity
+        * Observation.component:diastolic.valueQuantity.code
+        * Observation.component:diastolic.valueQuantity.system
+        * Observation.component:diastolic.valueQuantity.unit
+        * Observation.component:diastolic.valueQuantity.value
         * Observation.component:systolic
+        * Observation.component:systolic.code.coding.code
+        * Observation.component:systolic.dataAbsentReason
+        * Observation.component:systolic.valueQuantity
+        * Observation.component:systolic.valueQuantity.code
+        * Observation.component:systolic.valueQuantity.system
+        * Observation.component:systolic.valueQuantity.unit
+        * Observation.component:systolic.valueQuantity.value
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_must_support_test.rb
@@ -23,7 +23,6 @@ module USCoreTestKit
         * Observation.component.valueQuantity
         * Observation.component:diastolic
         * Observation.component:diastolic.code.coding.code
-        * Observation.component:diastolic.dataAbsentReason
         * Observation.component:diastolic.valueQuantity
         * Observation.component:diastolic.valueQuantity.code
         * Observation.component:diastolic.valueQuantity.system
@@ -31,7 +30,6 @@ module USCoreTestKit
         * Observation.component:diastolic.valueQuantity.value
         * Observation.component:systolic
         * Observation.component:systolic.code.coding.code
-        * Observation.component:systolic.dataAbsentReason
         * Observation.component:systolic.valueQuantity
         * Observation.component:systolic.valueQuantity.code
         * Observation.component:systolic.valueQuantity.system

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
@@ -141,21 +141,24 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.component:systolic
+  - :slice_id: Observation.component:systolic
+    :slice_name: systolic
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 8480-6
       :system: http://loinc.org
-  - :name: Observation.component:diastolic
+  - :slice_id: Observation.component:diastolic
+    :slice_name: diastolic
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 8462-4
       :system: http://loinc.org
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -167,10 +170,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 85354-9
@@ -181,22 +184,38 @@
     :original_path: effective[x]
   - :path: component
   - :path: component.code
-  - :path: component.code.coding.code
-    :fixed_value: 8480-6
-  - :path: component.valueQuantity.system
-    :original_path: component.value[x].system
-    :fixed_value: http://unitsofmeasure.org
-  - :path: component.valueQuantity.code
-    :original_path: component.value[x].code
-    :fixed_value: mm[Hg]
-  - :path: component.code.coding.code
-    :fixed_value: 8462-4
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component.valueQuantity.value
-    :original_path: component.value[x].value
-  - :path: component.valueQuantity.unit
-    :original_path: component.value[x].unit
+  - :path: component:systolic.code.coding.code
+    :fixed_value: 8480-6
+  - :path: component:systolic.valueQuantity
+    :original_path: component:systolic.value[x]
+  - :path: component:systolic.valueQuantity.value
+    :original_path: component:systolic.value[x].value
+  - :path: component:systolic.valueQuantity.unit
+    :original_path: component:systolic.value[x].unit
+  - :path: component:systolic.valueQuantity.system
+    :original_path: component:systolic.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:systolic.valueQuantity.code
+    :original_path: component:systolic.value[x].code
+    :fixed_value: mm[Hg]
+  - :path: component:systolic.dataAbsentReason
+  - :path: component:diastolic.code.coding.code
+    :fixed_value: 8462-4
+  - :path: component:diastolic.valueQuantity
+    :original_path: component:diastolic.value[x]
+  - :path: component:diastolic.valueQuantity.value
+    :original_path: component:diastolic.value[x].value
+  - :path: component:diastolic.valueQuantity.unit
+    :original_path: component:diastolic.value[x].unit
+  - :path: component:diastolic.valueQuantity.system
+    :original_path: component:diastolic.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:diastolic.valueQuantity.code
+    :original_path: component:diastolic.value[x].code
+    :fixed_value: mm[Hg]
+  - :path: component:diastolic.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
@@ -200,7 +200,6 @@
   - :path: component:systolic.valueQuantity.code
     :original_path: component:systolic.value[x].code
     :fixed_value: mm[Hg]
-  - :path: component:systolic.dataAbsentReason
   - :path: component:diastolic.code.coding.code
     :fixed_value: 8462-4
   - :path: component:diastolic.valueQuantity
@@ -215,7 +214,6 @@
   - :path: component:diastolic.valueQuantity.code
     :original_path: component:diastolic.value[x].code
     :fixed_value: mm[Hg]
-  - :path: component:diastolic.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v4.0.0/bmi/bmi_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/bmi/bmi_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_bmi_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/bmi/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 39156-5
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: kg/m2
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v4.0.0/body_height/body_height_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_height/body_height_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_body_height_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_height/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8302-2
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v4.0.0/body_temperature/body_temperature_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_temperature/body_temperature_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_body_temperature_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_temperature/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8310-5
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v4.0.0/body_weight/body_weight_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_weight/body_weight_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_body_weight_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_weight/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 29463-7
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v4.0.0/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_plan/metadata.yml
@@ -126,7 +126,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: CarePlan.category:AssessPlan
+  - :slice_id: CarePlan.category:AssessPlan
+    :slice_name: AssessPlan
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/metadata.yml
@@ -146,7 +146,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: DiagnosticReport.category:LaboratorySlice
+  - :slice_id: DiagnosticReport.category:LaboratorySlice
+    :slice_name: LaboratorySlice
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference/head_circumference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference/head_circumference_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_head_circumference_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 9843-4
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/head_circumference_percentile_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/head_circumference_percentile_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_head_circumference_percentile_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8289-1
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v4.0.0/heart_rate/heart_rate_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/heart_rate/heart_rate_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_heart_rate_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/heart_rate/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8867-4
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "/min"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -3073,7 +3073,6 @@
     - :path: component:systolic.valueQuantity.code
       :original_path: component:systolic.value[x].code
       :fixed_value: mm[Hg]
-    - :path: component:systolic.dataAbsentReason
     - :path: component:diastolic.code.coding.code
       :fixed_value: 8462-4
     - :path: component:diastolic.valueQuantity
@@ -3088,7 +3087,6 @@
     - :path: component:diastolic.valueQuantity.code
       :original_path: component:diastolic.value[x].code
       :fixed_value: mm[Hg]
-    - :path: component:diastolic.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -5717,7 +5715,6 @@
     - :path: component:FlowRate.valueQuantity.code
       :original_path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component:FlowRate.dataAbsentReason
     - :path: component:Concentration.code.coding.code
       :fixed_value: 3150-0
     - :path: component:Concentration.valueQuantity
@@ -5732,7 +5729,6 @@
     - :path: component:Concentration.valueQuantity.code
       :original_path: component:Concentration.value[x].code
       :fixed_value: "%"
-    - :path: component:Concentration.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -262,7 +262,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: CarePlan.category:AssessPlan
+    - :slice_id: CarePlan.category:AssessPlan
+      :slice_name: AssessPlan
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -976,7 +977,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: DiagnosticReport.category:LaboratorySlice
+    - :slice_id: DiagnosticReport.category:LaboratorySlice
+      :slice_name: LaboratorySlice
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -2782,7 +2784,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:Laboratory
+    - :slice_id: Observation.category:Laboratory
+      :slice_name: Laboratory
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -3011,21 +3014,24 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.component:systolic
+    - :slice_id: Observation.component:systolic
+      :slice_name: systolic
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 8480-6
         :system: http://loinc.org
-    - :name: Observation.component:diastolic
+    - :slice_id: Observation.component:diastolic
+      :slice_name: diastolic
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 8462-4
         :system: http://loinc.org
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -3037,10 +3043,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 85354-9
@@ -3051,22 +3057,38 @@
       :original_path: effective[x]
     - :path: component
     - :path: component.code
-    - :path: component.code.coding.code
-      :fixed_value: 8480-6
-    - :path: component.valueQuantity.system
-      :original_path: component.value[x].system
-      :fixed_value: http://unitsofmeasure.org
-    - :path: component.valueQuantity.code
-      :original_path: component.value[x].code
-      :fixed_value: mm[Hg]
-    - :path: component.code.coding.code
-      :fixed_value: 8462-4
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component.valueQuantity.value
-      :original_path: component.value[x].value
-    - :path: component.valueQuantity.unit
-      :original_path: component.value[x].unit
+    - :path: component:systolic.code.coding.code
+      :fixed_value: 8480-6
+    - :path: component:systolic.valueQuantity
+      :original_path: component:systolic.value[x]
+    - :path: component:systolic.valueQuantity.value
+      :original_path: component:systolic.value[x].value
+    - :path: component:systolic.valueQuantity.unit
+      :original_path: component:systolic.value[x].unit
+    - :path: component:systolic.valueQuantity.system
+      :original_path: component:systolic.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:systolic.valueQuantity.code
+      :original_path: component:systolic.value[x].code
+      :fixed_value: mm[Hg]
+    - :path: component:systolic.dataAbsentReason
+    - :path: component:diastolic.code.coding.code
+      :fixed_value: 8462-4
+    - :path: component:diastolic.valueQuantity
+      :original_path: component:diastolic.value[x]
+    - :path: component:diastolic.valueQuantity.value
+      :original_path: component:diastolic.value[x].value
+    - :path: component:diastolic.valueQuantity.unit
+      :original_path: component:diastolic.value[x].unit
+    - :path: component:diastolic.valueQuantity.system
+      :original_path: component:diastolic.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:diastolic.valueQuantity.code
+      :original_path: component:diastolic.value[x].code
+      :fixed_value: mm[Hg]
+    - :path: component:diastolic.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -3291,12 +3313,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -3308,10 +3332,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 39156-5
@@ -3321,11 +3345,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: kg/m2
   :mandatory_elements:
   - Observation.status
@@ -3546,12 +3570,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -3563,10 +3589,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 9843-4
@@ -3576,11 +3602,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -3804,12 +3830,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -3821,10 +3849,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8302-2
@@ -3834,11 +3862,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -4062,12 +4090,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4079,10 +4109,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 29463-7
@@ -4092,11 +4122,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -4320,12 +4350,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4337,10 +4369,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8310-5
@@ -4350,11 +4382,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -4578,12 +4610,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4595,10 +4629,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8867-4
@@ -4608,11 +4642,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "/min"
   :mandatory_elements:
   - Observation.status
@@ -4833,12 +4867,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4850,10 +4886,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 59576-9
@@ -4863,11 +4899,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -5089,12 +5125,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5106,10 +5144,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8289-1
@@ -5119,11 +5157,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -5344,12 +5382,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5361,10 +5401,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 77606-2
@@ -5374,11 +5414,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -5600,35 +5640,40 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.code.coding:PulseOx
+    - :slice_id: Observation.code.coding:PulseOx
+      :slice_name: PulseOx
       :path: code.coding
       :discriminator:
         :type: patternCoding
         :path: ''
         :code: 59408-5
         :system: http://loinc.org
-    - :name: Observation.code.coding:O2Sat
+    - :slice_id: Observation.code.coding:O2Sat
+      :slice_name: O2Sat
       :path: code.coding
       :discriminator:
         :type: patternCoding
         :path: ''
         :code: 2708-6
         :system: http://loinc.org
-    - :name: Observation.component:FlowRate
+    - :slice_id: Observation.component:FlowRate
+      :slice_name: FlowRate
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 3151-8
         :system: http://loinc.org
-    - :name: Observation.component:Concentration
+    - :slice_id: Observation.component:Concentration
+      :slice_name: Concentration
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 3150-0
         :system: http://loinc.org
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5640,10 +5685,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: code.coding
@@ -5658,23 +5703,36 @@
     - :path: component.code
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component.code.coding.code
+    - :path: component:FlowRate.code.coding.code
       :fixed_value: 3151-8
-    - :path: component.valueQuantity.system
-      :original_path: component.value[x].system
+    - :path: component:FlowRate.valueQuantity
+      :original_path: component:FlowRate.value[x]
+    - :path: component:FlowRate.valueQuantity.value
+      :original_path: component:FlowRate.value[x].value
+    - :path: component:FlowRate.valueQuantity.unit
+      :original_path: component:FlowRate.value[x].unit
+    - :path: component:FlowRate.valueQuantity.system
+      :original_path: component:FlowRate.value[x].system
       :fixed_value: http://unitsofmeasure.org
-    - :path: component.valueQuantity.code
-      :original_path: component.value[x].code
+    - :path: component:FlowRate.valueQuantity.code
+      :original_path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component.code.coding.code
+    - :path: component:FlowRate.dataAbsentReason
+    - :path: component:Concentration.code.coding.code
       :fixed_value: 3150-0
-    - :path: component.valueQuantity.value
-      :original_path: component.value[x].value
-    - :path: component.valueQuantity.unit
-      :original_path: component.value[x].unit
-    - :path: component.valueQuantity.code
-      :original_path: component.value[x].code
+    - :path: component:Concentration.valueQuantity
+      :original_path: component:Concentration.value[x]
+    - :path: component:Concentration.valueQuantity.value
+      :original_path: component:Concentration.value[x].value
+    - :path: component:Concentration.valueQuantity.unit
+      :original_path: component:Concentration.value[x].unit
+    - :path: component:Concentration.valueQuantity.system
+      :original_path: component:Concentration.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:Concentration.valueQuantity.code
+      :original_path: component:Concentration.value[x].code
       :fixed_value: "%"
+    - :path: component:Concentration.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -5899,12 +5957,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5916,10 +5976,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 9279-1
@@ -5929,11 +5989,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "/min"
   :mandatory_elements:
   - Observation.status
@@ -6148,19 +6208,22 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:SocialHistory
+    - :slice_id: Observation.category:SocialHistory
+      :slice_name: SocialHistory
       :path: category
       :discriminator:
         :type: patternCodeableConcept
         :path: ''
         :code: social-history
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.effective[x]:effectiveDateTime
+    - :slice_id: Observation.effective[x]:effectiveDateTime
+      :slice_name: effectiveDateTime
       :path: effective[x]
       :discriminator:
         :type: type
         :code: DateTime
-    - :name: Observation.value[x]:valueCodeableConcept
+    - :slice_id: Observation.value[x]:valueCodeableConcept
+      :slice_name: valueCodeableConcept
       :path: value[x]
       :discriminator:
         :type: type
@@ -6311,7 +6374,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Organization.identifier:NPI
+    - :slice_id: Organization.identifier:NPI
+      :slice_name: NPI
       :path: identifier
       :discriminator:
         :type: patternIdentifier
@@ -6732,7 +6796,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Practitioner.identifier:NPI
+    - :slice_id: Practitioner.identifier:NPI
+      :slice_name: NPI
       :path: identifier
       :discriminator:
         :type: patternIdentifier
@@ -7152,14 +7217,16 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Provenance.agent:ProvenanceAuthor
+    - :slice_id: Provenance.agent:ProvenanceAuthor
+      :slice_name: ProvenanceAuthor
       :path: agent
       :discriminator:
         :type: patternCodeableConcept
         :path: type
         :code: author
         :system: http://terminology.hl7.org/CodeSystem/provenance-participant-type
-    - :name: Provenance.agent:ProvenanceTransmitter
+    - :slice_id: Provenance.agent:ProvenanceTransmitter
+      :slice_name: ProvenanceTransmitter
       :path: agent
       :discriminator:
         :type: patternCodeableConcept
@@ -7182,9 +7249,9 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
-    - :path: agent.type.coding.code
+    - :path: agent:ProvenanceAuthor.type.coding.code
       :fixed_value: author
-    - :path: agent.type.coding.code
+    - :path: agent:ProvenanceTransmitter.type.coding.code
       :fixed_value: transmitter
   :mandatory_elements:
   - Provenance.target

--- a/lib/us_core_test_kit/generated/v4.0.0/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/observation_lab/metadata.yml
@@ -140,7 +140,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:Laboratory
+  - :slice_id: Observation.category:Laboratory
+    :slice_name: Laboratory
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v4.0.0/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/organization/metadata.yml
@@ -70,7 +70,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Organization.identifier:NPI
+  - :slice_id: Organization.identifier:NPI
+    :slice_name: NPI
     :path: identifier
     :discriminator:
       :type: patternIdentifier

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 59576-9
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/pediatric_bmi_for_age_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/pediatric_bmi_for_age_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_pediatric_bmi_for_age_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 77606-2
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/pediatric_weight_for_height_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/pediatric_weight_for_height_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_pediatric_weight_for_height_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/practitioner/metadata.yml
@@ -68,7 +68,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Practitioner.identifier:NPI
+  - :slice_id: Practitioner.identifier:NPI
+    :slice_name: NPI
     :path: identifier
     :discriminator:
       :type: patternIdentifier

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
@@ -38,14 +38,16 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Provenance.agent:ProvenanceAuthor
+  - :slice_id: Provenance.agent:ProvenanceAuthor
+    :slice_name: ProvenanceAuthor
     :path: agent
     :discriminator:
       :type: patternCodeableConcept
       :path: type
       :code: author
       :system: http://terminology.hl7.org/CodeSystem/provenance-participant-type
-  - :name: Provenance.agent:ProvenanceTransmitter
+  - :slice_id: Provenance.agent:ProvenanceTransmitter
+    :slice_name: ProvenanceTransmitter
     :path: agent
     :discriminator:
       :type: patternCodeableConcept
@@ -68,9 +70,9 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
-  - :path: agent.type.coding.code
+  - :path: agent:ProvenanceAuthor.type.coding.code
     :fixed_value: author
-  - :path: agent.type.coding.code
+  - :path: agent:ProvenanceTransmitter.type.coding.code
     :fixed_value: transmitter
 :mandatory_elements:
 - Provenance.target

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/provenance_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/provenance_must_support_test.rb
@@ -15,10 +15,11 @@ module USCoreTestKit
         * Provenance.agent
         * Provenance.agent.onBehalfOf
         * Provenance.agent.type
-        * Provenance.agent.type.coding.code
         * Provenance.agent.who
         * Provenance.agent:ProvenanceAuthor
+        * Provenance.agent:ProvenanceAuthor.type.coding.code
         * Provenance.agent:ProvenanceTransmitter
+        * Provenance.agent:ProvenanceTransmitter.type.coding.code
         * Provenance.recorded
         * Provenance.target
         * Provenance.target.reference

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
@@ -219,7 +219,6 @@
   - :path: component:FlowRate.valueQuantity.code
     :original_path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component:FlowRate.dataAbsentReason
   - :path: component:Concentration.code.coding.code
     :fixed_value: 3150-0
   - :path: component:Concentration.valueQuantity
@@ -234,7 +233,6 @@
   - :path: component:Concentration.valueQuantity.code
     :original_path: component:Concentration.value[x].code
     :fixed_value: "%"
-  - :path: component:Concentration.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
@@ -142,35 +142,40 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.code.coding:PulseOx
+  - :slice_id: Observation.code.coding:PulseOx
+    :slice_name: PulseOx
     :path: code.coding
     :discriminator:
       :type: patternCoding
       :path: ''
       :code: 59408-5
       :system: http://loinc.org
-  - :name: Observation.code.coding:O2Sat
+  - :slice_id: Observation.code.coding:O2Sat
+    :slice_name: O2Sat
     :path: code.coding
     :discriminator:
       :type: patternCoding
       :path: ''
       :code: 2708-6
       :system: http://loinc.org
-  - :name: Observation.component:FlowRate
+  - :slice_id: Observation.component:FlowRate
+    :slice_name: FlowRate
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 3151-8
       :system: http://loinc.org
-  - :name: Observation.component:Concentration
+  - :slice_id: Observation.component:Concentration
+    :slice_name: Concentration
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 3150-0
       :system: http://loinc.org
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -182,10 +187,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: code.coding
@@ -200,23 +205,36 @@
   - :path: component.code
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component.code.coding.code
+  - :path: component:FlowRate.code.coding.code
     :fixed_value: 3151-8
-  - :path: component.valueQuantity.system
-    :original_path: component.value[x].system
+  - :path: component:FlowRate.valueQuantity
+    :original_path: component:FlowRate.value[x]
+  - :path: component:FlowRate.valueQuantity.value
+    :original_path: component:FlowRate.value[x].value
+  - :path: component:FlowRate.valueQuantity.unit
+    :original_path: component:FlowRate.value[x].unit
+  - :path: component:FlowRate.valueQuantity.system
+    :original_path: component:FlowRate.value[x].system
     :fixed_value: http://unitsofmeasure.org
-  - :path: component.valueQuantity.code
-    :original_path: component.value[x].code
+  - :path: component:FlowRate.valueQuantity.code
+    :original_path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component.code.coding.code
+  - :path: component:FlowRate.dataAbsentReason
+  - :path: component:Concentration.code.coding.code
     :fixed_value: 3150-0
-  - :path: component.valueQuantity.value
-    :original_path: component.value[x].value
-  - :path: component.valueQuantity.unit
-    :original_path: component.value[x].unit
-  - :path: component.valueQuantity.code
-    :original_path: component.value[x].code
+  - :path: component:Concentration.valueQuantity
+    :original_path: component:Concentration.value[x]
+  - :path: component:Concentration.valueQuantity.value
+    :original_path: component:Concentration.value[x].value
+  - :path: component:Concentration.valueQuantity.unit
+    :original_path: component:Concentration.value[x].unit
+  - :path: component:Concentration.valueQuantity.system
+    :original_path: component:Concentration.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:Concentration.valueQuantity.code
+    :original_path: component:Concentration.value[x].code
     :fixed_value: "%"
+  - :path: component:Concentration.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -26,7 +26,6 @@ module USCoreTestKit
         * Observation.component.valueQuantity
         * Observation.component:Concentration
         * Observation.component:Concentration.code.coding.code
-        * Observation.component:Concentration.dataAbsentReason
         * Observation.component:Concentration.valueQuantity
         * Observation.component:Concentration.valueQuantity.code
         * Observation.component:Concentration.valueQuantity.system
@@ -34,7 +33,6 @@ module USCoreTestKit
         * Observation.component:Concentration.valueQuantity.value
         * Observation.component:FlowRate
         * Observation.component:FlowRate.code.coding.code
-        * Observation.component:FlowRate.dataAbsentReason
         * Observation.component:FlowRate.valueQuantity
         * Observation.component:FlowRate.valueQuantity.code
         * Observation.component:FlowRate.valueQuantity.system

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -13,24 +13,33 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.code.coding
         * Observation.code.coding:O2Sat
         * Observation.code.coding:PulseOx
         * Observation.component
         * Observation.component.code
-        * Observation.component.code.coding.code
         * Observation.component.valueQuantity
-        * Observation.component.valueQuantity.code
-        * Observation.component.valueQuantity.system
-        * Observation.component.valueQuantity.unit
-        * Observation.component.valueQuantity.value
         * Observation.component:Concentration
+        * Observation.component:Concentration.code.coding.code
+        * Observation.component:Concentration.dataAbsentReason
+        * Observation.component:Concentration.valueQuantity
+        * Observation.component:Concentration.valueQuantity.code
+        * Observation.component:Concentration.valueQuantity.system
+        * Observation.component:Concentration.valueQuantity.unit
+        * Observation.component:Concentration.valueQuantity.value
         * Observation.component:FlowRate
+        * Observation.component:FlowRate.code.coding.code
+        * Observation.component:FlowRate.dataAbsentReason
+        * Observation.component:FlowRate.valueQuantity
+        * Observation.component:FlowRate.valueQuantity.code
+        * Observation.component:FlowRate.valueQuantity.system
+        * Observation.component:FlowRate.valueQuantity.unit
+        * Observation.component:FlowRate.valueQuantity.value
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject

--- a/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 9279-1
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "/min"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/respiratory_rate_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/respiratory_rate_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v400_respiratory_rate_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
@@ -135,19 +135,22 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:SocialHistory
+  - :slice_id: Observation.category:SocialHistory
+    :slice_name: SocialHistory
     :path: category
     :discriminator:
       :type: patternCodeableConcept
       :path: ''
       :code: social-history
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.effective[x]:effectiveDateTime
+  - :slice_id: Observation.effective[x]:effectiveDateTime
+    :slice_name: effectiveDateTime
     :path: effective[x]
     :discriminator:
       :type: type
       :code: DateTime
-  - :name: Observation.value[x]:valueCodeableConcept
+  - :slice_id: Observation.value[x]:valueCodeableConcept
+    :slice_name: valueCodeableConcept
     :path: value[x]
     :discriminator:
       :type: type

--- a/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/blood_pressure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/blood_pressure_must_support_test.rb
@@ -13,21 +13,30 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.component
         * Observation.component.code
-        * Observation.component.code.coding.code
         * Observation.component.valueQuantity
-        * Observation.component.valueQuantity.code
-        * Observation.component.valueQuantity.system
-        * Observation.component.valueQuantity.unit
-        * Observation.component.valueQuantity.value
         * Observation.component:diastolic
+        * Observation.component:diastolic.code.coding.code
+        * Observation.component:diastolic.dataAbsentReason
+        * Observation.component:diastolic.valueQuantity
+        * Observation.component:diastolic.valueQuantity.code
+        * Observation.component:diastolic.valueQuantity.system
+        * Observation.component:diastolic.valueQuantity.unit
+        * Observation.component:diastolic.valueQuantity.value
         * Observation.component:systolic
+        * Observation.component:systolic.code.coding.code
+        * Observation.component:systolic.dataAbsentReason
+        * Observation.component:systolic.valueQuantity
+        * Observation.component:systolic.valueQuantity.code
+        * Observation.component:systolic.valueQuantity.system
+        * Observation.component:systolic.valueQuantity.unit
+        * Observation.component:systolic.valueQuantity.value
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject

--- a/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/blood_pressure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/blood_pressure_must_support_test.rb
@@ -20,7 +20,6 @@ module USCoreTestKit
         * Observation.code.coding.code
         * Observation.component
         * Observation.component.code
-        * Observation.component.code.coding.code
         * Observation.component.dataAbsentReason
         * Observation.component.valueQuantity
         * Observation.component:diastolic

--- a/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
@@ -141,21 +141,24 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.component:systolic
+  - :slice_id: Observation.component:systolic
+    :slice_name: systolic
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 8480-6
       :system: http://loinc.org
-  - :name: Observation.component:diastolic
+  - :slice_id: Observation.component:diastolic
+    :slice_name: diastolic
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 8462-4
       :system: http://loinc.org
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -167,10 +170,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 85354-9
@@ -181,22 +184,38 @@
     :original_path: effective[x]
   - :path: component
   - :path: component.code
-  - :path: component.code.coding.code
-    :fixed_value: 8480-6
-  - :path: component.valueQuantity.system
-    :original_path: component.value[x].system
-    :fixed_value: http://unitsofmeasure.org
-  - :path: component.valueQuantity.code
-    :original_path: component.value[x].code
-    :fixed_value: mm[Hg]
-  - :path: component.code.coding.code
-    :fixed_value: 8462-4
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component.valueQuantity.value
-    :original_path: component.value[x].value
-  - :path: component.valueQuantity.unit
-    :original_path: component.value[x].unit
+  - :path: component:systolic.code.coding.code
+    :fixed_value: 8480-6
+  - :path: component:systolic.valueQuantity
+    :original_path: component:systolic.value[x]
+  - :path: component:systolic.valueQuantity.value
+    :original_path: component:systolic.value[x].value
+  - :path: component:systolic.valueQuantity.unit
+    :original_path: component:systolic.value[x].unit
+  - :path: component:systolic.valueQuantity.system
+    :original_path: component:systolic.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:systolic.valueQuantity.code
+    :original_path: component:systolic.value[x].code
+    :fixed_value: mm[Hg]
+  - :path: component:systolic.dataAbsentReason
+  - :path: component:diastolic.code.coding.code
+    :fixed_value: 8462-4
+  - :path: component:diastolic.valueQuantity
+    :original_path: component:diastolic.value[x]
+  - :path: component:diastolic.valueQuantity.value
+    :original_path: component:diastolic.value[x].value
+  - :path: component:diastolic.valueQuantity.unit
+    :original_path: component:diastolic.value[x].unit
+  - :path: component:diastolic.valueQuantity.system
+    :original_path: component:diastolic.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:diastolic.valueQuantity.code
+    :original_path: component:diastolic.value[x].code
+    :fixed_value: mm[Hg]
+  - :path: component:diastolic.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
@@ -186,6 +186,7 @@
   - :path: component.code
   - :path: component.valueQuantity
     :original_path: component.value[x]
+  - :path: component.dataAbsentReason
   - :path: component:systolic.code.coding.code
     :fixed_value: 8480-6
   - :path: component:systolic.valueQuantity
@@ -216,7 +217,6 @@
     :original_path: component:diastolic.value[x].code
     :fixed_value: mm[Hg]
   - :path: component:diastolic.dataAbsentReason
-  - :path: component.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/bmi/bmi_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/bmi/bmi_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_bmi_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/bmi/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 39156-5
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: kg/m2
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v5.0.1/body_height/body_height_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_height/body_height_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_body_height_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_height/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8302-2
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/body_temperature/body_temperature_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_temperature/body_temperature_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_body_temperature_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_temperature/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8310-5
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/body_weight/body_weight_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_weight/body_weight_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_body_weight_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_weight/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 29463-7
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/care_plan/metadata.yml
@@ -126,7 +126,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: CarePlan.category:AssessPlan
+  - :slice_id: CarePlan.category:AssessPlan
+    :slice_name: AssessPlan
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
@@ -236,7 +236,8 @@
   - :id: Condition.extension:assertedDate
     :url: http://hl7.org/fhir/StructureDefinition/condition-assertedDate
   :slices:
-  - :name: Condition.category:us-core
+  - :slice_id: Condition.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
@@ -239,7 +239,8 @@
   - :id: Condition.extension:assertedDate
     :url: http://hl7.org/fhir/StructureDefinition/condition-assertedDate
   :slices:
-  - :name: Condition.category:us-core
+  - :slice_id: Condition.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding
@@ -247,7 +248,8 @@
       :values:
       - problem-list-item
       - health-concern
-  - :name: Condition.category:sdoh
+  - :slice_id: Condition.category:sdoh
+    :slice_name: sdoh
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_lab/metadata.yml
@@ -146,7 +146,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: DiagnosticReport.category:LaboratorySlice
+  - :slice_id: DiagnosticReport.category:LaboratorySlice
+    :slice_name: LaboratorySlice
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
@@ -149,7 +149,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: DiagnosticReport.category:us-core
+  - :slice_id: DiagnosticReport.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
@@ -178,7 +178,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: DocumentReference.category:us-core
+  - :slice_id: DocumentReference.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference/head_circumference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference/head_circumference_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_head_circumference_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 9843-4
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/head_circumference_percentile_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/head_circumference_percentile_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_head_circumference_percentile_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8289-1
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v5.0.1/heart_rate/heart_rate_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/heart_rate/heart_rate_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_heart_rate_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/heart_rate/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8867-4
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "/min"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
@@ -143,7 +143,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: MedicationRequest.category:us-core
+  - :slice_id: MedicationRequest.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -262,7 +262,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: CarePlan.category:AssessPlan
+    - :slice_id: CarePlan.category:AssessPlan
+      :slice_name: AssessPlan
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -785,7 +786,8 @@
     - :id: Condition.extension:assertedDate
       :url: http://hl7.org/fhir/StructureDefinition/condition-assertedDate
     :slices:
-    - :name: Condition.category:us-core
+    - :slice_id: Condition.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -1093,7 +1095,8 @@
     - :id: Condition.extension:assertedDate
       :url: http://hl7.org/fhir/StructureDefinition/condition-assertedDate
     :slices:
-    - :name: Condition.category:us-core
+    - :slice_id: Condition.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -1101,7 +1104,8 @@
         :values:
         - problem-list-item
         - health-concern
-    - :name: Condition.category:sdoh
+    - :slice_id: Condition.category:sdoh
+      :slice_name: sdoh
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -1445,7 +1449,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: DiagnosticReport.category:us-core
+    - :slice_id: DiagnosticReport.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -1688,7 +1693,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: DiagnosticReport.category:LaboratorySlice
+    - :slice_id: DiagnosticReport.category:LaboratorySlice
+      :slice_name: LaboratorySlice
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -1947,7 +1953,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: DocumentReference.category:us-core
+    - :slice_id: DocumentReference.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -3062,7 +3069,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: MedicationRequest.category:us-core
+    - :slice_id: MedicationRequest.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -3330,7 +3338,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:Laboratory
+    - :slice_id: Observation.category:Laboratory
+      :slice_name: Laboratory
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -3605,14 +3614,16 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:survey
+    - :slice_id: Observation.category:survey
+      :slice_name: survey
       :path: category
       :discriminator:
         :type: patternCodeableConcept
         :path: ''
         :code: survey
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.category:sdoh
+    - :slice_id: Observation.category:sdoh
+      :slice_name: sdoh
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -3859,12 +3870,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -3876,10 +3889,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 9279-1
@@ -3889,11 +3902,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "/min"
   :mandatory_elements:
   - Observation.status
@@ -4113,14 +4126,16 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:us-core/social-history
+    - :slice_id: Observation.category:us-core/social-history
+      :slice_name: us-core/social-history
       :path: category
       :discriminator:
         :type: patternCodeableConcept
         :path: ''
         :code: social-history
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.category:sdoh
+    - :slice_id: Observation.category:sdoh
+      :slice_name: sdoh
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -4361,12 +4376,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4378,10 +4395,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8867-4
@@ -4391,11 +4408,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "/min"
   :mandatory_elements:
   - Observation.status
@@ -4616,12 +4633,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4633,10 +4652,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8310-5
@@ -4646,11 +4665,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -4874,12 +4893,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4891,10 +4912,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 77606-2
@@ -4904,11 +4925,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -5130,35 +5151,40 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.code.coding:PulseOx
+    - :slice_id: Observation.code.coding:PulseOx
+      :slice_name: PulseOx
       :path: code.coding
       :discriminator:
         :type: patternCoding
         :path: ''
         :code: 59408-5
         :system: http://loinc.org
-    - :name: Observation.code.coding:O2Sat
+    - :slice_id: Observation.code.coding:O2Sat
+      :slice_name: O2Sat
       :path: code.coding
       :discriminator:
         :type: patternCoding
         :path: ''
         :code: 2708-6
         :system: http://loinc.org
-    - :name: Observation.component:FlowRate
+    - :slice_id: Observation.component:FlowRate
+      :slice_name: FlowRate
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 3151-8
         :system: http://loinc.org
-    - :name: Observation.component:Concentration
+    - :slice_id: Observation.component:Concentration
+      :slice_name: Concentration
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 3150-0
         :system: http://loinc.org
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5170,10 +5196,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: code.coding
@@ -5188,23 +5214,36 @@
     - :path: component.code
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component.code.coding.code
+    - :path: component:FlowRate.code.coding.code
       :fixed_value: 3151-8
-    - :path: component.valueQuantity.system
-      :original_path: component.value[x].system
+    - :path: component:FlowRate.valueQuantity
+      :original_path: component:FlowRate.value[x]
+    - :path: component:FlowRate.valueQuantity.value
+      :original_path: component:FlowRate.value[x].value
+    - :path: component:FlowRate.valueQuantity.unit
+      :original_path: component:FlowRate.value[x].unit
+    - :path: component:FlowRate.valueQuantity.system
+      :original_path: component:FlowRate.value[x].system
       :fixed_value: http://unitsofmeasure.org
-    - :path: component.valueQuantity.code
-      :original_path: component.value[x].code
+    - :path: component:FlowRate.valueQuantity.code
+      :original_path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component.code.coding.code
+    - :path: component:FlowRate.dataAbsentReason
+    - :path: component:Concentration.code.coding.code
       :fixed_value: 3150-0
-    - :path: component.valueQuantity.value
-      :original_path: component.value[x].value
-    - :path: component.valueQuantity.unit
-      :original_path: component.value[x].unit
-    - :path: component.valueQuantity.code
-      :original_path: component.value[x].code
+    - :path: component:Concentration.valueQuantity
+      :original_path: component:Concentration.value[x]
+    - :path: component:Concentration.valueQuantity.value
+      :original_path: component:Concentration.value[x].value
+    - :path: component:Concentration.valueQuantity.unit
+      :original_path: component:Concentration.value[x].unit
+    - :path: component:Concentration.valueQuantity.system
+      :original_path: component:Concentration.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:Concentration.valueQuantity.code
+      :original_path: component:Concentration.value[x].code
       :fixed_value: "%"
+    - :path: component:Concentration.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -5423,19 +5462,22 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:SocialHistory
+    - :slice_id: Observation.category:SocialHistory
+      :slice_name: SocialHistory
       :path: category
       :discriminator:
         :type: patternCodeableConcept
         :path: ''
         :code: social-history
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.effective[x]:effectiveDateTime
+    - :slice_id: Observation.effective[x]:effectiveDateTime
+      :slice_name: effectiveDateTime
       :path: effective[x]
       :discriminator:
         :type: type
         :code: DateTime
-    - :name: Observation.value[x]:valueCodeableConcept
+    - :slice_id: Observation.value[x]:valueCodeableConcept
+      :slice_name: valueCodeableConcept
       :path: value[x]
       :discriminator:
         :type: type
@@ -5658,7 +5700,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueCodeableConcept
+    - :slice_id: Observation.value[x]:valueCodeableConcept
+      :slice_name: valueCodeableConcept
       :path: value[x]
       :discriminator:
         :type: type
@@ -5878,12 +5921,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5895,10 +5940,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 9843-4
@@ -5908,11 +5953,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -6136,12 +6181,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -6153,10 +6200,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8302-2
@@ -6166,11 +6213,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -6394,12 +6441,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -6411,10 +6460,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 39156-5
@@ -6424,11 +6473,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: kg/m2
   :mandatory_elements:
   - Observation.status
@@ -6649,21 +6698,24 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.component:systolic
+    - :slice_id: Observation.component:systolic
+      :slice_name: systolic
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 8480-6
         :system: http://loinc.org
-    - :name: Observation.component:diastolic
+    - :slice_id: Observation.component:diastolic
+      :slice_name: diastolic
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 8462-4
         :system: http://loinc.org
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -6675,10 +6727,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 85354-9
@@ -6689,22 +6741,38 @@
       :original_path: effective[x]
     - :path: component
     - :path: component.code
-    - :path: component.code.coding.code
-      :fixed_value: 8480-6
-    - :path: component.valueQuantity.system
-      :original_path: component.value[x].system
-      :fixed_value: http://unitsofmeasure.org
-    - :path: component.valueQuantity.code
-      :original_path: component.value[x].code
-      :fixed_value: mm[Hg]
-    - :path: component.code.coding.code
-      :fixed_value: 8462-4
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component.valueQuantity.value
-      :original_path: component.value[x].value
-    - :path: component.valueQuantity.unit
-      :original_path: component.value[x].unit
+    - :path: component:systolic.code.coding.code
+      :fixed_value: 8480-6
+    - :path: component:systolic.valueQuantity
+      :original_path: component:systolic.value[x]
+    - :path: component:systolic.valueQuantity.value
+      :original_path: component:systolic.value[x].value
+    - :path: component:systolic.valueQuantity.unit
+      :original_path: component:systolic.value[x].unit
+    - :path: component:systolic.valueQuantity.system
+      :original_path: component:systolic.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:systolic.valueQuantity.code
+      :original_path: component:systolic.value[x].code
+      :fixed_value: mm[Hg]
+    - :path: component:systolic.dataAbsentReason
+    - :path: component:diastolic.code.coding.code
+      :fixed_value: 8462-4
+    - :path: component:diastolic.valueQuantity
+      :original_path: component:diastolic.value[x]
+    - :path: component:diastolic.valueQuantity.value
+      :original_path: component:diastolic.value[x].value
+    - :path: component:diastolic.valueQuantity.unit
+      :original_path: component:diastolic.value[x].unit
+    - :path: component:diastolic.valueQuantity.system
+      :original_path: component:diastolic.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:diastolic.valueQuantity.code
+      :original_path: component:diastolic.value[x].code
+      :fixed_value: mm[Hg]
+    - :path: component:diastolic.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -6928,7 +6996,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:imaging
+    - :slice_id: Observation.category:imaging
+      :slice_name: imaging
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -7617,7 +7686,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:clinical-test
+    - :slice_id: Observation.category:clinical-test
+      :slice_name: clinical-test
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -7846,12 +7916,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -7863,10 +7935,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 59576-9
@@ -7876,11 +7948,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -8102,12 +8174,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -8119,10 +8193,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8289-1
@@ -8132,11 +8206,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -8357,12 +8431,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -8374,10 +8450,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 29463-7
@@ -8387,11 +8463,11 @@
     - :path: effectiveDateTime
       :original_path: effective[x]
     - :path: value[x]
-    - :path: value[x].value
-    - :path: value[x].unit
-    - :path: value[x].system
+    - :path: value[x]:valueQuantity.value
+    - :path: value[x]:valueQuantity.unit
+    - :path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: value[x].code
+    - :path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -8545,7 +8621,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Organization.identifier:NPI
+    - :slice_id: Organization.identifier:NPI
+      :slice_name: NPI
       :path: identifier
       :discriminator:
         :type: patternIdentifier
@@ -8996,7 +9073,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Practitioner.identifier:NPI
+    - :slice_id: Practitioner.identifier:NPI
+      :slice_name: NPI
       :path: identifier
       :discriminator:
         :type: patternIdentifier
@@ -9440,14 +9518,16 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Provenance.agent:ProvenanceAuthor
+    - :slice_id: Provenance.agent:ProvenanceAuthor
+      :slice_name: ProvenanceAuthor
       :path: agent
       :discriminator:
         :type: patternCodeableConcept
         :path: type
         :code: author
         :system: http://terminology.hl7.org/CodeSystem/provenance-participant-type
-    - :name: Provenance.agent:ProvenanceTransmitter
+    - :slice_id: Provenance.agent:ProvenanceTransmitter
+      :slice_name: ProvenanceTransmitter
       :path: agent
       :discriminator:
         :type: patternCodeableConcept
@@ -9470,9 +9550,9 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
-    - :path: agent.type.coding.code
+    - :path: agent:ProvenanceAuthor.type.coding.code
       :fixed_value: author
-    - :path: agent.type.coding.code
+    - :path: agent:ProvenanceTransmitter.type.coding.code
       :fixed_value: transmitter
   :mandatory_elements:
   - Provenance.target
@@ -9710,7 +9790,8 @@
     - :id: QuestionnaireResponse.questionnaire.extension:url
       :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-extension-questionnaire-uri
     :slices:
-    - :name: QuestionnaireResponse.meta.tag:sdoh
+    - :slice_id: QuestionnaireResponse.meta.tag:sdoh
+      :slice_name: sdoh
       :path: meta.tag
       :discriminator:
         :type: patternCoding
@@ -10051,7 +10132,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: ServiceRequest.category:us-core
+    - :slice_id: ServiceRequest.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -5228,7 +5228,6 @@
     - :path: component:FlowRate.valueQuantity.code
       :original_path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component:FlowRate.dataAbsentReason
     - :path: component:Concentration.code.coding.code
       :fixed_value: 3150-0
     - :path: component:Concentration.valueQuantity
@@ -5243,7 +5242,6 @@
     - :path: component:Concentration.valueQuantity.code
       :original_path: component:Concentration.value[x].code
       :fixed_value: "%"
-    - :path: component:Concentration.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -6743,6 +6743,7 @@
     - :path: component.code
     - :path: component.valueQuantity
       :original_path: component.value[x]
+    - :path: component.dataAbsentReason
     - :path: component:systolic.code.coding.code
       :fixed_value: 8480-6
     - :path: component:systolic.valueQuantity
@@ -6773,7 +6774,6 @@
       :original_path: component:diastolic.value[x].code
       :fixed_value: mm[Hg]
     - :path: component:diastolic.dataAbsentReason
-    - :path: component.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_clinical_test/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_clinical_test/metadata.yml
@@ -601,7 +601,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:clinical-test
+  - :slice_id: Observation.category:clinical-test
+    :slice_name: clinical-test
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_imaging/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_imaging/metadata.yml
@@ -140,7 +140,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:imaging
+  - :slice_id: Observation.category:imaging
+    :slice_name: imaging
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_lab/metadata.yml
@@ -140,7 +140,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:Laboratory
+  - :slice_id: Observation.category:Laboratory
+    :slice_name: Laboratory
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
@@ -187,14 +187,16 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:survey
+  - :slice_id: Observation.category:survey
+    :slice_name: survey
     :path: category
     :discriminator:
       :type: patternCodeableConcept
       :path: ''
       :code: survey
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.category:sdoh
+  - :slice_id: Observation.category:sdoh
+    :slice_name: sdoh
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sexual_orientation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sexual_orientation/metadata.yml
@@ -143,7 +143,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueCodeableConcept
+  - :slice_id: Observation.value[x]:valueCodeableConcept
+    :slice_name: valueCodeableConcept
     :path: value[x]
     :discriminator:
       :type: type

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
@@ -140,14 +140,16 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:us-core/social-history
+  - :slice_id: Observation.category:us-core/social-history
+    :slice_name: us-core/social-history
     :path: category
     :discriminator:
       :type: patternCodeableConcept
       :path: ''
       :code: social-history
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.category:sdoh
+  - :slice_id: Observation.category:sdoh
+    :slice_name: sdoh
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v5.0.1/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/organization/metadata.yml
@@ -70,7 +70,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Organization.identifier:NPI
+  - :slice_id: Organization.identifier:NPI
+    :slice_name: NPI
     :path: identifier
     :discriminator:
       :type: patternIdentifier

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 59576-9
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/pediatric_bmi_for_age_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/pediatric_bmi_for_age_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_pediatric_bmi_for_age_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 77606-2
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/pediatric_weight_for_height_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/pediatric_weight_for_height_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_pediatric_weight_for_height_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/practitioner/metadata.yml
@@ -83,7 +83,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Practitioner.identifier:NPI
+  - :slice_id: Practitioner.identifier:NPI
+    :slice_name: NPI
     :path: identifier
     :discriminator:
       :type: patternIdentifier

--- a/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
@@ -38,14 +38,16 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Provenance.agent:ProvenanceAuthor
+  - :slice_id: Provenance.agent:ProvenanceAuthor
+    :slice_name: ProvenanceAuthor
     :path: agent
     :discriminator:
       :type: patternCodeableConcept
       :path: type
       :code: author
       :system: http://terminology.hl7.org/CodeSystem/provenance-participant-type
-  - :name: Provenance.agent:ProvenanceTransmitter
+  - :slice_id: Provenance.agent:ProvenanceTransmitter
+    :slice_name: ProvenanceTransmitter
     :path: agent
     :discriminator:
       :type: patternCodeableConcept
@@ -68,9 +70,9 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
-  - :path: agent.type.coding.code
+  - :path: agent:ProvenanceAuthor.type.coding.code
     :fixed_value: author
-  - :path: agent.type.coding.code
+  - :path: agent:ProvenanceTransmitter.type.coding.code
     :fixed_value: transmitter
 :mandatory_elements:
 - Provenance.target

--- a/lib/us_core_test_kit/generated/v5.0.1/provenance/provenance_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/provenance/provenance_must_support_test.rb
@@ -15,10 +15,11 @@ module USCoreTestKit
         * Provenance.agent
         * Provenance.agent.onBehalfOf
         * Provenance.agent.type
-        * Provenance.agent.type.coding.code
         * Provenance.agent.who
         * Provenance.agent:ProvenanceAuthor
+        * Provenance.agent:ProvenanceAuthor.type.coding.code
         * Provenance.agent:ProvenanceTransmitter
+        * Provenance.agent:ProvenanceTransmitter.type.coding.code
         * Provenance.recorded
         * Provenance.target
         * Provenance.target.reference

--- a/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
@@ -219,7 +219,6 @@
   - :path: component:FlowRate.valueQuantity.code
     :original_path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component:FlowRate.dataAbsentReason
   - :path: component:Concentration.code.coding.code
     :fixed_value: 3150-0
   - :path: component:Concentration.valueQuantity
@@ -234,7 +233,6 @@
   - :path: component:Concentration.valueQuantity.code
     :original_path: component:Concentration.value[x].code
     :fixed_value: "%"
-  - :path: component:Concentration.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
@@ -142,35 +142,40 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.code.coding:PulseOx
+  - :slice_id: Observation.code.coding:PulseOx
+    :slice_name: PulseOx
     :path: code.coding
     :discriminator:
       :type: patternCoding
       :path: ''
       :code: 59408-5
       :system: http://loinc.org
-  - :name: Observation.code.coding:O2Sat
+  - :slice_id: Observation.code.coding:O2Sat
+    :slice_name: O2Sat
     :path: code.coding
     :discriminator:
       :type: patternCoding
       :path: ''
       :code: 2708-6
       :system: http://loinc.org
-  - :name: Observation.component:FlowRate
+  - :slice_id: Observation.component:FlowRate
+    :slice_name: FlowRate
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 3151-8
       :system: http://loinc.org
-  - :name: Observation.component:Concentration
+  - :slice_id: Observation.component:Concentration
+    :slice_name: Concentration
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 3150-0
       :system: http://loinc.org
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -182,10 +187,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: code.coding
@@ -200,23 +205,36 @@
   - :path: component.code
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component.code.coding.code
+  - :path: component:FlowRate.code.coding.code
     :fixed_value: 3151-8
-  - :path: component.valueQuantity.system
-    :original_path: component.value[x].system
+  - :path: component:FlowRate.valueQuantity
+    :original_path: component:FlowRate.value[x]
+  - :path: component:FlowRate.valueQuantity.value
+    :original_path: component:FlowRate.value[x].value
+  - :path: component:FlowRate.valueQuantity.unit
+    :original_path: component:FlowRate.value[x].unit
+  - :path: component:FlowRate.valueQuantity.system
+    :original_path: component:FlowRate.value[x].system
     :fixed_value: http://unitsofmeasure.org
-  - :path: component.valueQuantity.code
-    :original_path: component.value[x].code
+  - :path: component:FlowRate.valueQuantity.code
+    :original_path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component.code.coding.code
+  - :path: component:FlowRate.dataAbsentReason
+  - :path: component:Concentration.code.coding.code
     :fixed_value: 3150-0
-  - :path: component.valueQuantity.value
-    :original_path: component.value[x].value
-  - :path: component.valueQuantity.unit
-    :original_path: component.value[x].unit
-  - :path: component.valueQuantity.code
-    :original_path: component.value[x].code
+  - :path: component:Concentration.valueQuantity
+    :original_path: component:Concentration.value[x]
+  - :path: component:Concentration.valueQuantity.value
+    :original_path: component:Concentration.value[x].value
+  - :path: component:Concentration.valueQuantity.unit
+    :original_path: component:Concentration.value[x].unit
+  - :path: component:Concentration.valueQuantity.system
+    :original_path: component:Concentration.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:Concentration.valueQuantity.code
+    :original_path: component:Concentration.value[x].code
     :fixed_value: "%"
+  - :path: component:Concentration.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -26,7 +26,6 @@ module USCoreTestKit
         * Observation.component.valueQuantity
         * Observation.component:Concentration
         * Observation.component:Concentration.code.coding.code
-        * Observation.component:Concentration.dataAbsentReason
         * Observation.component:Concentration.valueQuantity
         * Observation.component:Concentration.valueQuantity.code
         * Observation.component:Concentration.valueQuantity.system
@@ -34,7 +33,6 @@ module USCoreTestKit
         * Observation.component:Concentration.valueQuantity.value
         * Observation.component:FlowRate
         * Observation.component:FlowRate.code.coding.code
-        * Observation.component:FlowRate.dataAbsentReason
         * Observation.component:FlowRate.valueQuantity
         * Observation.component:FlowRate.valueQuantity.code
         * Observation.component:FlowRate.valueQuantity.system

--- a/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -13,24 +13,33 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.code.coding
         * Observation.code.coding:O2Sat
         * Observation.code.coding:PulseOx
         * Observation.component
         * Observation.component.code
-        * Observation.component.code.coding.code
         * Observation.component.valueQuantity
-        * Observation.component.valueQuantity.code
-        * Observation.component.valueQuantity.system
-        * Observation.component.valueQuantity.unit
-        * Observation.component.valueQuantity.value
         * Observation.component:Concentration
+        * Observation.component:Concentration.code.coding.code
+        * Observation.component:Concentration.dataAbsentReason
+        * Observation.component:Concentration.valueQuantity
+        * Observation.component:Concentration.valueQuantity.code
+        * Observation.component:Concentration.valueQuantity.system
+        * Observation.component:Concentration.valueQuantity.unit
+        * Observation.component:Concentration.valueQuantity.value
         * Observation.component:FlowRate
+        * Observation.component:FlowRate.code.coding.code
+        * Observation.component:FlowRate.dataAbsentReason
+        * Observation.component:FlowRate.valueQuantity
+        * Observation.component:FlowRate.valueQuantity.code
+        * Observation.component:FlowRate.valueQuantity.system
+        * Observation.component:FlowRate.valueQuantity.unit
+        * Observation.component:FlowRate.valueQuantity.value
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
@@ -159,7 +159,8 @@
   - :id: QuestionnaireResponse.questionnaire.extension:url
     :url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-extension-questionnaire-uri
   :slices:
-  - :name: QuestionnaireResponse.meta.tag:sdoh
+  - :slice_id: QuestionnaireResponse.meta.tag:sdoh
+    :slice_name: sdoh
     :path: meta.tag
     :discriminator:
       :type: patternCoding

--- a/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 9279-1
@@ -171,11 +173,11 @@
   - :path: effectiveDateTime
     :original_path: effective[x]
   - :path: value[x]
-  - :path: value[x].value
-  - :path: value[x].unit
-  - :path: value[x].system
+  - :path: value[x]:valueQuantity.value
+  - :path: value[x]:valueQuantity.unit
+  - :path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: value[x].code
+  - :path: value[x]:valueQuantity.code
     :fixed_value: "/min"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/respiratory_rate_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/respiratory_rate_must_support_test.rb
@@ -13,20 +13,20 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.value[x]
-        * Observation.value[x].code
-        * Observation.value[x].system
-        * Observation.value[x].unit
-        * Observation.value[x].value
         * Observation.value[x]:valueQuantity
+        * Observation.value[x]:valueQuantity.code
+        * Observation.value[x]:valueQuantity.system
+        * Observation.value[x]:valueQuantity.unit
+        * Observation.value[x]:valueQuantity.value
       )
 
       id :us_core_v501_respiratory_rate_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
@@ -166,7 +166,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: ServiceRequest.category:us-core
+  - :slice_id: ServiceRequest.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
@@ -135,19 +135,22 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:SocialHistory
+  - :slice_id: Observation.category:SocialHistory
+    :slice_name: SocialHistory
     :path: category
     :discriminator:
       :type: patternCodeableConcept
       :path: ''
       :code: social-history
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.effective[x]:effectiveDateTime
+  - :slice_id: Observation.effective[x]:effectiveDateTime
+    :slice_name: effectiveDateTime
     :path: effective[x]
     :discriminator:
       :type: type
       :code: DateTime
-  - :name: Observation.value[x]:valueCodeableConcept
+  - :slice_id: Observation.value[x]:valueCodeableConcept
+    :slice_name: valueCodeableConcept
     :path: value[x]
     :discriminator:
       :type: type

--- a/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/blood_pressure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/blood_pressure_must_support_test.rb
@@ -13,21 +13,30 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.component
         * Observation.component.code
-        * Observation.component.code.coding.code
         * Observation.component.valueQuantity
-        * Observation.component.valueQuantity.code
-        * Observation.component.valueQuantity.system
-        * Observation.component.valueQuantity.unit
-        * Observation.component.valueQuantity.value
         * Observation.component:diastolic
+        * Observation.component:diastolic.code.coding.code
+        * Observation.component:diastolic.dataAbsentReason
+        * Observation.component:diastolic.valueQuantity
+        * Observation.component:diastolic.valueQuantity.code
+        * Observation.component:diastolic.valueQuantity.system
+        * Observation.component:diastolic.valueQuantity.unit
+        * Observation.component:diastolic.valueQuantity.value
         * Observation.component:systolic
+        * Observation.component:systolic.code.coding.code
+        * Observation.component:systolic.dataAbsentReason
+        * Observation.component:systolic.valueQuantity
+        * Observation.component:systolic.valueQuantity.code
+        * Observation.component:systolic.valueQuantity.system
+        * Observation.component:systolic.valueQuantity.unit
+        * Observation.component:systolic.valueQuantity.value
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject

--- a/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/blood_pressure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/blood_pressure_must_support_test.rb
@@ -20,7 +20,6 @@ module USCoreTestKit
         * Observation.code.coding.code
         * Observation.component
         * Observation.component.code
-        * Observation.component.code.coding.code
         * Observation.component.dataAbsentReason
         * Observation.component.valueQuantity
         * Observation.component:diastolic

--- a/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
@@ -186,6 +186,7 @@
   - :path: component.code
   - :path: component.valueQuantity
     :original_path: component.value[x]
+  - :path: component.dataAbsentReason
   - :path: component:systolic.code.coding.code
     :fixed_value: 8480-6
   - :path: component:systolic.valueQuantity
@@ -209,7 +210,6 @@
     :original_path: component:diastolic.value[x].value
   - :path: component:diastolic.valueQuantity.unit
     :original_path: component:diastolic.value[x].unit
-  - :path: component.dataAbsentReason
   - :path: component:diastolic.valueQuantity.system
     :original_path: component:diastolic.value[x].system
     :fixed_value: http://unitsofmeasure.org

--- a/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
@@ -141,21 +141,24 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.component:systolic
+  - :slice_id: Observation.component:systolic
+    :slice_name: systolic
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 8480-6
       :system: http://loinc.org
-  - :name: Observation.component:diastolic
+  - :slice_id: Observation.component:diastolic
+    :slice_name: diastolic
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 8462-4
       :system: http://loinc.org
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -167,10 +170,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 85354-9
@@ -181,22 +184,38 @@
     :original_path: effective[x]
   - :path: component
   - :path: component.code
-  - :path: component.code.coding.code
-    :fixed_value: 8480-6
-  - :path: component.valueQuantity.system
-    :original_path: component.value[x].system
-    :fixed_value: http://unitsofmeasure.org
-  - :path: component.valueQuantity.code
-    :original_path: component.value[x].code
-    :fixed_value: mm[Hg]
-  - :path: component.code.coding.code
-    :fixed_value: 8462-4
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component.valueQuantity.value
-    :original_path: component.value[x].value
-  - :path: component.valueQuantity.unit
-    :original_path: component.value[x].unit
+  - :path: component:systolic.code.coding.code
+    :fixed_value: 8480-6
+  - :path: component:systolic.valueQuantity
+    :original_path: component:systolic.value[x]
+  - :path: component:systolic.valueQuantity.value
+    :original_path: component:systolic.value[x].value
+  - :path: component:systolic.valueQuantity.unit
+    :original_path: component:systolic.value[x].unit
+  - :path: component:systolic.valueQuantity.system
+    :original_path: component:systolic.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:systolic.valueQuantity.code
+    :original_path: component:systolic.value[x].code
+    :fixed_value: mm[Hg]
+  - :path: component:systolic.dataAbsentReason
+  - :path: component:diastolic.code.coding.code
+    :fixed_value: 8462-4
+  - :path: component:diastolic.valueQuantity
+    :original_path: component:diastolic.value[x]
+  - :path: component:diastolic.valueQuantity.value
+    :original_path: component:diastolic.value[x].value
+  - :path: component:diastolic.valueQuantity.unit
+    :original_path: component:diastolic.value[x].unit
+  - :path: component:diastolic.valueQuantity.system
+    :original_path: component:diastolic.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:diastolic.valueQuantity.code
+    :original_path: component:diastolic.value[x].code
+    :fixed_value: mm[Hg]
+  - :path: component:diastolic.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/bmi/bmi_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/bmi/bmi_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/bmi/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 39156-5
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
     :fixed_value: kg/m2
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v6.1.0/body_height/body_height_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_height/body_height_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_height/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8302-2
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/body_temperature/body_temperature_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_temperature/body_temperature_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_temperature/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8310-5
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/body_weight/body_weight_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_weight/body_weight_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_weight/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 29463-7
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/care_plan/metadata.yml
@@ -126,7 +126,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: CarePlan.category:AssessPlan
+  - :slice_id: CarePlan.category:AssessPlan
+    :slice_name: AssessPlan
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_encounter_diagnosis/metadata.yml
@@ -243,7 +243,8 @@
   - :id: Condition.extension:assertedDate
     :url: http://hl7.org/fhir/StructureDefinition/condition-assertedDate
   :slices:
-  - :name: Condition.category:us-core
+  - :slice_id: Condition.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_problems_health_concerns/metadata.yml
@@ -250,7 +250,8 @@
   - :id: Condition.extension:assertedDate
     :url: http://hl7.org/fhir/StructureDefinition/condition-assertedDate
   :slices:
-  - :name: Condition.category:us-core
+  - :slice_id: Condition.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding
@@ -258,7 +259,8 @@
       :values:
       - problem-list-item
       - health-concern
-  - :name: Condition.category:screening-assessment
+  - :slice_id: Condition.category:screening-assessment
+    :slice_name: screening-assessment
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v6.1.0/coverage/coverage_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/coverage/coverage_must_support_test.rb
@@ -14,13 +14,15 @@ module USCoreTestKit
 
         * Coverage.beneficiary
         * Coverage.class
-        * Coverage.class.name
-        * Coverage.class.value
         * Coverage.class:group
+        * Coverage.class:group.name
+        * Coverage.class:group.value
         * Coverage.class:plan
+        * Coverage.class:plan.name
+        * Coverage.class:plan.value
         * Coverage.identifier
-        * Coverage.identifier.type.coding.code
         * Coverage.identifier:memberid
+        * Coverage.identifier:memberid.type.coding.code
         * Coverage.payor
         * Coverage.period
         * Coverage.relationship

--- a/lib/us_core_test_kit/generated/v6.1.0/coverage/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/coverage/metadata.yml
@@ -54,21 +54,24 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Coverage.identifier:memberid
+  - :slice_id: Coverage.identifier:memberid
+    :slice_name: memberid
     :path: identifier
     :discriminator:
       :type: patternCodeableConcept
       :path: type
       :code: MB
       :system: http://terminology.hl7.org/CodeSystem/v2-0203
-  - :name: Coverage.class:group
+  - :slice_id: Coverage.class:group
+    :slice_name: group
     :path: class
     :discriminator:
       :type: patternCodeableConcept
       :path: type
       :code: group
       :system: http://terminology.hl7.org/CodeSystem/coverage-class
-  - :name: Coverage.class:plan
+  - :slice_id: Coverage.class:plan
+    :slice_name: plan
     :path: class
     :discriminator:
       :type: patternCodeableConcept
@@ -77,7 +80,7 @@
       :system: http://terminology.hl7.org/CodeSystem/coverage-class
   :elements:
   - :path: identifier
-  - :path: identifier.type.coding.code
+  - :path: identifier:memberid.type.coding.code
     :fixed_value: MB
   - :path: status
   - :path: type
@@ -93,8 +96,10 @@
     :target_profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
   - :path: class
-  - :path: class.value
-  - :path: class.name
+  - :path: class:group.value
+  - :path: class:group.name
+  - :path: class:plan.value
+  - :path: class:plan.name
 :mandatory_elements:
 - Coverage.identifier.type
 - Coverage.status

--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_lab/metadata.yml
@@ -146,7 +146,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: DiagnosticReport.category:LaboratorySlice
+  - :slice_id: DiagnosticReport.category:LaboratorySlice
+    :slice_name: LaboratorySlice
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
@@ -149,7 +149,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: DiagnosticReport.category:us-core
+  - :slice_id: DiagnosticReport.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v6.1.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/document_reference/metadata.yml
@@ -178,7 +178,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: DocumentReference.category:uscore
+  - :slice_id: DocumentReference.category:uscore
+    :slice_name: uscore
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v6.1.0/head_circumference/head_circumference_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/head_circumference/head_circumference_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/head_circumference/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 9843-4
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/head_circumference_percentile/head_circumference_percentile_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/head_circumference_percentile/head_circumference_percentile_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/head_circumference_percentile/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8289-1
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v6.1.0/heart_rate/heart_rate_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/heart_rate/heart_rate_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/heart_rate/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 8867-4
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
     :fixed_value: "/min"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v6.1.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/medication_request/metadata.yml
@@ -143,7 +143,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: MedicationRequest.category:us-core
+  - :slice_id: MedicationRequest.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -262,7 +262,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: CarePlan.category:AssessPlan
+    - :slice_id: CarePlan.category:AssessPlan
+      :slice_name: AssessPlan
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -790,7 +791,8 @@
     - :id: Condition.extension:assertedDate
       :url: http://hl7.org/fhir/StructureDefinition/condition-assertedDate
     :slices:
-    - :name: Condition.category:us-core
+    - :slice_id: Condition.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -1109,7 +1111,8 @@
     - :id: Condition.extension:assertedDate
       :url: http://hl7.org/fhir/StructureDefinition/condition-assertedDate
     :slices:
-    - :name: Condition.category:us-core
+    - :slice_id: Condition.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -1117,7 +1120,8 @@
         :values:
         - problem-list-item
         - health-concern
-    - :name: Condition.category:screening-assessment
+    - :slice_id: Condition.category:screening-assessment
+      :slice_name: screening-assessment
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -1246,21 +1250,24 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Coverage.identifier:memberid
+    - :slice_id: Coverage.identifier:memberid
+      :slice_name: memberid
       :path: identifier
       :discriminator:
         :type: patternCodeableConcept
         :path: type
         :code: MB
         :system: http://terminology.hl7.org/CodeSystem/v2-0203
-    - :name: Coverage.class:group
+    - :slice_id: Coverage.class:group
+      :slice_name: group
       :path: class
       :discriminator:
         :type: patternCodeableConcept
         :path: type
         :code: group
         :system: http://terminology.hl7.org/CodeSystem/coverage-class
-    - :name: Coverage.class:plan
+    - :slice_id: Coverage.class:plan
+      :slice_name: plan
       :path: class
       :discriminator:
         :type: patternCodeableConcept
@@ -1269,7 +1276,7 @@
         :system: http://terminology.hl7.org/CodeSystem/coverage-class
     :elements:
     - :path: identifier
-    - :path: identifier.type.coding.code
+    - :path: identifier:memberid.type.coding.code
       :fixed_value: MB
     - :path: status
     - :path: type
@@ -1285,8 +1292,10 @@
       :target_profiles:
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
     - :path: class
-    - :path: class.value
-    - :path: class.name
+    - :path: class:group.value
+    - :path: class:group.name
+    - :path: class:plan.value
+    - :path: class:plan.name
   :mandatory_elements:
   - Coverage.identifier.type
   - Coverage.status
@@ -1629,7 +1638,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: DiagnosticReport.category:us-core
+    - :slice_id: DiagnosticReport.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -1871,7 +1881,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: DiagnosticReport.category:LaboratorySlice
+    - :slice_id: DiagnosticReport.category:LaboratorySlice
+      :slice_name: LaboratorySlice
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -2130,7 +2141,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: DocumentReference.category:uscore
+    - :slice_id: DocumentReference.category:uscore
+      :slice_name: uscore
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -3461,7 +3473,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: MedicationRequest.category:us-core
+    - :slice_id: MedicationRequest.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -3745,7 +3758,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:us-core
+    - :slice_id: Observation.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: patternCodeableConcept
@@ -3993,19 +4007,22 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:SocialHistory
+    - :slice_id: Observation.category:SocialHistory
+      :slice_name: SocialHistory
       :path: category
       :discriminator:
         :type: patternCodeableConcept
         :path: ''
         :code: social-history
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.effective[x]:effectiveDateTime
+    - :slice_id: Observation.effective[x]:effectiveDateTime
+      :slice_name: effectiveDateTime
       :path: effective[x]
       :discriminator:
         :type: type
         :code: DateTime
-    - :name: Observation.value[x]:valueCodeableConcept
+    - :slice_id: Observation.value[x]:valueCodeableConcept
+      :slice_name: valueCodeableConcept
       :path: value[x]
       :discriminator:
         :type: type
@@ -4234,19 +4251,22 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:SocialHistory
+    - :slice_id: Observation.category:SocialHistory
+      :slice_name: SocialHistory
       :path: category
       :discriminator:
         :type: patternCodeableConcept
         :path: ''
         :code: social-history
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.effective[x]:effectiveDateTime
+    - :slice_id: Observation.effective[x]:effectiveDateTime
+      :slice_name: effectiveDateTime
       :path: effective[x]
       :discriminator:
         :type: type
         :code: DateTime
-    - :name: Observation.value[x]:valueCodeableConcept
+    - :slice_id: Observation.value[x]:valueCodeableConcept
+      :slice_name: valueCodeableConcept
       :path: value[x]
       :discriminator:
         :type: type
@@ -4475,26 +4495,30 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:socialhistory
+    - :slice_id: Observation.category:socialhistory
+      :slice_name: socialhistory
       :path: category
       :discriminator:
         :type: patternCodeableConcept
         :path: ''
         :code: social-history
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.component:industry
+    - :slice_id: Observation.component:industry
+      :slice_name: industry
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 86188-0
         :system: http://loinc.org
-    - :name: Observation.effective[x]:effectivePeriod
+    - :slice_id: Observation.effective[x]:effectivePeriod
+      :slice_name: effectivePeriod
       :path: effective[x]
       :discriminator:
         :type: type
         :code: Period
-    - :name: Observation.value[x]:valueCodeableConcept
+    - :slice_id: Observation.value[x]:valueCodeableConcept
+      :slice_name: valueCodeableConcept
       :path: value[x]
       :discriminator:
         :type: type
@@ -4508,9 +4532,9 @@
       :types:
       - Reference
     - :path: component
-    - :path: component.code.coding.code
+    - :path: component:industry.code.coding.code
       :fixed_value: 86188-0
-    - :path: component.value[x]
+    - :path: component:industry.value[x]
   :mandatory_elements:
   - Observation.status
   - Observation.code
@@ -4719,12 +4743,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -4736,10 +4762,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 9279-1
@@ -4750,15 +4776,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
       :fixed_value: "/min"
   :mandatory_elements:
   - Observation.status
@@ -4990,7 +5016,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:us-core
+    - :slice_id: Observation.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -5245,12 +5272,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5262,10 +5291,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8867-4
@@ -5276,15 +5305,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
       :fixed_value: "/min"
   :mandatory_elements:
   - Observation.status
@@ -5505,12 +5534,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5522,10 +5553,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8310-5
@@ -5536,15 +5567,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -5768,12 +5799,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -5785,10 +5818,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 77606-2
@@ -5799,15 +5832,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -6029,40 +6062,46 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.code.coding:PulseOx
+    - :slice_id: Observation.code.coding:PulseOx
+      :slice_name: PulseOx
       :path: code.coding
       :discriminator:
         :type: patternCoding
         :path: ''
         :code: 59408-5
         :system: http://loinc.org
-    - :name: Observation.code.coding:O2Sat
+    - :slice_id: Observation.code.coding:O2Sat
+      :slice_name: O2Sat
       :path: code.coding
       :discriminator:
         :type: patternCoding
         :path: ''
         :code: 2708-6
         :system: http://loinc.org
-    - :name: Observation.component:FlowRate
+    - :slice_id: Observation.component:FlowRate
+      :slice_name: FlowRate
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 3151-8
         :system: http://loinc.org
-    - :name: Observation.component:Concentration
+    - :slice_id: Observation.component:Concentration
+      :slice_name: Concentration
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 3150-0
         :system: http://loinc.org
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -6074,10 +6113,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code
     - :path: code.coding
@@ -6088,37 +6127,50 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
       :fixed_value: "%"
     - :path: component
     - :path: component.code
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component.code.coding.code
+    - :path: component:FlowRate.code.coding.code
       :fixed_value: 3151-8
-    - :path: component.valueQuantity.system
-      :original_path: component.value[x].system
+    - :path: component:FlowRate.valueQuantity
+      :original_path: component:FlowRate.value[x]
+    - :path: component:FlowRate.valueQuantity.value
+      :original_path: component:FlowRate.value[x].value
+    - :path: component:FlowRate.valueQuantity.unit
+      :original_path: component:FlowRate.value[x].unit
+    - :path: component:FlowRate.valueQuantity.system
+      :original_path: component:FlowRate.value[x].system
       :fixed_value: http://unitsofmeasure.org
-    - :path: component.valueQuantity.code
-      :original_path: component.value[x].code
+    - :path: component:FlowRate.valueQuantity.code
+      :original_path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component.code.coding.code
+    - :path: component:FlowRate.dataAbsentReason
+    - :path: component:Concentration.code.coding.code
       :fixed_value: 3150-0
-    - :path: component.valueQuantity.value
-      :original_path: component.value[x].value
-    - :path: component.valueQuantity.unit
-      :original_path: component.value[x].unit
-    - :path: component.valueQuantity.code
-      :original_path: component.value[x].code
+    - :path: component:Concentration.valueQuantity
+      :original_path: component:Concentration.value[x]
+    - :path: component:Concentration.valueQuantity.value
+      :original_path: component:Concentration.value[x].value
+    - :path: component:Concentration.valueQuantity.unit
+      :original_path: component:Concentration.value[x].unit
+    - :path: component:Concentration.valueQuantity.system
+      :original_path: component:Concentration.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:Concentration.valueQuantity.code
+      :original_path: component:Concentration.value[x].code
       :fixed_value: "%"
+    - :path: component:Concentration.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -6345,14 +6397,16 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:SocialHistory
+    - :slice_id: Observation.category:SocialHistory
+      :slice_name: SocialHistory
       :path: category
       :discriminator:
         :type: patternCodeableConcept
         :path: ''
         :code: social-history
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.effective[x]:effectiveDateTime
+    - :slice_id: Observation.effective[x]:effectiveDateTime
+      :slice_name: effectiveDateTime
       :path: effective[x]
       :discriminator:
         :type: type
@@ -6586,7 +6640,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueCodeableConcept
+    - :slice_id: Observation.value[x]:valueCodeableConcept
+      :slice_name: valueCodeableConcept
       :path: value[x]
       :discriminator:
         :type: type
@@ -6806,12 +6861,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -6823,10 +6880,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 9843-4
@@ -6837,15 +6894,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -7069,12 +7126,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -7086,10 +7145,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8302-2
@@ -7100,15 +7159,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -7332,12 +7391,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -7349,10 +7410,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 39156-5
@@ -7363,15 +7424,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
       :fixed_value: kg/m2
   :mandatory_elements:
   - Observation.status
@@ -7591,14 +7652,16 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:survey
+    - :slice_id: Observation.category:survey
+      :slice_name: survey
       :path: category
       :discriminator:
         :type: patternCodeableConcept
         :path: ''
         :code: survey
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :name: Observation.category:screening-assessment
+    - :slice_id: Observation.category:screening-assessment
+      :slice_name: screening-assessment
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -7853,21 +7916,24 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.component:systolic
+    - :slice_id: Observation.component:systolic
+      :slice_name: systolic
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 8480-6
         :system: http://loinc.org
-    - :name: Observation.component:diastolic
+    - :slice_id: Observation.component:diastolic
+      :slice_name: diastolic
       :path: component
       :discriminator:
         :type: patternCodeableConcept
         :path: code
         :code: 8462-4
         :system: http://loinc.org
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -7879,10 +7945,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 85354-9
@@ -7893,22 +7959,38 @@
       :original_path: effective[x]
     - :path: component
     - :path: component.code
-    - :path: component.code.coding.code
-      :fixed_value: 8480-6
-    - :path: component.valueQuantity.system
-      :original_path: component.value[x].system
-      :fixed_value: http://unitsofmeasure.org
-    - :path: component.valueQuantity.code
-      :original_path: component.value[x].code
-      :fixed_value: mm[Hg]
-    - :path: component.code.coding.code
-      :fixed_value: 8462-4
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component.valueQuantity.value
-      :original_path: component.value[x].value
-    - :path: component.valueQuantity.unit
-      :original_path: component.value[x].unit
+    - :path: component:systolic.code.coding.code
+      :fixed_value: 8480-6
+    - :path: component:systolic.valueQuantity
+      :original_path: component:systolic.value[x]
+    - :path: component:systolic.valueQuantity.value
+      :original_path: component:systolic.value[x].value
+    - :path: component:systolic.valueQuantity.unit
+      :original_path: component:systolic.value[x].unit
+    - :path: component:systolic.valueQuantity.system
+      :original_path: component:systolic.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:systolic.valueQuantity.code
+      :original_path: component:systolic.value[x].code
+      :fixed_value: mm[Hg]
+    - :path: component:systolic.dataAbsentReason
+    - :path: component:diastolic.code.coding.code
+      :fixed_value: 8462-4
+    - :path: component:diastolic.valueQuantity
+      :original_path: component:diastolic.value[x]
+    - :path: component:diastolic.valueQuantity.value
+      :original_path: component:diastolic.value[x].value
+    - :path: component:diastolic.valueQuantity.unit
+      :original_path: component:diastolic.value[x].unit
+    - :path: component:diastolic.valueQuantity.system
+      :original_path: component:diastolic.value[x].system
+      :fixed_value: http://unitsofmeasure.org
+    - :path: component:diastolic.valueQuantity.code
+      :original_path: component:diastolic.value[x].code
+      :fixed_value: mm[Hg]
+    - :path: component:diastolic.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -8138,7 +8220,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.category:us-core
+    - :slice_id: Observation.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding
@@ -8373,12 +8456,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -8390,10 +8475,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 59576-9
@@ -8404,15 +8489,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -8634,12 +8719,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -8651,10 +8738,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 8289-1
@@ -8665,15 +8752,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
       :fixed_value: "%"
   :mandatory_elements:
   - Observation.status
@@ -8894,12 +8981,14 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Observation.value[x]:valueQuantity
+    - :slice_id: Observation.value[x]:valueQuantity
+      :slice_name: valueQuantity
       :path: value[x]
       :discriminator:
         :type: type
         :code: Quantity
-    - :name: Observation.category:VSCat
+    - :slice_id: Observation.category:VSCat
+      :slice_name: VSCat
       :path: category
       :discriminator:
         :type: value
@@ -8911,10 +9000,10 @@
     :elements:
     - :path: status
     - :path: category
-    - :path: category.coding
-    - :path: category.coding.system
+    - :path: category:VSCat.coding
+    - :path: category:VSCat.coding.system
       :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-    - :path: category.coding.code
+    - :path: category:VSCat.coding.code
       :fixed_value: vital-signs
     - :path: code.coding.code
       :fixed_value: 29463-7
@@ -8925,15 +9014,15 @@
       :original_path: effective[x]
     - :path: valueQuantity
       :original_path: value[x]
-    - :path: valueQuantity.value
-      :original_path: value[x].value
-    - :path: valueQuantity.unit
-      :original_path: value[x].unit
-    - :path: valueQuantity.system
-      :original_path: value[x].system
+    - :path: valueQuantity:valueQuantity.value
+      :original_path: value[x]:valueQuantity.value
+    - :path: valueQuantity:valueQuantity.unit
+      :original_path: value[x]:valueQuantity.unit
+    - :path: valueQuantity:valueQuantity.system
+      :original_path: value[x]:valueQuantity.system
       :fixed_value: http://unitsofmeasure.org
-    - :path: valueQuantity.code
-      :original_path: value[x].code
+    - :path: valueQuantity:valueQuantity.code
+      :original_path: value[x]:valueQuantity.code
   :mandatory_elements:
   - Observation.status
   - Observation.category
@@ -9087,7 +9176,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Organization.identifier:NPI
+    - :slice_id: Organization.identifier:NPI
+      :slice_name: NPI
       :path: identifier
       :discriminator:
         :type: patternIdentifier
@@ -9586,7 +9676,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Practitioner.identifier:NPI
+    - :slice_id: Practitioner.identifier:NPI
+      :slice_name: NPI
       :path: identifier
       :discriminator:
         :type: patternIdentifier
@@ -10034,14 +10125,16 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: Provenance.agent:ProvenanceAuthor
+    - :slice_id: Provenance.agent:ProvenanceAuthor
+      :slice_name: ProvenanceAuthor
       :path: agent
       :discriminator:
         :type: patternCodeableConcept
         :path: type
         :code: author
         :system: http://terminology.hl7.org/CodeSystem/provenance-participant-type
-    - :name: Provenance.agent:ProvenanceTransmitter
+    - :slice_id: Provenance.agent:ProvenanceTransmitter
+      :slice_name: ProvenanceTransmitter
       :path: agent
       :discriminator:
         :type: patternCodeableConcept
@@ -10064,9 +10157,9 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
-    - :path: agent.type.coding.code
+    - :path: agent:ProvenanceAuthor.type.coding.code
       :fixed_value: author
-    - :path: agent.type.coding.code
+    - :path: agent:ProvenanceTransmitter.type.coding.code
       :fixed_value: transmitter
   :mandatory_elements:
   - Provenance.target
@@ -10635,7 +10728,8 @@
   :must_supports:
     :extensions: []
     :slices:
-    - :name: ServiceRequest.category:us-core
+    - :slice_id: ServiceRequest.category:us-core
+      :slice_name: us-core
       :path: category
       :discriminator:
         :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -7961,6 +7961,7 @@
     - :path: component.code
     - :path: component.valueQuantity
       :original_path: component.value[x]
+    - :path: component.dataAbsentReason
     - :path: component:systolic.code.coding.code
       :fixed_value: 8480-6
     - :path: component:systolic.valueQuantity
@@ -7991,7 +7992,6 @@
       :original_path: component:diastolic.value[x].code
       :fixed_value: mm[Hg]
     - :path: component:diastolic.dataAbsentReason
-    - :path: component.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -6155,7 +6155,6 @@
     - :path: component:FlowRate.valueQuantity.code
       :original_path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component:FlowRate.dataAbsentReason
     - :path: component:Concentration.code.coding.code
       :fixed_value: 3150-0
     - :path: component:Concentration.valueQuantity
@@ -6170,7 +6169,6 @@
     - :path: component:Concentration.valueQuantity.code
       :original_path: component:Concentration.value[x].code
       :fixed_value: "%"
-    - :path: component:Concentration.dataAbsentReason
   :mandatory_elements:
   - Observation.status
   - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_clinical_result/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_clinical_result/metadata.yml
@@ -146,7 +146,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:us-core
+  - :slice_id: Observation.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_lab/metadata.yml
@@ -140,7 +140,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:us-core
+  - :slice_id: Observation.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: patternCodeableConcept

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/metadata.yml
@@ -149,26 +149,30 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:socialhistory
+  - :slice_id: Observation.category:socialhistory
+    :slice_name: socialhistory
     :path: category
     :discriminator:
       :type: patternCodeableConcept
       :path: ''
       :code: social-history
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.component:industry
+  - :slice_id: Observation.component:industry
+    :slice_name: industry
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 86188-0
       :system: http://loinc.org
-  - :name: Observation.effective[x]:effectivePeriod
+  - :slice_id: Observation.effective[x]:effectivePeriod
+    :slice_name: effectivePeriod
     :path: effective[x]
     :discriminator:
       :type: type
       :code: Period
-  - :name: Observation.value[x]:valueCodeableConcept
+  - :slice_id: Observation.value[x]:valueCodeableConcept
+    :slice_name: valueCodeableConcept
     :path: value[x]
     :discriminator:
       :type: type
@@ -182,9 +186,9 @@
     :types:
     - Reference
   - :path: component
-  - :path: component.code.coding.code
+  - :path: component:industry.code.coding.code
     :fixed_value: 86188-0
-  - :path: component.value[x]
+  - :path: component:industry.value[x]
 :mandatory_elements:
 - Observation.status
 - Observation.code

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/observation_occupation_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/observation_occupation_must_support_test.rb
@@ -16,9 +16,9 @@ module USCoreTestKit
         * Observation.category:socialhistory
         * Observation.code.coding.code
         * Observation.component
-        * Observation.component.code.coding.code
-        * Observation.component.value[x]
         * Observation.component:industry
+        * Observation.component:industry.code.coding.code
+        * Observation.component:industry.value[x]
         * Observation.effective[x]:effectivePeriod
         * Observation.status
         * Observation.subject

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancyintent/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancyintent/metadata.yml
@@ -149,19 +149,22 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:SocialHistory
+  - :slice_id: Observation.category:SocialHistory
+    :slice_name: SocialHistory
     :path: category
     :discriminator:
       :type: patternCodeableConcept
       :path: ''
       :code: social-history
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.effective[x]:effectiveDateTime
+  - :slice_id: Observation.effective[x]:effectiveDateTime
+    :slice_name: effectiveDateTime
     :path: effective[x]
     :discriminator:
       :type: type
       :code: DateTime
-  - :name: Observation.value[x]:valueCodeableConcept
+  - :slice_id: Observation.value[x]:valueCodeableConcept
+    :slice_name: valueCodeableConcept
     :path: value[x]
     :discriminator:
       :type: type

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancystatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancystatus/metadata.yml
@@ -149,19 +149,22 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:SocialHistory
+  - :slice_id: Observation.category:SocialHistory
+    :slice_name: SocialHistory
     :path: category
     :discriminator:
       :type: patternCodeableConcept
       :path: ''
       :code: social-history
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.effective[x]:effectiveDateTime
+  - :slice_id: Observation.effective[x]:effectiveDateTime
+    :slice_name: effectiveDateTime
     :path: effective[x]
     :discriminator:
       :type: type
       :code: DateTime
-  - :name: Observation.value[x]:valueCodeableConcept
+  - :slice_id: Observation.value[x]:valueCodeableConcept
+    :slice_name: valueCodeableConcept
     :path: value[x]
     :discriminator:
       :type: type

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_screening_assessment/metadata.yml
@@ -140,14 +140,16 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:survey
+  - :slice_id: Observation.category:survey
+    :slice_name: survey
     :path: category
     :discriminator:
       :type: patternCodeableConcept
       :path: ''
       :code: survey
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.category:screening-assessment
+  - :slice_id: Observation.category:screening-assessment
+    :slice_name: screening-assessment
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_sexual_orientation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_sexual_orientation/metadata.yml
@@ -152,7 +152,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueCodeableConcept
+  - :slice_id: Observation.value[x]:valueCodeableConcept
+    :slice_name: valueCodeableConcept
     :path: value[x]
     :discriminator:
       :type: type

--- a/lib/us_core_test_kit/generated/v6.1.0/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/organization/metadata.yml
@@ -70,7 +70,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Organization.identifier:NPI
+  - :slice_id: Organization.identifier:NPI
+    :slice_name: NPI
     :path: identifier
     :discriminator:
       :type: patternIdentifier

--- a/lib/us_core_test_kit/generated/v6.1.0/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pediatric_bmi_for_age/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 59576-9
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v6.1.0/pediatric_bmi_for_age/pediatric_bmi_for_age_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/pediatric_bmi_for_age/pediatric_bmi_for_age_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pediatric_weight_for_height/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 77606-2
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
     :fixed_value: "%"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v6.1.0/pediatric_weight_for_height/pediatric_weight_for_height_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/pediatric_weight_for_height/pediatric_weight_for_height_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/practitioner/metadata.yml
@@ -83,7 +83,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Practitioner.identifier:NPI
+  - :slice_id: Practitioner.identifier:NPI
+    :slice_name: NPI
     :path: identifier
     :discriminator:
       :type: patternIdentifier

--- a/lib/us_core_test_kit/generated/v6.1.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/provenance/metadata.yml
@@ -38,14 +38,16 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Provenance.agent:ProvenanceAuthor
+  - :slice_id: Provenance.agent:ProvenanceAuthor
+    :slice_name: ProvenanceAuthor
     :path: agent
     :discriminator:
       :type: patternCodeableConcept
       :path: type
       :code: author
       :system: http://terminology.hl7.org/CodeSystem/provenance-participant-type
-  - :name: Provenance.agent:ProvenanceTransmitter
+  - :slice_id: Provenance.agent:ProvenanceTransmitter
+    :slice_name: ProvenanceTransmitter
     :path: agent
     :discriminator:
       :type: patternCodeableConcept
@@ -68,9 +70,9 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
-  - :path: agent.type.coding.code
+  - :path: agent:ProvenanceAuthor.type.coding.code
     :fixed_value: author
-  - :path: agent.type.coding.code
+  - :path: agent:ProvenanceTransmitter.type.coding.code
     :fixed_value: transmitter
 :mandatory_elements:
 - Provenance.target

--- a/lib/us_core_test_kit/generated/v6.1.0/provenance/provenance_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/provenance/provenance_must_support_test.rb
@@ -15,10 +15,11 @@ module USCoreTestKit
         * Provenance.agent
         * Provenance.agent.onBehalfOf
         * Provenance.agent.type
-        * Provenance.agent.type.coding.code
         * Provenance.agent.who
         * Provenance.agent:ProvenanceAuthor
+        * Provenance.agent:ProvenanceAuthor.type.coding.code
         * Provenance.agent:ProvenanceTransmitter
+        * Provenance.agent:ProvenanceTransmitter.type.coding.code
         * Provenance.recorded
         * Provenance.target
         * Provenance.target.reference

--- a/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
@@ -142,40 +142,46 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.code.coding:PulseOx
+  - :slice_id: Observation.code.coding:PulseOx
+    :slice_name: PulseOx
     :path: code.coding
     :discriminator:
       :type: patternCoding
       :path: ''
       :code: 59408-5
       :system: http://loinc.org
-  - :name: Observation.code.coding:O2Sat
+  - :slice_id: Observation.code.coding:O2Sat
+    :slice_name: O2Sat
     :path: code.coding
     :discriminator:
       :type: patternCoding
       :path: ''
       :code: 2708-6
       :system: http://loinc.org
-  - :name: Observation.component:FlowRate
+  - :slice_id: Observation.component:FlowRate
+    :slice_name: FlowRate
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 3151-8
       :system: http://loinc.org
-  - :name: Observation.component:Concentration
+  - :slice_id: Observation.component:Concentration
+    :slice_name: Concentration
     :path: component
     :discriminator:
       :type: patternCodeableConcept
       :path: code
       :code: 3150-0
       :system: http://loinc.org
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -187,10 +193,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code
   - :path: code.coding
@@ -201,37 +207,50 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
     :fixed_value: "%"
   - :path: component
   - :path: component.code
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component.code.coding.code
+  - :path: component:FlowRate.code.coding.code
     :fixed_value: 3151-8
-  - :path: component.valueQuantity.system
-    :original_path: component.value[x].system
+  - :path: component:FlowRate.valueQuantity
+    :original_path: component:FlowRate.value[x]
+  - :path: component:FlowRate.valueQuantity.value
+    :original_path: component:FlowRate.value[x].value
+  - :path: component:FlowRate.valueQuantity.unit
+    :original_path: component:FlowRate.value[x].unit
+  - :path: component:FlowRate.valueQuantity.system
+    :original_path: component:FlowRate.value[x].system
     :fixed_value: http://unitsofmeasure.org
-  - :path: component.valueQuantity.code
-    :original_path: component.value[x].code
+  - :path: component:FlowRate.valueQuantity.code
+    :original_path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component.code.coding.code
+  - :path: component:FlowRate.dataAbsentReason
+  - :path: component:Concentration.code.coding.code
     :fixed_value: 3150-0
-  - :path: component.valueQuantity.value
-    :original_path: component.value[x].value
-  - :path: component.valueQuantity.unit
-    :original_path: component.value[x].unit
-  - :path: component.valueQuantity.code
-    :original_path: component.value[x].code
+  - :path: component:Concentration.valueQuantity
+    :original_path: component:Concentration.value[x]
+  - :path: component:Concentration.valueQuantity.value
+    :original_path: component:Concentration.value[x].value
+  - :path: component:Concentration.valueQuantity.unit
+    :original_path: component:Concentration.value[x].unit
+  - :path: component:Concentration.valueQuantity.system
+    :original_path: component:Concentration.value[x].system
+    :fixed_value: http://unitsofmeasure.org
+  - :path: component:Concentration.valueQuantity.code
+    :original_path: component:Concentration.value[x].code
     :fixed_value: "%"
+  - :path: component:Concentration.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
@@ -235,7 +235,6 @@
   - :path: component:FlowRate.valueQuantity.code
     :original_path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component:FlowRate.dataAbsentReason
   - :path: component:Concentration.code.coding.code
     :fixed_value: 3150-0
   - :path: component:Concentration.valueQuantity
@@ -250,7 +249,6 @@
   - :path: component:Concentration.valueQuantity.code
     :original_path: component:Concentration.value[x].code
     :fixed_value: "%"
-  - :path: component:Concentration.dataAbsentReason
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -13,32 +13,41 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code
         * Observation.code.coding
         * Observation.code.coding:O2Sat
         * Observation.code.coding:PulseOx
         * Observation.component
         * Observation.component.code
-        * Observation.component.code.coding.code
         * Observation.component.valueQuantity
-        * Observation.component.valueQuantity.code
-        * Observation.component.valueQuantity.system
-        * Observation.component.valueQuantity.unit
-        * Observation.component.valueQuantity.value
         * Observation.component:Concentration
+        * Observation.component:Concentration.code.coding.code
+        * Observation.component:Concentration.dataAbsentReason
+        * Observation.component:Concentration.valueQuantity
+        * Observation.component:Concentration.valueQuantity.code
+        * Observation.component:Concentration.valueQuantity.system
+        * Observation.component:Concentration.valueQuantity.unit
+        * Observation.component:Concentration.valueQuantity.value
         * Observation.component:FlowRate
+        * Observation.component:FlowRate.code.coding.code
+        * Observation.component:FlowRate.dataAbsentReason
+        * Observation.component:FlowRate.valueQuantity
+        * Observation.component:FlowRate.valueQuantity.code
+        * Observation.component:FlowRate.valueQuantity.system
+        * Observation.component:FlowRate.valueQuantity.unit
+        * Observation.component:FlowRate.valueQuantity.value
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -26,7 +26,6 @@ module USCoreTestKit
         * Observation.component.valueQuantity
         * Observation.component:Concentration
         * Observation.component:Concentration.code.coding.code
-        * Observation.component:Concentration.dataAbsentReason
         * Observation.component:Concentration.valueQuantity
         * Observation.component:Concentration.valueQuantity.code
         * Observation.component:Concentration.valueQuantity.system
@@ -34,7 +33,6 @@ module USCoreTestKit
         * Observation.component:Concentration.valueQuantity.value
         * Observation.component:FlowRate
         * Observation.component:FlowRate.code.coding.code
-        * Observation.component:FlowRate.dataAbsentReason
         * Observation.component:FlowRate.valueQuantity
         * Observation.component:FlowRate.valueQuantity.code
         * Observation.component:FlowRate.valueQuantity.system

--- a/lib/us_core_test_kit/generated/v6.1.0/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/respiratory_rate/metadata.yml
@@ -141,12 +141,14 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.value[x]:valueQuantity
+  - :slice_id: Observation.value[x]:valueQuantity
+    :slice_name: valueQuantity
     :path: value[x]
     :discriminator:
       :type: type
       :code: Quantity
-  - :name: Observation.category:VSCat
+  - :slice_id: Observation.category:VSCat
+    :slice_name: VSCat
     :path: category
     :discriminator:
       :type: value
@@ -158,10 +160,10 @@
   :elements:
   - :path: status
   - :path: category
-  - :path: category.coding
-  - :path: category.coding.system
+  - :path: category:VSCat.coding
+  - :path: category:VSCat.coding.system
     :fixed_value: http://terminology.hl7.org/CodeSystem/observation-category
-  - :path: category.coding.code
+  - :path: category:VSCat.coding.code
     :fixed_value: vital-signs
   - :path: code.coding.code
     :fixed_value: 9279-1
@@ -172,15 +174,15 @@
     :original_path: effective[x]
   - :path: valueQuantity
     :original_path: value[x]
-  - :path: valueQuantity.value
-    :original_path: value[x].value
-  - :path: valueQuantity.unit
-    :original_path: value[x].unit
-  - :path: valueQuantity.system
-    :original_path: value[x].system
+  - :path: valueQuantity:valueQuantity.value
+    :original_path: value[x]:valueQuantity.value
+  - :path: valueQuantity:valueQuantity.unit
+    :original_path: value[x]:valueQuantity.unit
+  - :path: valueQuantity:valueQuantity.system
+    :original_path: value[x]:valueQuantity.system
     :fixed_value: http://unitsofmeasure.org
-  - :path: valueQuantity.code
-    :original_path: value[x].code
+  - :path: valueQuantity:valueQuantity.code
+    :original_path: value[x]:valueQuantity.code
     :fixed_value: "/min"
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v6.1.0/respiratory_rate/respiratory_rate_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/respiratory_rate/respiratory_rate_must_support_test.rb
@@ -13,19 +13,19 @@ module USCoreTestKit
         found previously for the following must support elements:
 
         * Observation.category
-        * Observation.category.coding
-        * Observation.category.coding.code
-        * Observation.category.coding.system
         * Observation.category:VSCat
+        * Observation.category:VSCat.coding
+        * Observation.category:VSCat.coding.code
+        * Observation.category:VSCat.coding.system
         * Observation.code.coding.code
         * Observation.effectiveDateTime
         * Observation.status
         * Observation.subject
         * Observation.valueQuantity
-        * Observation.valueQuantity.code
-        * Observation.valueQuantity.system
-        * Observation.valueQuantity.unit
-        * Observation.valueQuantity.value
+        * Observation.valueQuantity:valueQuantity.code
+        * Observation.valueQuantity:valueQuantity.system
+        * Observation.valueQuantity:valueQuantity.unit
+        * Observation.valueQuantity:valueQuantity.value
         * Observation.value[x]:valueQuantity
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/service_request/metadata.yml
@@ -169,7 +169,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: ServiceRequest.category:us-core
+  - :slice_id: ServiceRequest.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v6.1.0/simple_observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/simple_observation/metadata.yml
@@ -152,7 +152,8 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:us-core
+  - :slice_id: Observation.category:us-core
+    :slice_name: us-core
     :path: category
     :discriminator:
       :type: requiredBinding

--- a/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/metadata.yml
@@ -135,14 +135,16 @@
 :must_supports:
   :extensions: []
   :slices:
-  - :name: Observation.category:SocialHistory
+  - :slice_id: Observation.category:SocialHistory
+    :slice_name: SocialHistory
     :path: category
     :discriminator:
       :type: patternCodeableConcept
       :path: ''
       :code: social-history
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :name: Observation.effective[x]:effectiveDateTime
+  - :slice_id: Observation.effective[x]:effectiveDateTime
+    :slice_name: effectiveDateTime
     :path: effective[x]
     :discriminator:
       :type: type

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -78,7 +78,7 @@ module USCoreTestKit
         must_support_pattern_slice_elements.map do |current_element|
           {
             slice_id: current_element.id,
-            slice_name: current_element.id.split(':')[1],
+            slice_name: current_element.sliceName,
             path: current_element.path.gsub("#{resource}.", '')
           }.tap do |metadata|
             discriminator = discriminators(sliced_element(current_element)).first
@@ -157,7 +157,7 @@ module USCoreTestKit
 
           {
             slice_id: current_element.id,
-            slice_name: current_element.id.split(':')[1],
+            slice_name: current_element.sliceName,
             path: current_element.path.gsub("#{resource}.", ''),
             discriminator: {
               type: 'type',
@@ -181,7 +181,7 @@ module USCoreTestKit
         must_support_value_slice_elements.map do |current_element|
           {
             slice_id: current_element.id,
-            slice_name: current_element.id.split(':')[1],
+            slice_name: current_element.sliceName,
             path: current_element.path.gsub("#{resource}.", ''),
             discriminator: {
               type: 'value'

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -360,13 +360,14 @@ module USCoreTestKit
       def remove_blood_pressure_value_data_absent_reason
         return unless is_blood_pressure?
 
+        pattern = /component(:[^.]+)?\.dataAbsentReason/
+
         @must_supports[:elements].delete_if do |element|
           element[:path].start_with?('value[x]') ||
           element[:original_path]&.start_with?('value[x]') ||
           element[:path] == ('dataAbsentReason') ||
           (
-            element[:path] == ('component.dataAbsentReason') &&
-            ['3.1.1', '4.0.0'].include?(ig_resources.ig.version)
+            pattern.match?(element[:path]) && ['3.1.1', '4.0.0'].include?(ig_resources.ig.version)
           )
         end
 
@@ -383,9 +384,11 @@ module USCoreTestKit
       def remove_observation_data_absent_reason
         return if is_blood_pressure?
 
+        pattern = /(component(:[^.]+)?\.)?dataAbsentReason/
+
         if profile.type == 'Observation'
           @must_supports[:elements].delete_if do |element|
-            ['dataAbsentReason', 'component.dataAbsentReason'].include?(element[:path])
+            pattern.match?(element[:path])
           end
         end
       end

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -77,7 +77,8 @@ module USCoreTestKit
       def pattern_slices
         must_support_pattern_slice_elements.map do |current_element|
           {
-            name: current_element.id,
+            slice_id: current_element.id,
+            slice_name: current_element.id.split(':')[1],
             path: current_element.path.gsub("#{resource}.", '')
           }.tap do |metadata|
             discriminator = discriminators(sliced_element(current_element)).first
@@ -89,7 +90,6 @@ module USCoreTestKit
               else
                 current_element
               end
-
             metadata[:discriminator] =
               if pattern_element.patternCodeableConcept.present?
                 {
@@ -156,7 +156,8 @@ module USCoreTestKit
           type_code = type_element.type.first.code
 
           {
-            name: current_element.id,
+            slice_id: current_element.id,
+            slice_name: current_element.id.split(':')[1],
             path: current_element.path.gsub("#{resource}.", ''),
             discriminator: {
               type: 'type',
@@ -179,7 +180,8 @@ module USCoreTestKit
       def value_slices
         must_support_value_slice_elements.map do |current_element|
           {
-            name: current_element.id,
+            slice_id: current_element.id,
+            slice_name: current_element.id.split(':')[1],
             path: current_element.path.gsub("#{resource}.", ''),
             discriminator: {
               type: 'value'
@@ -283,7 +285,7 @@ module USCoreTestKit
       def must_support_elements
         plain_must_support_elements.each_with_object([]) do |current_element, must_support_elements_metadata|
           {
-            path: current_element.path.gsub("#{resource}.", '')
+            path: current_element.id.gsub("#{resource}.", '')
           }.tap do |current_metadata|
             if is_uscdi_requirement_element?(current_element)
               current_metadata[:uscdi_only] = true

--- a/lib/us_core_test_kit/generator/must_support_test_generator.rb
+++ b/lib/us_core_test_kit/generator/must_support_test_generator.rb
@@ -78,7 +78,7 @@ module USCoreTestKit
       def build_must_support_list_string(uscdi_only)
         slice_names = group_metadata.must_supports[:slices]
           .select { |slice| slice[:uscdi_only].presence == uscdi_only.presence }
-          .map { |slice| slice[:name] }
+          .map { |slice| slice[:slice_id] }
 
         element_names = group_metadata.must_supports[:elements]
           .select { |element| element[:uscdi_only].presence == uscdi_only.presence }

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -15,12 +15,12 @@ module USCoreTestKit
       skip_if resources.blank?, "No #{resource_type} resources were found"
 
       missing_elements(resources)
-      missing_slices(resources)
-      missing_extensions(resources)
+      # missing_slices(resources)
+      # missing_extensions(resources)
 
-      handle_must_support_choices if metadata.must_supports[:choices].present?
+      # handle_must_support_choices if metadata.must_supports[:choices].present?
 
-      if (missing_elements + missing_slices + missing_extensions).length.zero?
+      if (missing_elements).length.zero?# + missing_slices + missing_extensions 
         pass
       end
       skip "Could not find #{missing_must_support_strings.join(', ')} in the #{resources.length} " \
@@ -54,9 +54,9 @@ module USCoreTestKit
     end
 
     def missing_must_support_strings
-      missing_elements.map { |element_definition| missing_element_string(element_definition) } +
-        missing_slices.map { |slice_definition| slice_definition[:slice_id] } +
-        missing_extensions.map { |extension_definition| extension_definition[:id] }
+      missing_elements.map { |element_definition| missing_element_string(element_definition) } # +
+        #missing_slices.map { |slice_definition| slice_definition[:slice_id] } +
+        #missing_extensions.map { |extension_definition| extension_definition[:id] }
     end
 
     def missing_element_string(element_definition)
@@ -109,12 +109,10 @@ module USCoreTestKit
                 (element_definition[:fixed_value].blank? || value == element_definition[:fixed_value])
 
             end
-
             # Note that false.present? => false, which is why we need to add this extra check
             value_found.present? || value_found == false
           end
         end
-
       @missing_elements
     end
 
@@ -180,31 +178,31 @@ module USCoreTestKit
       end
     end
 
-    def find_slice_by_values(element, value_definitions)
-      path_prefixes = value_definitions.map { |value_definition| value_definition[:path].first }.uniq
-      Array.wrap(element).find do |el|
-        path_prefixes.all? do |path_prefix|
-          value_definitions_for_path =
-            value_definitions
-              .select { |value_definition| value_definition[:path].first == path_prefix }
-              .each { |value_definition| value_definition[:path].shift }
+    # def find_slice_by_values(element, value_definitions)
+    #   path_prefixes = value_definitions.map { |value_definition| value_definition[:path].first }.uniq
+    #   Array.wrap(element).find do |el|
+    #     path_prefixes.all? do |path_prefix|
+    #       value_definitions_for_path =
+    #         value_definitions
+    #           .select { |value_definition| value_definition[:path].first == path_prefix }
+    #           .each { |value_definition| value_definition[:path].shift }
 
-          find_a_value_at(el, path_prefix) do |el_found|
-            child_element_value_definitions, current_element_value_definitions =
-              value_definitions_for_path.partition { |value_definition| value_definition[:path].present? }
+    #       find_a_value_at(el, path_prefix) do |el_found|
+    #         child_element_value_definitions, current_element_value_definitions =
+    #           value_definitions_for_path.partition { |value_definition| value_definition[:path].present? }
 
-            current_element_values_match =
-              current_element_value_definitions
-                .all? { |value_definition| value_definition[:value] == el_found }
+    #         current_element_values_match =
+    #           current_element_value_definitions
+    #             .all? { |value_definition| value_definition[:value] == el_found }
 
-            child_element_values_match =
-              child_element_value_definitions.present? ?
-                find_slice_by_values(el_found, child_element_value_definitions) : true
+    #         child_element_values_match =
+    #           child_element_value_definitions.present? ?
+    #             find_slice_by_values(el_found, child_element_value_definitions) : true
 
-            current_element_values_match && child_element_values_match
-          end
-        end
-      end
-    end
+    #         current_element_values_match && child_element_values_match
+    #       end
+    #     end
+    #   end
+    # end
   end
 end

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -15,12 +15,12 @@ module USCoreTestKit
       skip_if resources.blank?, "No #{resource_type} resources were found"
 
       missing_elements(resources)
-      # missing_slices(resources)
-      # missing_extensions(resources)
+      missing_slices(resources)
+      missing_extensions(resources)
 
-      # handle_must_support_choices if metadata.must_supports[:choices].present?
+      handle_must_support_choices if metadata.must_supports[:choices].present?
 
-      if (missing_elements).length.zero?# + missing_slices + missing_extensions 
+      if (missing_elements + missing_slices + missing_extensions).length.zero?
         pass
       end
       skip "Could not find #{missing_must_support_strings.join(', ')} in the #{resources.length} " \
@@ -54,9 +54,9 @@ module USCoreTestKit
     end
 
     def missing_must_support_strings
-      missing_elements.map { |element_definition| missing_element_string(element_definition) } # +
-        #missing_slices.map { |slice_definition| slice_definition[:slice_id] } +
-        #missing_extensions.map { |extension_definition| extension_definition[:id] }
+      missing_elements.map { |element_definition| missing_element_string(element_definition) } +
+      missing_slices.map { |slice_definition| slice_definition[:slice_id] } +
+      missing_extensions.map { |extension_definition| extension_definition[:id] }
     end
 
     def missing_element_string(element_definition)
@@ -178,31 +178,31 @@ module USCoreTestKit
       end
     end
 
-    # def find_slice_by_values(element, value_definitions)
-    #   path_prefixes = value_definitions.map { |value_definition| value_definition[:path].first }.uniq
-    #   Array.wrap(element).find do |el|
-    #     path_prefixes.all? do |path_prefix|
-    #       value_definitions_for_path =
-    #         value_definitions
-    #           .select { |value_definition| value_definition[:path].first == path_prefix }
-    #           .each { |value_definition| value_definition[:path].shift }
+    def find_slice_by_values(element, value_definitions)
+      path_prefixes = value_definitions.map { |value_definition| value_definition[:path].first }.uniq
+      Array.wrap(element).find do |el|
+        path_prefixes.all? do |path_prefix|
+          value_definitions_for_path =
+            value_definitions
+              .select { |value_definition| value_definition[:path].first == path_prefix }
+              .each { |value_definition| value_definition[:path].shift }
 
-    #       find_a_value_at(el, path_prefix) do |el_found|
-    #         child_element_value_definitions, current_element_value_definitions =
-    #           value_definitions_for_path.partition { |value_definition| value_definition[:path].present? }
+          find_a_value_at(el, path_prefix) do |el_found|
+            child_element_value_definitions, current_element_value_definitions =
+              value_definitions_for_path.partition { |value_definition| value_definition[:path].present? }
 
-    #         current_element_values_match =
-    #           current_element_value_definitions
-    #             .all? { |value_definition| value_definition[:value] == el_found }
+            current_element_values_match =
+              current_element_value_definitions
+                .all? { |value_definition| value_definition[:value] == el_found }
 
-    #         child_element_values_match =
-    #           child_element_value_definitions.present? ?
-    #             find_slice_by_values(el_found, child_element_value_definitions) : true
+            child_element_values_match =
+              child_element_value_definitions.present? ?
+                find_slice_by_values(el_found, child_element_value_definitions) : true
 
-    #         current_element_values_match && child_element_values_match
-    #       end
-    #     end
-    #   end
-    # end
+            current_element_values_match && child_element_values_match
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -23,7 +23,6 @@ module USCoreTestKit
       if (missing_elements + missing_slices + missing_extensions).length.zero?
         pass
       end
-
       skip "Could not find #{missing_must_support_strings.join(', ')} in the #{resources.length} " \
            "provided #{resource_type} resource(s)"
     end
@@ -56,7 +55,7 @@ module USCoreTestKit
 
     def missing_must_support_strings
       missing_elements.map { |element_definition| missing_element_string(element_definition) } +
-        missing_slices.map { |slice_definition| slice_definition[:name] } +
+        missing_slices.map { |slice_definition| slice_definition[:slice_id] } +
         missing_extensions.map { |extension_definition| extension_definition[:id] }
     end
 

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -18,502 +18,502 @@ RSpec.describe USCoreTestKit::MustSupportTest do
     Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
   end
 
-  # describe 'must support test for choice elements and regular elements' do
-  #   let(:device_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_device_must_support_test')}
-  #   let(:device) do
-  #     FHIR::Device.new(
-  #       udiCarrier: [{ deviceIdentifier: '43069338026389', carrierHRF: 'carrierHRF' }],
-  #       distinctIdentifier: '43069338026389',
-  #       manufactureDate: '2000-03-02T18:33:18-05:00',
-  #       expirationDate: '2025-03-17T19:33:18-04:00',
-  #       lotNumber: '1134',
-  #       serialNumber: '842026117977',
-  #       type: {
-  #         text: 'Implantable defibrillator, device (physical object)'
-  #       },
-  #       patient: {
-  #         reference: patient_ref
-  #       }
-  #     )
-  #   end
+  describe 'must support test for choice elements and regular elements' do
+    let(:device_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_device_must_support_test')}
+    let(:device) do
+      FHIR::Device.new(
+        udiCarrier: [{ deviceIdentifier: '43069338026389', carrierHRF: 'carrierHRF' }],
+        distinctIdentifier: '43069338026389',
+        manufactureDate: '2000-03-02T18:33:18-05:00',
+        expirationDate: '2025-03-17T19:33:18-04:00',
+        lotNumber: '1134',
+        serialNumber: '842026117977',
+        type: {
+          text: 'Implantable defibrillator, device (physical object)'
+        },
+        patient: {
+          reference: patient_ref
+        }
+      )
+    end
 
-  #   it 'fails if server supports none of the choice' do
-  #     device.udiCarrier.first.carrierHRF = nil
-  #     allow_any_instance_of(device_must_support_test)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [device]
-  #         }
-  #       )
+    it 'fails if server supports none of the choice' do
+      device.udiCarrier.first.carrierHRF = nil
+      allow_any_instance_of(device_must_support_test)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [device]
+          }
+        )
 
-  #     result = run(device_must_support_test)
-  #     expect(result.result).to eq('skip')
-  #     expect(result.result_message).to include('udiCarrier.carrierAIDC, udiCarrier.carrierHRF')
-  #   end
+      result = run(device_must_support_test)
+      expect(result.result).to eq('skip')
+      expect(result.result_message).to include('udiCarrier.carrierAIDC, udiCarrier.carrierHRF')
+    end
 
-  #   it 'passes if server supports at least one of the choice' do
-  #     allow_any_instance_of(device_must_support_test)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [device]
-  #         }
-  #       )
+    it 'passes if server supports at least one of the choice' do
+      allow_any_instance_of(device_must_support_test)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [device]
+          }
+        )
 
-  #     result = run(device_must_support_test)
-  #     expect(result.result).to eq('pass')
-  #   end
+      result = run(device_must_support_test)
+      expect(result.result).to eq('pass')
+    end
 
-  #   it 'fails if server does not support one MS element' do
-  #     device.distinctIdentifier = nil
-  #     allow_any_instance_of(device_must_support_test)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [device]
-  #         }
-  #       )
+    it 'fails if server does not support one MS element' do
+      device.distinctIdentifier = nil
+      allow_any_instance_of(device_must_support_test)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [device]
+          }
+        )
 
-  #     result = run(device_must_support_test)
-  #     expect(result.result).to eq('skip')
-  #     expect(result.result_message).to include('distinctIdentifier')
-  #   end
-  # end
+      result = run(device_must_support_test)
+      expect(result.result).to eq('skip')
+      expect(result.result_message).to include('distinctIdentifier')
+    end
+  end
 
-  # describe 'must support test for extensions' do
-  #   let(:patient_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_patient_must_support_test')}
-  #   let(:patient) do
-  #     FHIR::Patient.new(
-  #       identifier: [{system: 'system', value: 'value'}],
-  #       name: [{family: 'family', given: 'given'}],
-  #       telecom: [{system: 'phone', value: 'value', use: 'home'}],
-  #       gender: 'male',
-  #       birthDate: '2020-01-01',
-  #       address: [{line: 'line', city: 'city', state: 'state', postalCode: 'postalCode', period: {start: '2020-01-01'}}],
-  #       communication: [{language: {text: 'text'}}],
-  #       extension: [
-  #         {
-  #           url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
-  #           extension: [
-  #             {url: 'ombCategory', valueCoding: {display: 'display'}},
-  #             {url: 'text', valueString: 'valueString'}
-  #           ]
-  #         },
-  #         {
-  #           url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
-  #           extension: [
-  #             {url: 'ombCategory', valueCoding: {display: 'display'}},
-  #             {url: 'text', valueString: 'valueString'}
-  #           ]
-  #         },
-  #         {
-  #           url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
-  #           valueCode: 'M'
-  #         }
-  #       ]
-  #     )
-  #   end
+  describe 'must support test for extensions' do
+    let(:patient_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_patient_must_support_test')}
+    let(:patient) do
+      FHIR::Patient.new(
+        identifier: [{system: 'system', value: 'value'}],
+        name: [{family: 'family', given: 'given'}],
+        telecom: [{system: 'phone', value: 'value', use: 'home'}],
+        gender: 'male',
+        birthDate: '2020-01-01',
+        address: [{line: 'line', city: 'city', state: 'state', postalCode: 'postalCode', period: {start: '2020-01-01'}}],
+        communication: [{language: {text: 'text'}}],
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+            extension: [
+              {url: 'ombCategory', valueCoding: {display: 'display'}},
+              {url: 'text', valueString: 'valueString'}
+            ]
+          },
+          {
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
+            extension: [
+              {url: 'ombCategory', valueCoding: {display: 'display'}},
+              {url: 'text', valueString: 'valueString'}
+            ]
+          },
+          {
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
+            valueCode: 'M'
+          }
+        ]
+      )
+    end
 
-  #   it 'passes if server suports all MS extensions' do
-  #     allow_any_instance_of(patient_must_support_test)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [patient]
-  #         }
-  #       )
+    it 'passes if server suports all MS extensions' do
+      allow_any_instance_of(patient_must_support_test)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [patient]
+          }
+        )
 
-  #     result = run(patient_must_support_test)
+      result = run(patient_must_support_test)
 
-  #     expect(result.result).to eq('pass')
-  #   end
+      expect(result.result).to eq('pass')
+    end
 
-  #   it 'fails if server does not suport one MS extensions' do
-  #     patient.extension.delete_at(0)
+    it 'fails if server does not suport one MS extensions' do
+      patient.extension.delete_at(0)
 
-  #     allow_any_instance_of(patient_must_support_test)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [patient]
-  #         }
-  #       )
+      allow_any_instance_of(patient_must_support_test)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [patient]
+          }
+        )
 
-  #     result = run(patient_must_support_test)
+      result = run(patient_must_support_test)
 
-  #     expect(result.result).to eq('skip')
-  #     expect(result.result_message).to include('Patient.extension:race')
-  #   end
-  # end
+      expect(result.result).to eq('skip')
+      expect(result.result_message).to include('Patient.extension:race')
+    end
+  end
 
-  # describe 'must support test for slices' do
-  #   context 'slicing with pattern' do
-  #     let(:care_plan_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_care_plan_must_support_test')}
-  #     let(:careplan) do
-  #       FHIR::CarePlan.new(
-  #         text: { status: 'status' },
-  #         status: 'status',
-  #         intent: 'intent',
-  #         category: [
-  #           {
-  #             coding: [
-  #               {
-  #                 system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category',
-  #                 code: 'assess-plan'
-  #               }
-  #             ]
-  #           }
-  #         ],
-  #         subject: {
-  #           reference: patient_ref
-  #         }
-  #       )
-  #     end
+  describe 'must support test for slices' do
+    context 'slicing with pattern' do
+      let(:care_plan_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_care_plan_must_support_test')}
+      let(:careplan) do
+        FHIR::CarePlan.new(
+          text: { status: 'status' },
+          status: 'status',
+          intent: 'intent',
+          category: [
+            {
+              coding: [
+                {
+                  system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category',
+                  code: 'assess-plan'
+                }
+              ]
+            }
+          ],
+          subject: {
+            reference: patient_ref
+          }
+        )
+      end
 
-  #     it 'passes if server suports all MS slices' do
-  #       allow_any_instance_of(care_plan_must_support_test)
-  #         .to receive(:scratch_resources).and_return(
-  #           {
-  #             all: [careplan]
-  #           }
-  #         )
-
-
-  #       result = run(care_plan_must_support_test)
-
-  #       expect(result.result).to eq('pass')
-  #     end
-
-  #     it 'fails if server does not suport one MS extensions' do
-  #       careplan.category.first.coding.first.code = 'something else'
-  #       allow_any_instance_of(care_plan_must_support_test)
-  #         .to receive(:scratch_resources).and_return(
-  #           {
-  #             all: [careplan]
-  #           }
-  #         )
-
-  #       result = run(care_plan_must_support_test)
-
-  #       expect(result.result).to eq('skip')
-  #       expect(result.result_message).to include('CarePlan.category:AssessPlan')
-  #     end
-  #   end
-
-  #   context 'slicing with type' do
-  #     let(:test_class) { USCoreTestKit::USCoreV400::SmokingstatusMustSupportTest }
-  #     let(:observation) {
-  #       FHIR::Observation.new(
-  #         status: 'final',
-  #         category: [
-  #           {
-  #             coding: [
-  #               {
-  #                 system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-  #                 code: 'social-history'
-  #               }
-  #             ]
-  #           }
-  #         ],
-  #         code: {
-  #           coding: [
-  #             {
-  #               system: 'http://loinc.org',
-  #               code: '72166-2'
-  #             }
-  #           ],
-  #           text: 'Tobacco smoking status'
-  #         },
-  #         subject: {
-  #           reference: 'Patient/902'
-  #         },
-  #         effectiveDateTime: '2013-04-23T21:07:05Z',
-  #         valueCodeableConcept: {
-  #           coding: [
-  #             {
-  #               system: 'http://snomed.info/sct',
-  #               code: '449868002'
-  #             }
-  #           ]
-  #         }
-  #       )
-  #     }
-
-  #     it 'passes if server suports all MS slices' do
-  #       allow_any_instance_of(test_class)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [observation]
-  #         }
-  #       )
+      it 'passes if server suports all MS slices' do
+        allow_any_instance_of(care_plan_must_support_test)
+          .to receive(:scratch_resources).and_return(
+            {
+              all: [careplan]
+            }
+          )
 
 
-  #       result = run(test_class)
+        result = run(care_plan_must_support_test)
 
-  #       expect(result.result).to eq('pass')
-  #     end
+        expect(result.result).to eq('pass')
+      end
 
-  #     it 'skips if datetime format is not correct' do
-  #       observation.effectiveDateTime = "not a date time"
-  #       allow_any_instance_of(test_class)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [observation]
-  #         }
-  #       )
+      it 'fails if server does not suport one MS extensions' do
+        careplan.category.first.coding.first.code = 'something else'
+        allow_any_instance_of(care_plan_must_support_test)
+          .to receive(:scratch_resources).and_return(
+            {
+              all: [careplan]
+            }
+          )
 
+        result = run(care_plan_must_support_test)
 
-  #       result = run(test_class)
+        expect(result.result).to eq('skip')
+        expect(result.result_message).to include('CarePlan.category:AssessPlan')
+      end
+    end
 
-  #       expect(result.result).to eq('skip')
-  #       expect(result.result_message).to include('Observation.effective[x]:effectiveDateTime')
-  #     end
-  #   end
+    context 'slicing with type' do
+      let(:test_class) { USCoreTestKit::USCoreV400::SmokingstatusMustSupportTest }
+      let(:observation) {
+        FHIR::Observation.new(
+          status: 'final',
+          category: [
+            {
+              coding: [
+                {
+                  system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+                  code: 'social-history'
+                }
+              ]
+            }
+          ],
+          code: {
+            coding: [
+              {
+                system: 'http://loinc.org',
+                code: '72166-2'
+              }
+            ],
+            text: 'Tobacco smoking status'
+          },
+          subject: {
+            reference: 'Patient/902'
+          },
+          effectiveDateTime: '2013-04-23T21:07:05Z',
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://snomed.info/sct',
+                code: '449868002'
+              }
+            ]
+          }
+        )
+      }
 
-  #   context 'slicing with requiredBinding' do
-  #     context 'Condition ProblemsHealthConcerns' do
-  #       let(:test_class) { USCoreTestKit::USCoreV501::ConditionProblemsHealthConcernsMustSupportTest }
-  #       let(:condition) {
-  #         FHIR::Condition.new(
-  #           extension: [
-  #             {
-  #               url: 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate',
-  #               valueDateTime: '2016-08-10'
-  #             }
-  #           ],
-  #           clinicalStatus: {
-  #             coding: [
-  #               {
-  #                 system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
-  #                 code: 'active'
-  #               }
-  #             ]
-  #           },
-  #           verificationStatus: {
-  #             coding: [
-  #               {
-  #                 system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status',
-  #                 code: 'confirmed'
-  #               }
-  #             ]
-  #           },
-  #           category: [
-  #             {
-  #               coding: [
-  #                 {
-  #                   system: 'http://terminology.hl7.org/CodeSystem/condition-category',
-  #                   code: 'problem-list-item'
-  #                 }
-  #               ]
-  #             },
-  #             {
-  #               coding: [
-  #                 {
-  #                   system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags',
-  #                   code: 'sdoh'
-  #                 }
-  #               ]
-  #             }
-  #           ],
-  #           code: {
-  #             coding: [
-  #               {
-  #                 system: 'http://snomed.info/sct',
-  #                 code: '445281000124101'
-  #               }
-  #             ]
-  #           },
-  #           subject: {
-  #             reference: 'Patient/123',
-  #           },
-  #           recordedDate: '2016-08-10T07:15:07-08:00',
-  #           onsetDateTime: '2016-08-10T07:15:07-08:00',
-  #           abatementDateTime: '2016-08-10T07:15:07-08:00'
-  #         )
-  #       }
-
-  #       it 'passes if server suports all MS slices' do
-  #         allow_any_instance_of(test_class)
-  #           .to receive(:scratch_resources).and_return(
-  #             {
-  #               all: [condition]
-  #             }
-  #           )
+      it 'passes if server suports all MS slices' do
+        allow_any_instance_of(test_class)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [observation]
+          }
+        )
 
 
-  #         result = run(test_class)
-  #         expect(result.result).to eq('pass')
-  #       end
+        result = run(test_class)
 
-  #       it 'skips if server does not support category:us-core slice' do
-  #         condition.category.delete_if { |category| category.coding.first.code == 'problem-list-item' }
-  #         allow_any_instance_of(test_class)
-  #         .to receive(:scratch_resources).and_return(
-  #           {
-  #             all: [condition]
-  #           }
-  #         )
+        expect(result.result).to eq('pass')
+      end
 
-  #         result = run(test_class)
-  #         expect(result.result).to eq('skip')
-  #         expect(result.result_message).to include('Condition.category:us-core')
-  #       end
-  #     end
-
-  #     context 'MedicationRequest' do
-  #       let(:test_class) { USCoreTestKit::USCoreV501::MedicationRequestMustSupportTest }
-  #       let(:medication_request_1) {
-  #         FHIR::MedicationRequest.new(
-  #           status: 'active',
-  #           intent: 'order',
-  #           category: [
-  #             {
-  #               coding: [
-  #                 system: 'http://terminology.hl7.org/CodeSystem/medicationrequest-category',
-  #                 code: 'outpatient'
-  #               ]
-  #             }
-  #           ],
-  #           reportedBoolean: false,
-  #           medicationReference: {
-  #             reference: 'Medication/m1'
-  #           },
-  #           subject: {
-  #             reference: 'Patient/p1',
-  #           },
-  #           encounter: {
-  #             reference: 'Encounter/e1'
-  #           },
-  #           authoredOn: '2021-08-04T00:00:00-04:00',
-  #           requester: {
-  #             reference: 'Practitioner/p2'
-  #           },
-  #           dosageInstruction: [
-  #             {
-  #               text: 'this is a dosage instruction'
-  #             }
-  #           ]
-  #         )
-  #       }
-
-  #       it 'passes if server suports all MS slices' do
-  #         allow_any_instance_of(test_class)
-  #           .to receive(:scratch_resources).and_return(
-  #             {
-  #               all: [medication_request_1]
-  #             }
-  #           )
+      it 'skips if datetime format is not correct' do
+        observation.effectiveDateTime = "not a date time"
+        allow_any_instance_of(test_class)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [observation]
+          }
+        )
 
 
-  #         result = run(test_class)
-  #         expect(result.result).to eq('pass')
-  #       end
-  #     end
-  #   end
-  # end
+        result = run(test_class)
 
-  # describe 'must support test for choices' do
-  #   let(:test_class) { USCoreTestKit::USCoreV501::ConditionProblemsHealthConcernsMustSupportTest }
-  #   let(:condition) {
-  #     FHIR::Condition.new(
-  #       extension: [
-  #         {
-  #           url: 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate',
-  #           valueDateTime: '2016-08-10'
-  #         }
-  #       ],
-  #       clinicalStatus: {
-  #         coding: [
-  #           {
-  #             system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
-  #             code: 'active'
-  #           }
-  #         ]
-  #       },
-  #       verificationStatus: {
-  #         coding: [
-  #           {
-  #             system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status',
-  #             code: 'confirmed'
-  #           }
-  #         ]
-  #       },
-  #       category: [
-  #         {
-  #           coding: [
-  #             {
-  #               system: 'http://terminology.hl7.org/CodeSystem/condition-category',
-  #               code: 'problem-list-item'
-  #             }
-  #           ]
-  #         },
-  #         {
-  #           coding: [
-  #             {
-  #               system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags',
-  #               code: 'sdoh'
-  #             }
-  #           ]
-  #         }
-  #       ],
-  #       code: {
-  #         coding: [
-  #           {
-  #             system: 'http://snomed.info/sct',
-  #             code: '445281000124101'
-  #           }
-  #         ]
-  #       },
-  #       subject: {
-  #         reference: 'Patient/123',
-  #       },
-  #       recordedDate: '2016-08-10T07:15:07-08:00',
-  #       onsetDateTime: '2016-08-10T07:15:07-08:00',
-  #       abatementDateTime: '2016-08-10T07:15:07-08:00'
-  #     )
-  #   }
+        expect(result.result).to eq('skip')
+        expect(result.result_message).to include('Observation.effective[x]:effectiveDateTime')
+      end
+    end
 
-  #   it 'passes if server suports assertDate extension' do
-  #     condition.onsetDateTime = nil
+    context 'slicing with requiredBinding' do
+      context 'Condition ProblemsHealthConcerns' do
+        let(:test_class) { USCoreTestKit::USCoreV501::ConditionProblemsHealthConcernsMustSupportTest }
+        let(:condition) {
+          FHIR::Condition.new(
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate',
+                valueDateTime: '2016-08-10'
+              }
+            ],
+            clinicalStatus: {
+              coding: [
+                {
+                  system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
+                  code: 'active'
+                }
+              ]
+            },
+            verificationStatus: {
+              coding: [
+                {
+                  system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status',
+                  code: 'confirmed'
+                }
+              ]
+            },
+            category: [
+              {
+                coding: [
+                  {
+                    system: 'http://terminology.hl7.org/CodeSystem/condition-category',
+                    code: 'problem-list-item'
+                  }
+                ]
+              },
+              {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags',
+                    code: 'sdoh'
+                  }
+                ]
+              }
+            ],
+            code: {
+              coding: [
+                {
+                  system: 'http://snomed.info/sct',
+                  code: '445281000124101'
+                }
+              ]
+            },
+            subject: {
+              reference: 'Patient/123',
+            },
+            recordedDate: '2016-08-10T07:15:07-08:00',
+            onsetDateTime: '2016-08-10T07:15:07-08:00',
+            abatementDateTime: '2016-08-10T07:15:07-08:00'
+          )
+        }
 
-  #     allow_any_instance_of(test_class)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [condition]
-  #         }
-  #       )
+        it 'passes if server suports all MS slices' do
+          allow_any_instance_of(test_class)
+            .to receive(:scratch_resources).and_return(
+              {
+                all: [condition]
+              }
+            )
 
-  #     result = run(test_class)
-  #     expect(result.result).to eq('pass')
-  #   end
 
-  #   it 'passes if server suports onsetDate' do
-  #     condition.extension = []
+          result = run(test_class)
+          expect(result.result).to eq('pass')
+        end
 
-  #     allow_any_instance_of(test_class)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [condition]
-  #         }
-  #       )
+        it 'skips if server does not support category:us-core slice' do
+          condition.category.delete_if { |category| category.coding.first.code == 'problem-list-item' }
+          allow_any_instance_of(test_class)
+          .to receive(:scratch_resources).and_return(
+            {
+              all: [condition]
+            }
+          )
 
-  #     result = run(test_class)
-  #     expect(result.result).to eq('pass')
-  #   end
+          result = run(test_class)
+          expect(result.result).to eq('skip')
+          expect(result.result_message).to include('Condition.category:us-core')
+        end
+      end
 
-  #   it 'skips if server suports none of assertDate extension and onsetDate' do
-  #     condition.onsetDateTime = nil
-  #     condition.extension = []
+      context 'MedicationRequest' do
+        let(:test_class) { USCoreTestKit::USCoreV501::MedicationRequestMustSupportTest }
+        let(:medication_request_1) {
+          FHIR::MedicationRequest.new(
+            status: 'active',
+            intent: 'order',
+            category: [
+              {
+                coding: [
+                  system: 'http://terminology.hl7.org/CodeSystem/medicationrequest-category',
+                  code: 'outpatient'
+                ]
+              }
+            ],
+            reportedBoolean: false,
+            medicationReference: {
+              reference: 'Medication/m1'
+            },
+            subject: {
+              reference: 'Patient/p1',
+            },
+            encounter: {
+              reference: 'Encounter/e1'
+            },
+            authoredOn: '2021-08-04T00:00:00-04:00',
+            requester: {
+              reference: 'Practitioner/p2'
+            },
+            dosageInstruction: [
+              {
+                text: 'this is a dosage instruction'
+              }
+            ]
+          )
+        }
 
-  #     allow_any_instance_of(test_class)
-  #       .to receive(:scratch_resources).and_return(
-  #         {
-  #           all: [condition]
-  #         }
-  #       )
+        it 'passes if server suports all MS slices' do
+          allow_any_instance_of(test_class)
+            .to receive(:scratch_resources).and_return(
+              {
+                all: [medication_request_1]
+              }
+            )
 
-  #     result = run(test_class)
-  #     expect(result.result).to eq('skip')
-  #     expect(result.result_message).to include('onsetDateTime')
-  #     expect(result.result_message).to include('Condition.extension:assertedDate')
-  #   end
-  # end
+
+          result = run(test_class)
+          expect(result.result).to eq('pass')
+        end
+      end
+    end
+  end
+
+  describe 'must support test for choices' do
+    let(:test_class) { USCoreTestKit::USCoreV501::ConditionProblemsHealthConcernsMustSupportTest }
+    let(:condition) {
+      FHIR::Condition.new(
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate',
+            valueDateTime: '2016-08-10'
+          }
+        ],
+        clinicalStatus: {
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
+              code: 'active'
+            }
+          ]
+        },
+        verificationStatus: {
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status',
+              code: 'confirmed'
+            }
+          ]
+        },
+        category: [
+          {
+            coding: [
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/condition-category',
+                code: 'problem-list-item'
+              }
+            ]
+          },
+          {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags',
+                code: 'sdoh'
+              }
+            ]
+          }
+        ],
+        code: {
+          coding: [
+            {
+              system: 'http://snomed.info/sct',
+              code: '445281000124101'
+            }
+          ]
+        },
+        subject: {
+          reference: 'Patient/123',
+        },
+        recordedDate: '2016-08-10T07:15:07-08:00',
+        onsetDateTime: '2016-08-10T07:15:07-08:00',
+        abatementDateTime: '2016-08-10T07:15:07-08:00'
+      )
+    }
+
+    it 'passes if server suports assertDate extension' do
+      condition.onsetDateTime = nil
+
+      allow_any_instance_of(test_class)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [condition]
+          }
+        )
+
+      result = run(test_class)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'passes if server suports onsetDate' do
+      condition.extension = []
+
+      allow_any_instance_of(test_class)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [condition]
+          }
+        )
+
+      result = run(test_class)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'skips if server suports none of assertDate extension and onsetDate' do
+      condition.onsetDateTime = nil
+      condition.extension = []
+
+      allow_any_instance_of(test_class)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [condition]
+          }
+        )
+
+      result = run(test_class)
+      expect(result.result).to eq('skip')
+      expect(result.result_message).to include('onsetDateTime')
+      expect(result.result_message).to include('Condition.extension:assertedDate')
+    end
+  end
 
   describe 'must support tests for sub elements of slices' do
     let (:test_class) {

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -18,500 +18,589 @@ RSpec.describe USCoreTestKit::MustSupportTest do
     Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
   end
 
-  describe 'must support test for choice elements and regular elements' do
-    let(:device_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_device_must_support_test')}
-    let(:device) do
-      FHIR::Device.new(
-        udiCarrier: [{ deviceIdentifier: '43069338026389', carrierHRF: 'carrierHRF' }],
-        distinctIdentifier: '43069338026389',
-        manufactureDate: '2000-03-02T18:33:18-05:00',
-        expirationDate: '2025-03-17T19:33:18-04:00',
-        lotNumber: '1134',
-        serialNumber: '842026117977',
-        type: {
-          text: 'Implantable defibrillator, device (physical object)'
+  # describe 'must support test for choice elements and regular elements' do
+  #   let(:device_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_device_must_support_test')}
+  #   let(:device) do
+  #     FHIR::Device.new(
+  #       udiCarrier: [{ deviceIdentifier: '43069338026389', carrierHRF: 'carrierHRF' }],
+  #       distinctIdentifier: '43069338026389',
+  #       manufactureDate: '2000-03-02T18:33:18-05:00',
+  #       expirationDate: '2025-03-17T19:33:18-04:00',
+  #       lotNumber: '1134',
+  #       serialNumber: '842026117977',
+  #       type: {
+  #         text: 'Implantable defibrillator, device (physical object)'
+  #       },
+  #       patient: {
+  #         reference: patient_ref
+  #       }
+  #     )
+  #   end
+
+  #   it 'fails if server supports none of the choice' do
+  #     device.udiCarrier.first.carrierHRF = nil
+  #     allow_any_instance_of(device_must_support_test)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [device]
+  #         }
+  #       )
+
+  #     result = run(device_must_support_test)
+  #     expect(result.result).to eq('skip')
+  #     expect(result.result_message).to include('udiCarrier.carrierAIDC, udiCarrier.carrierHRF')
+  #   end
+
+  #   it 'passes if server supports at least one of the choice' do
+  #     allow_any_instance_of(device_must_support_test)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [device]
+  #         }
+  #       )
+
+  #     result = run(device_must_support_test)
+  #     expect(result.result).to eq('pass')
+  #   end
+
+  #   it 'fails if server does not support one MS element' do
+  #     device.distinctIdentifier = nil
+  #     allow_any_instance_of(device_must_support_test)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [device]
+  #         }
+  #       )
+
+  #     result = run(device_must_support_test)
+  #     expect(result.result).to eq('skip')
+  #     expect(result.result_message).to include('distinctIdentifier')
+  #   end
+  # end
+
+  # describe 'must support test for extensions' do
+  #   let(:patient_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_patient_must_support_test')}
+  #   let(:patient) do
+  #     FHIR::Patient.new(
+  #       identifier: [{system: 'system', value: 'value'}],
+  #       name: [{family: 'family', given: 'given'}],
+  #       telecom: [{system: 'phone', value: 'value', use: 'home'}],
+  #       gender: 'male',
+  #       birthDate: '2020-01-01',
+  #       address: [{line: 'line', city: 'city', state: 'state', postalCode: 'postalCode', period: {start: '2020-01-01'}}],
+  #       communication: [{language: {text: 'text'}}],
+  #       extension: [
+  #         {
+  #           url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+  #           extension: [
+  #             {url: 'ombCategory', valueCoding: {display: 'display'}},
+  #             {url: 'text', valueString: 'valueString'}
+  #           ]
+  #         },
+  #         {
+  #           url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
+  #           extension: [
+  #             {url: 'ombCategory', valueCoding: {display: 'display'}},
+  #             {url: 'text', valueString: 'valueString'}
+  #           ]
+  #         },
+  #         {
+  #           url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
+  #           valueCode: 'M'
+  #         }
+  #       ]
+  #     )
+  #   end
+
+  #   it 'passes if server suports all MS extensions' do
+  #     allow_any_instance_of(patient_must_support_test)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [patient]
+  #         }
+  #       )
+
+  #     result = run(patient_must_support_test)
+
+  #     expect(result.result).to eq('pass')
+  #   end
+
+  #   it 'fails if server does not suport one MS extensions' do
+  #     patient.extension.delete_at(0)
+
+  #     allow_any_instance_of(patient_must_support_test)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [patient]
+  #         }
+  #       )
+
+  #     result = run(patient_must_support_test)
+
+  #     expect(result.result).to eq('skip')
+  #     expect(result.result_message).to include('Patient.extension:race')
+  #   end
+  # end
+
+  # describe 'must support test for slices' do
+  #   context 'slicing with pattern' do
+  #     let(:care_plan_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_care_plan_must_support_test')}
+  #     let(:careplan) do
+  #       FHIR::CarePlan.new(
+  #         text: { status: 'status' },
+  #         status: 'status',
+  #         intent: 'intent',
+  #         category: [
+  #           {
+  #             coding: [
+  #               {
+  #                 system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category',
+  #                 code: 'assess-plan'
+  #               }
+  #             ]
+  #           }
+  #         ],
+  #         subject: {
+  #           reference: patient_ref
+  #         }
+  #       )
+  #     end
+
+  #     it 'passes if server suports all MS slices' do
+  #       allow_any_instance_of(care_plan_must_support_test)
+  #         .to receive(:scratch_resources).and_return(
+  #           {
+  #             all: [careplan]
+  #           }
+  #         )
+
+
+  #       result = run(care_plan_must_support_test)
+
+  #       expect(result.result).to eq('pass')
+  #     end
+
+  #     it 'fails if server does not suport one MS extensions' do
+  #       careplan.category.first.coding.first.code = 'something else'
+  #       allow_any_instance_of(care_plan_must_support_test)
+  #         .to receive(:scratch_resources).and_return(
+  #           {
+  #             all: [careplan]
+  #           }
+  #         )
+
+  #       result = run(care_plan_must_support_test)
+
+  #       expect(result.result).to eq('skip')
+  #       expect(result.result_message).to include('CarePlan.category:AssessPlan')
+  #     end
+  #   end
+
+  #   context 'slicing with type' do
+  #     let(:test_class) { USCoreTestKit::USCoreV400::SmokingstatusMustSupportTest }
+  #     let(:observation) {
+  #       FHIR::Observation.new(
+  #         status: 'final',
+  #         category: [
+  #           {
+  #             coding: [
+  #               {
+  #                 system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+  #                 code: 'social-history'
+  #               }
+  #             ]
+  #           }
+  #         ],
+  #         code: {
+  #           coding: [
+  #             {
+  #               system: 'http://loinc.org',
+  #               code: '72166-2'
+  #             }
+  #           ],
+  #           text: 'Tobacco smoking status'
+  #         },
+  #         subject: {
+  #           reference: 'Patient/902'
+  #         },
+  #         effectiveDateTime: '2013-04-23T21:07:05Z',
+  #         valueCodeableConcept: {
+  #           coding: [
+  #             {
+  #               system: 'http://snomed.info/sct',
+  #               code: '449868002'
+  #             }
+  #           ]
+  #         }
+  #       )
+  #     }
+
+  #     it 'passes if server suports all MS slices' do
+  #       allow_any_instance_of(test_class)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [observation]
+  #         }
+  #       )
+
+
+  #       result = run(test_class)
+
+  #       expect(result.result).to eq('pass')
+  #     end
+
+  #     it 'skips if datetime format is not correct' do
+  #       observation.effectiveDateTime = "not a date time"
+  #       allow_any_instance_of(test_class)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [observation]
+  #         }
+  #       )
+
+
+  #       result = run(test_class)
+
+  #       expect(result.result).to eq('skip')
+  #       expect(result.result_message).to include('Observation.effective[x]:effectiveDateTime')
+  #     end
+  #   end
+
+  #   context 'slicing with requiredBinding' do
+  #     context 'Condition ProblemsHealthConcerns' do
+  #       let(:test_class) { USCoreTestKit::USCoreV501::ConditionProblemsHealthConcernsMustSupportTest }
+  #       let(:condition) {
+  #         FHIR::Condition.new(
+  #           extension: [
+  #             {
+  #               url: 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate',
+  #               valueDateTime: '2016-08-10'
+  #             }
+  #           ],
+  #           clinicalStatus: {
+  #             coding: [
+  #               {
+  #                 system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
+  #                 code: 'active'
+  #               }
+  #             ]
+  #           },
+  #           verificationStatus: {
+  #             coding: [
+  #               {
+  #                 system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status',
+  #                 code: 'confirmed'
+  #               }
+  #             ]
+  #           },
+  #           category: [
+  #             {
+  #               coding: [
+  #                 {
+  #                   system: 'http://terminology.hl7.org/CodeSystem/condition-category',
+  #                   code: 'problem-list-item'
+  #                 }
+  #               ]
+  #             },
+  #             {
+  #               coding: [
+  #                 {
+  #                   system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags',
+  #                   code: 'sdoh'
+  #                 }
+  #               ]
+  #             }
+  #           ],
+  #           code: {
+  #             coding: [
+  #               {
+  #                 system: 'http://snomed.info/sct',
+  #                 code: '445281000124101'
+  #               }
+  #             ]
+  #           },
+  #           subject: {
+  #             reference: 'Patient/123',
+  #           },
+  #           recordedDate: '2016-08-10T07:15:07-08:00',
+  #           onsetDateTime: '2016-08-10T07:15:07-08:00',
+  #           abatementDateTime: '2016-08-10T07:15:07-08:00'
+  #         )
+  #       }
+
+  #       it 'passes if server suports all MS slices' do
+  #         allow_any_instance_of(test_class)
+  #           .to receive(:scratch_resources).and_return(
+  #             {
+  #               all: [condition]
+  #             }
+  #           )
+
+
+  #         result = run(test_class)
+  #         expect(result.result).to eq('pass')
+  #       end
+
+  #       it 'skips if server does not support category:us-core slice' do
+  #         condition.category.delete_if { |category| category.coding.first.code == 'problem-list-item' }
+  #         allow_any_instance_of(test_class)
+  #         .to receive(:scratch_resources).and_return(
+  #           {
+  #             all: [condition]
+  #           }
+  #         )
+
+  #         result = run(test_class)
+  #         expect(result.result).to eq('skip')
+  #         expect(result.result_message).to include('Condition.category:us-core')
+  #       end
+  #     end
+
+  #     context 'MedicationRequest' do
+  #       let(:test_class) { USCoreTestKit::USCoreV501::MedicationRequestMustSupportTest }
+  #       let(:medication_request_1) {
+  #         FHIR::MedicationRequest.new(
+  #           status: 'active',
+  #           intent: 'order',
+  #           category: [
+  #             {
+  #               coding: [
+  #                 system: 'http://terminology.hl7.org/CodeSystem/medicationrequest-category',
+  #                 code: 'outpatient'
+  #               ]
+  #             }
+  #           ],
+  #           reportedBoolean: false,
+  #           medicationReference: {
+  #             reference: 'Medication/m1'
+  #           },
+  #           subject: {
+  #             reference: 'Patient/p1',
+  #           },
+  #           encounter: {
+  #             reference: 'Encounter/e1'
+  #           },
+  #           authoredOn: '2021-08-04T00:00:00-04:00',
+  #           requester: {
+  #             reference: 'Practitioner/p2'
+  #           },
+  #           dosageInstruction: [
+  #             {
+  #               text: 'this is a dosage instruction'
+  #             }
+  #           ]
+  #         )
+  #       }
+
+  #       it 'passes if server suports all MS slices' do
+  #         allow_any_instance_of(test_class)
+  #           .to receive(:scratch_resources).and_return(
+  #             {
+  #               all: [medication_request_1]
+  #             }
+  #           )
+
+
+  #         result = run(test_class)
+  #         expect(result.result).to eq('pass')
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe 'must support test for choices' do
+  #   let(:test_class) { USCoreTestKit::USCoreV501::ConditionProblemsHealthConcernsMustSupportTest }
+  #   let(:condition) {
+  #     FHIR::Condition.new(
+  #       extension: [
+  #         {
+  #           url: 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate',
+  #           valueDateTime: '2016-08-10'
+  #         }
+  #       ],
+  #       clinicalStatus: {
+  #         coding: [
+  #           {
+  #             system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
+  #             code: 'active'
+  #           }
+  #         ]
+  #       },
+  #       verificationStatus: {
+  #         coding: [
+  #           {
+  #             system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status',
+  #             code: 'confirmed'
+  #           }
+  #         ]
+  #       },
+  #       category: [
+  #         {
+  #           coding: [
+  #             {
+  #               system: 'http://terminology.hl7.org/CodeSystem/condition-category',
+  #               code: 'problem-list-item'
+  #             }
+  #           ]
+  #         },
+  #         {
+  #           coding: [
+  #             {
+  #               system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags',
+  #               code: 'sdoh'
+  #             }
+  #           ]
+  #         }
+  #       ],
+  #       code: {
+  #         coding: [
+  #           {
+  #             system: 'http://snomed.info/sct',
+  #             code: '445281000124101'
+  #           }
+  #         ]
+  #       },
+  #       subject: {
+  #         reference: 'Patient/123',
+  #       },
+  #       recordedDate: '2016-08-10T07:15:07-08:00',
+  #       onsetDateTime: '2016-08-10T07:15:07-08:00',
+  #       abatementDateTime: '2016-08-10T07:15:07-08:00'
+  #     )
+  #   }
+
+  #   it 'passes if server suports assertDate extension' do
+  #     condition.onsetDateTime = nil
+
+  #     allow_any_instance_of(test_class)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [condition]
+  #         }
+  #       )
+
+  #     result = run(test_class)
+  #     expect(result.result).to eq('pass')
+  #   end
+
+  #   it 'passes if server suports onsetDate' do
+  #     condition.extension = []
+
+  #     allow_any_instance_of(test_class)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [condition]
+  #         }
+  #       )
+
+  #     result = run(test_class)
+  #     expect(result.result).to eq('pass')
+  #   end
+
+  #   it 'skips if server suports none of assertDate extension and onsetDate' do
+  #     condition.onsetDateTime = nil
+  #     condition.extension = []
+
+  #     allow_any_instance_of(test_class)
+  #       .to receive(:scratch_resources).and_return(
+  #         {
+  #           all: [condition]
+  #         }
+  #       )
+
+  #     result = run(test_class)
+  #     expect(result.result).to eq('skip')
+  #     expect(result.result_message).to include('onsetDateTime')
+  #     expect(result.result_message).to include('Condition.extension:assertedDate')
+  #   end
+  # end
+
+  describe 'must support tests for sub elements of slices' do
+    let (:test_class) {
+      USCoreTestKit::USCoreV610::CoverageMustSupportTest
+    }
+    let(:coverage_with_two_classes) {
+      FHIR::Coverage.new.tap{ |cov|
+        cov.status = "active"
+        cov.type = FHIR::CodeableConcept.new.tap{ |code_concept|
+          code_concept.coding = [ FHIR::Coding.new.tap { |coding|
+              coding.system = "https://nahdo.org/sopt"
+              coding.code = "3712"
+              coding.display = "PPO"
+            },
+            FHIR::Coding.new.tap { |coding|
+              coding.system = "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+              coding.code = "PPO"
+              coding.display = "preferred provider organization policy"
+            }
+          ],
+          code_concept.text = "PPO"
         },
-        patient: {
-          reference: patient_ref
+        cov.subscriberId = "888009335"
+        cov.beneficiary = FHIR::Reference.new.tap { |ref|
+          ref.reference = "Patient/example"
         }
-      )
-    end
-
-    it 'fails if server supports none of the choice' do
-      device.udiCarrier.first.carrierHRF = nil
-      allow_any_instance_of(device_must_support_test)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [device]
+        cov.relationship = FHIR::CodeableConcept.new.tap { |code_concept|
+          code_concept.coding = [FHIR::Coding.new.tap { |coding|
+              coding.system ="http://terminology.hl7.org/CodeSystem/subscriber-relationship"
+              coding.code = "self"
+            }
+          ],
+          code_concept.text = "Self"
+        },
+        cov.period =  FHIR::Period.new.tap { |period|
+          period.start = "2020-01-01"
+        }
+        cov.payor = [ FHIR::Reference.new.tap { |ref|
+            ref.reference = "Organization/acme-payer"
+            ref.display = "Acme Health Plan"
           }
-        )
-
-      result = run(device_must_support_test)
-      expect(result.result).to eq('skip')
-      expect(result.result_message).to include('udiCarrier.carrierAIDC, udiCarrier.carrierHRF')
-    end
-
-    it 'passes if server supports at least one of the choice' do
-      allow_any_instance_of(device_must_support_test)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [device]
-          }
-        )
-
-      result = run(device_must_support_test)
-      expect(result.result).to eq('pass')
-    end
-
-    it 'fails if server does not support one MS element' do
-      device.distinctIdentifier = nil
-      allow_any_instance_of(device_must_support_test)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [device]
-          }
-        )
-
-      result = run(device_must_support_test)
-      expect(result.result).to eq('skip')
-      expect(result.result_message).to include('distinctIdentifier')
-    end
-  end
-
-  describe 'must support test for extensions' do
-    let(:patient_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_patient_must_support_test')}
-    let(:patient) do
-      FHIR::Patient.new(
-        identifier: [{system: 'system', value: 'value'}],
-        name: [{family: 'family', given: 'given'}],
-        telecom: [{system: 'phone', value: 'value', use: 'home'}],
-        gender: 'male',
-        birthDate: '2020-01-01',
-        address: [{line: 'line', city: 'city', state: 'state', postalCode: 'postalCode', period: {start: '2020-01-01'}}],
-        communication: [{language: {text: 'text'}}],
-        extension: [
-          {
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
-            extension: [
-              {url: 'ombCategory', valueCoding: {display: 'display'}},
-              {url: 'text', valueString: 'valueString'}
-            ]
-          },
-          {
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
-            extension: [
-              {url: 'ombCategory', valueCoding: {display: 'display'}},
-              {url: 'text', valueString: 'valueString'}
-            ]
-          },
-          {
-            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
-            valueCode: 'M'
+        ],
+        cov.local_class = [FHIR::Coverage::Class.new.tap{ |loc_class|
+            loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
+              code_concept.coding = [FHIR::Coding.new.tap{ |coding|
+                coding.system = "http://terminology.hl7.org/CodeSystem/coverage-class"
+                coding.code = "group"
+              }]
+            }
+            loc_class.value = "group-class-value"
+            loc_class.name = "group-class-name"
+            },
+          FHIR::Coverage::Class.new.tap{ |loc_class|
+            loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
+              code_concept.coding = [FHIR::Coding.new.tap{ |coding|
+                coding.system = "http://terminology.hl7.org/CodeSystem/coverage-class"
+                coding.code = "plan"
+              }]
+            }
+          loc_class.value = "plan-class-value"
+          loc_class.name = "plan-class-name"
           }
         ]
-      )
-    end
-
-    it 'passes if server suports all MS extensions' do
-      allow_any_instance_of(patient_must_support_test)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [patient]
-          }
-        )
-
-      result = run(patient_must_support_test)
-
-      expect(result.result).to eq('pass')
-    end
-
-    it 'fails if server does not suport one MS extensions' do
-      patient.extension.delete_at(0)
-
-      allow_any_instance_of(patient_must_support_test)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [patient]
-          }
-        )
-
-      result = run(patient_must_support_test)
-
-      expect(result.result).to eq('skip')
-      expect(result.result_message).to include('Patient.extension:race')
-    end
-  end
-
-  describe 'must support test for slices' do
-    context 'slicing with pattern' do
-      let(:care_plan_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_care_plan_must_support_test')}
-      let(:careplan) do
-        FHIR::CarePlan.new(
-          text: { status: 'status' },
-          status: 'status',
-          intent: 'intent',
-          category: [
-            {
-              coding: [
-                {
-                  system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category',
-                  code: 'assess-plan'
-                }
-              ]
+        cov.identifier = [FHIR::Identifier.new.tap {|identifier|
+            identifier.type = FHIR::CodeableConcept.new.tap { |code_concept|
+              code_concept.coding = [FHIR::Coding.new.tap{ |coding|
+                coding.system = "http://terminology.hl7.org/CodeSystem/v2-0203"
+                coding.code = "MB"
+              }]
             }
-          ],
-          subject: {
-            reference: patient_ref
+            identifier.system = "https://github.com/inferno-framework/us-core-test-kit"
+            identifier.value = "f4a375d2-4e53-4f81-ba95-345e7573b550"
           }
-        )
-      end
-
-      it 'passes if server suports all MS slices' do
-        allow_any_instance_of(care_plan_must_support_test)
-          .to receive(:scratch_resources).and_return(
-            {
-              all: [careplan]
-            }
-          )
-
-
-        result = run(care_plan_must_support_test)
-
-        expect(result.result).to eq('pass')
-      end
-
-      it 'fails if server does not suport one MS extensions' do
-        careplan.category.first.coding.first.code = 'something else'
-        allow_any_instance_of(care_plan_must_support_test)
-          .to receive(:scratch_resources).and_return(
-            {
-              all: [careplan]
-            }
-          )
-
-        result = run(care_plan_must_support_test)
-
-        expect(result.result).to eq('skip')
-        expect(result.result_message).to include('CarePlan.category:AssessPlan')
-      end
-    end
-
-    context 'slicing with type' do
-      let(:test_class) { USCoreTestKit::USCoreV400::SmokingstatusMustSupportTest }
-      let(:observation) {
-        FHIR::Observation.new(
-          status: 'final',
-          category: [
-            {
-              coding: [
-                {
-                  system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                  code: 'social-history'
-                }
-              ]
-            }
-          ],
-          code: {
-            coding: [
-              {
-                system: 'http://loinc.org',
-                code: '72166-2'
-              }
-            ],
-            text: 'Tobacco smoking status'
-          },
-          subject: {
-            reference: 'Patient/902'
-          },
-          effectiveDateTime: '2013-04-23T21:07:05Z',
-          valueCodeableConcept: {
-            coding: [
-              {
-                system: 'http://snomed.info/sct',
-                code: '449868002'
-              }
-            ]
-          }
-        )
+        ] 
       }
-
-      it 'passes if server suports all MS slices' do
-        allow_any_instance_of(test_class)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [observation]
-          }
-        )
-
-
-        result = run(test_class)
-
-        expect(result.result).to eq('pass')
-      end
-
-      it 'skips if datetime format is not correct' do
-        observation.effectiveDateTime = "not a date time"
-        allow_any_instance_of(test_class)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [observation]
-          }
-        )
-
-
-        result = run(test_class)
-
-        expect(result.result).to eq('skip')
-        expect(result.result_message).to include('Observation.effective[x]:effectiveDateTime')
-      end
-    end
-
-    context 'slicing with requiredBinding' do
-      context 'Condition ProblemsHealthConcerns' do
-        let(:test_class) { USCoreTestKit::USCoreV501::ConditionProblemsHealthConcernsMustSupportTest }
-        let(:condition) {
-          FHIR::Condition.new(
-            extension: [
-              {
-                url: 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate',
-                valueDateTime: '2016-08-10'
-              }
-            ],
-            clinicalStatus: {
-              coding: [
-                {
-                  system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
-                  code: 'active'
-                }
-              ]
-            },
-            verificationStatus: {
-              coding: [
-                {
-                  system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status',
-                  code: 'confirmed'
-                }
-              ]
-            },
-            category: [
-              {
-                coding: [
-                  {
-                    system: 'http://terminology.hl7.org/CodeSystem/condition-category',
-                    code: 'problem-list-item'
-                  }
-                ]
-              },
-              {
-                coding: [
-                  {
-                    system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags',
-                    code: 'sdoh'
-                  }
-                ]
-              }
-            ],
-            code: {
-              coding: [
-                {
-                  system: 'http://snomed.info/sct',
-                  code: '445281000124101'
-                }
-              ]
-            },
-            subject: {
-              reference: 'Patient/123',
-            },
-            recordedDate: '2016-08-10T07:15:07-08:00',
-            onsetDateTime: '2016-08-10T07:15:07-08:00',
-            abatementDateTime: '2016-08-10T07:15:07-08:00'
-          )
-        }
-
-        it 'passes if server suports all MS slices' do
-          allow_any_instance_of(test_class)
-            .to receive(:scratch_resources).and_return(
-              {
-                all: [condition]
-              }
-            )
-
-
-          result = run(test_class)
-          expect(result.result).to eq('pass')
-        end
-
-        it 'skips if server does not support category:us-core slice' do
-          condition.category.delete_if { |category| category.coding.first.code == 'problem-list-item' }
-          allow_any_instance_of(test_class)
-          .to receive(:scratch_resources).and_return(
-            {
-              all: [condition]
-            }
-          )
-
-          result = run(test_class)
-          expect(result.result).to eq('skip')
-          expect(result.result_message).to include('Condition.category:us-core')
-        end
-      end
-
-      context 'MedicationRequest' do
-        let(:test_class) { USCoreTestKit::USCoreV501::MedicationRequestMustSupportTest }
-        let(:medication_request_1) {
-          FHIR::MedicationRequest.new(
-            status: 'active',
-            intent: 'order',
-            category: [
-              {
-                coding: [
-                  system: 'http://terminology.hl7.org/CodeSystem/medicationrequest-category',
-                  code: 'outpatient'
-                ]
-              }
-            ],
-            reportedBoolean: false,
-            medicationReference: {
-              reference: 'Medication/m1'
-            },
-            subject: {
-              reference: 'Patient/p1',
-            },
-            encounter: {
-              reference: 'Encounter/e1'
-            },
-            authoredOn: '2021-08-04T00:00:00-04:00',
-            requester: {
-              reference: 'Practitioner/p2'
-            },
-            dosageInstruction: [
-              {
-                text: 'this is a dosage instruction'
-              }
-            ]
-          )
-        }
-
-        it 'passes if server suports all MS slices' do
-          allow_any_instance_of(test_class)
-            .to receive(:scratch_resources).and_return(
-              {
-                all: [medication_request_1]
-              }
-            )
-
-
-          result = run(test_class)
-          expect(result.result).to eq('pass')
-        end
-      end
-    end
-  end
-
-  describe 'must support test for choices' do
-    let(:test_class) { USCoreTestKit::USCoreV501::ConditionProblemsHealthConcernsMustSupportTest }
-    let(:condition) {
-      FHIR::Condition.new(
-        extension: [
-          {
-            url: 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate',
-            valueDateTime: '2016-08-10'
-          }
-        ],
-        clinicalStatus: {
-          coding: [
-            {
-              system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
-              code: 'active'
-            }
-          ]
-        },
-        verificationStatus: {
-          coding: [
-            {
-              system: 'http://terminology.hl7.org/CodeSystem/condition-ver-status',
-              code: 'confirmed'
-            }
-          ]
-        },
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/condition-category',
-                code: 'problem-list-item'
-              }
-            ]
-          },
-          {
-            coding: [
-              {
-                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags',
-                code: 'sdoh'
-              }
-            ]
-          }
-        ],
-        code: {
-          coding: [
-            {
-              system: 'http://snomed.info/sct',
-              code: '445281000124101'
-            }
-          ]
-        },
-        subject: {
-          reference: 'Patient/123',
-        },
-        recordedDate: '2016-08-10T07:15:07-08:00',
-        onsetDateTime: '2016-08-10T07:15:07-08:00',
-        abatementDateTime: '2016-08-10T07:15:07-08:00'
-      )
     }
 
-    it 'passes if server suports assertDate extension' do
-      condition.onsetDateTime = nil
-
+    it 'passes if resources cover all must support sub elements of slices' do
       allow_any_instance_of(test_class)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [condition]
-          }
-        )
+          .to receive(:scratch_resources).and_return(
+            {
+              all: [coverage_with_two_classes]
+            }
+          )
 
-      result = run(test_class)
-      expect(result.result).to eq('pass')
-    end
-
-    it 'passes if server suports onsetDate' do
-      condition.extension = []
-
-      allow_any_instance_of(test_class)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [condition]
-          }
-        )
-
-      result = run(test_class)
-      expect(result.result).to eq('pass')
-    end
-
-    it 'skips if server suports none of assertDate extension and onsetDate' do
-      condition.onsetDateTime = nil
-      condition.extension = []
-
-      allow_any_instance_of(test_class)
-        .to receive(:scratch_resources).and_return(
-          {
-            all: [condition]
-          }
-        )
-
-      result = run(test_class)
-      expect(result.result).to eq('skip')
-      expect(result.result_message).to include('onsetDateTime')
-      expect(result.result_message).to include('Condition.extension:assertedDate')
+        result = run(test_class)
+        expect(result.result).to eq('pass')
     end
   end
 

--- a/spec/us_core/resource_navigation_spec.rb
+++ b/spec/us_core/resource_navigation_spec.rb
@@ -1,40 +1,98 @@
 require_relative '../../lib/us_core_test_kit/fhir_resource_navigation'
 
 RSpec.describe USCoreTestKit::FHIRResourceNavigation do
-  let (:navigation_class) {
-    Class.new.extend(USCoreTestKit::FHIRResourceNavigation)
+  # Using a must_support_test instance to perform navigation in order to have access to metadata.
+  let (:must_support_coverage_test) {
+    USCoreTestKit::USCoreV610::CoverageMustSupportTest.new
   }
-  let(:coverage_with_two_classes) {
+  let (:must_support_heartrate_test) {
+    USCoreTestKit::USCoreV610::HeartRateMustSupportTest.new
+  }
+  let (:coverage_with_two_classes) {
     FHIR::Coverage.new.tap{ |cov|
       cov.local_class = [FHIR::Coverage::Class.new.tap{ |loc_class|
         loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
-          code_concept.coding = FHIR::Coding.new.tap{ |coding|
-            coding.system = "A"
+          code_concept.coding = [FHIR::Coding.new.tap{ |coding|
+            coding.system = "http://terminology.hl7.org/CodeSystem/coverage-class"
             coding.code = "group"
-          }
+          }]
         }
-      loc_class.value = "groupclass"
-      },
-      FHIR::Coverage::Class.new.tap{ |loc_class|
-        loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
-          code_concept.coding = FHIR::Coding.new.tap{ |coding|
-            coding.system = "B"
-            coding.code = "plan"
+        loc_class.value = "groupclass"
+        },
+        FHIR::Coverage::Class.new.tap{ |loc_class|
+          loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
+            code_concept.coding = [FHIR::Coding.new.tap{ |coding|
+              coding.system = "http://terminology.hl7.org/CodeSystem/coverage-class"
+              coding.code = "plan"
+            }]
           }
+        loc_class.value = "planclass"
         }
-      loc_class.value = "planclass"
-      }
+        ]
+        cov.identifier = [FHIR::Identifier.new.tap {|identifier|
+          identifier.type = FHIR::CodeableConcept.new.tap { |code_concept|
+            code_concept.coding = [FHIR::Coding.new.tap{ |coding|
+              coding.system = "http://terminology.hl7.org/CodeSystem/v2-0203"
+              coding.code = "MB"
+            }]
+          }
+          identifier.system = "https://github.com/inferno-framework/us-core-test-kit"
+          identifier.value = "f4a375d2-4e53-4f81-ba95-345e7573b550"
+        }
       ]
+    }
+  }
+  let (:heartrate_by_value) {
+    FHIR::Observation.new.tap { |observation| 
+      observation.category = [FHIR::CodeableConcept.new.tap { |code_concept| 
+        code_concept.coding = [FHIR::Coding.new.tap { |code| 
+          code.system = 'something-else'
+          code.code = 'vital-signs'
+        }]
+        code_concept.text = 'heartrate-example-wrong-system'
+      },
+      FHIR::CodeableConcept.new.tap { |code_concept| 
+        code_concept.coding = [FHIR::Coding.new.tap { |code| 
+          code.system = 'http://terminology.hl7.org/CodeSystem/observation-category'
+          code.code = 'something-else'
+        }]
+        code_concept.text = 'heartrate-example-wrong-code'
+      },
+        FHIR::CodeableConcept.new.tap { |code_concept| 
+        code_concept.coding = [FHIR::Coding.new.tap { |code| 
+          code.system = 'http://terminology.hl7.org/CodeSystem/observation-category'
+          code.code = 'vital-signs'
+        }]
+        code_concept.text = 'heartrate-example'
+      }]
+      observation.valueQuantity = FHIR::Quantity.new.tap { |quantity| 
+        quantity.value = 44
+        quantity.unit = "beats/min"
+        quantity.system = "http://unitsofmeasure.org"
+        quantity.code = "/min"
+      }
     }
   }
 
   context '#find_a_value_at' do
     it 'finds the first value when not given a specific slice' do
-      expect(navigation_class.find_a_value_at(coverage_with_two_classes, 'class.value')).to  eq('groupclass')
+      expect(must_support_coverage_test.find_a_value_at(coverage_with_two_classes, 'class.value')).to  eq('groupclass')
     end
 
     it 'finds a specific slice value when given a specific slice' do
-      expect(navigation_class.find_a_value_at(coverage_with_two_classes, 'class:plan.value')).to eq('planclass')
+      expect(must_support_coverage_test.find_a_value_at(coverage_with_two_classes, 'class:plan.value')).to eq('planclass')
+    end
+
+    it 'can find fixed elements given a specific slice' do
+      expect(must_support_coverage_test.find_a_value_at(coverage_with_two_classes, 'identifier:memberid.type.coding.code')).to eq('MB')
+    end
+
+    it 'can find an element in a specific slice discriminated by values' do
+      expect(must_support_heartrate_test.find_a_value_at(heartrate_by_value, 'category:VSCat.text')).to eq('heartrate-example')
+    end
+
+    it 'can find an element in a specific slice discriminated by type' do
+      expect(must_support_heartrate_test.find_a_value_at(heartrate_by_value, 'value[x]:valueQuantity.code')).to eq('/min')
     end
   end
 end

--- a/spec/us_core/resource_navigation_spec.rb
+++ b/spec/us_core/resource_navigation_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../lib/us_core_test_kit/fhir_resource_navigation'
+
+RSpec.describe USCoreTestKit::FHIRResourceNavigation do
+  let (:navigation_class) {
+    Class.new.extend(USCoreTestKit::FHIRResourceNavigation)
+  }
+  let(:coverage_with_two_classes) {
+    FHIR::Coverage.new.tap{ |cov|
+      cov.local_class = [FHIR::Coverage::Class.new.tap{ |loc_class|
+        loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
+          code_concept.coding = FHIR::Coding.new.tap{ |coding|
+            coding.system = "A"
+            coding.code = "group"
+          }
+        }
+      loc_class.value = "groupclass"
+      },
+      FHIR::Coverage::Class.new.tap{ |loc_class|
+        loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
+          code_concept.coding = FHIR::Coding.new.tap{ |coding|
+            coding.system = "B"
+            coding.code = "plan"
+          }
+        }
+      loc_class.value = "planclass"
+      }
+      ]
+    }
+  }
+
+  context '#find_a_value_at' do
+    it 'finds the first value when not given a specific slice' do
+      expect(navigation_class.find_a_value_at(coverage_with_two_classes, 'class.value')).to  eq('groupclass')
+    end
+
+    it 'finds a specific slice value when given a specific slice' do
+      expect(navigation_class.find_a_value_at(coverage_with_two_classes, 'class:plan.value')).to eq('planclass')
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Completion of [FI-2313](https://oncprojectracking.healthit.gov/support/browse/FI-2313)
- metadata extraction now collects both the tail end of slices and stores it under `slice_name` and stores the full id (not path) under `slice_id`
- areas that referenced slice[:name] correctly use slice_id 
- `fhir_resource_navigation` updated to be able to navigate slices using their discriminator.
