### PR TITLE
FI-2348 Add guard for fixed values on slice discriminators

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -3816,8 +3816,7 @@
     - :path: component
     - :path: component.code
     - :path: component.value[x]
-    - :path: component:FlowRate.code.coding.code
-      :fixed_value: 3151-8
+    - :path: component:FlowRate.code
     - :path: component:FlowRate.value[x]
     - :path: component:FlowRate.value[x].value
     - :path: component:FlowRate.value[x].unit
@@ -3825,8 +3824,7 @@
       :fixed_value: http://unitsofmeasure.org
     - :path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component:Concentration.code.coding.code
-      :fixed_value: 3150-0
+    - :path: component:Concentration.code
     - :path: component:Concentration.value[x]
     - :path: component:Concentration.value[x].value
     - :path: component:Concentration.value[x].unit
@@ -6720,10 +6718,8 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
-    - :path: agent:ProvenanceAuthor.type.coding.code
-      :fixed_value: author
-    - :path: agent:ProvenanceTransmitter.type.coding.code
-      :fixed_value: transmitter
+    - :path: agent:ProvenanceAuthor.type
+    - :path: agent:ProvenanceTransmitter.type
   :mandatory_elements:
   - Provenance.target
   - Provenance.recorded

--- a/lib/us_core_test_kit/generated/v3.1.1/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/provenance/metadata.yml
@@ -67,10 +67,8 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
-  - :path: agent:ProvenanceAuthor.type.coding.code
-    :fixed_value: author
-  - :path: agent:ProvenanceTransmitter.type.coding.code
-    :fixed_value: transmitter
+  - :path: agent:ProvenanceAuthor.type
+  - :path: agent:ProvenanceTransmitter.type
 :mandatory_elements:
 - Provenance.target
 - Provenance.recorded

--- a/lib/us_core_test_kit/generated/v3.1.1/provenance/provenance_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/provenance/provenance_must_support_test.rb
@@ -17,9 +17,9 @@ module USCoreTestKit
         * Provenance.agent.type
         * Provenance.agent.who
         * Provenance.agent:ProvenanceAuthor
-        * Provenance.agent:ProvenanceAuthor.type.coding.code
+        * Provenance.agent:ProvenanceAuthor.type
         * Provenance.agent:ProvenanceTransmitter
-        * Provenance.agent:ProvenanceTransmitter.type.coding.code
+        * Provenance.agent:ProvenanceTransmitter.type
         * Provenance.recorded
         * Provenance.target
       )

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
@@ -212,8 +212,7 @@
   - :path: component
   - :path: component.code
   - :path: component.value[x]
-  - :path: component:FlowRate.code.coding.code
-    :fixed_value: 3151-8
+  - :path: component:FlowRate.code
   - :path: component:FlowRate.value[x]
   - :path: component:FlowRate.value[x].value
   - :path: component:FlowRate.value[x].unit
@@ -221,8 +220,7 @@
     :fixed_value: http://unitsofmeasure.org
   - :path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component:Concentration.code.coding.code
-    :fixed_value: 3150-0
+  - :path: component:Concentration.code
   - :path: component:Concentration.value[x]
   - :path: component:Concentration.value[x].value
   - :path: component:Concentration.value[x].unit

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -26,14 +26,14 @@ module USCoreTestKit
         * Observation.component.code
         * Observation.component.value[x]
         * Observation.component:Concentration
-        * Observation.component:Concentration.code.coding.code
+        * Observation.component:Concentration.code
         * Observation.component:Concentration.value[x]
         * Observation.component:Concentration.value[x].code
         * Observation.component:Concentration.value[x].system
         * Observation.component:Concentration.value[x].unit
         * Observation.component:Concentration.value[x].value
         * Observation.component:FlowRate
-        * Observation.component:FlowRate.code.coding.code
+        * Observation.component:FlowRate.code
         * Observation.component:FlowRate.value[x]
         * Observation.component:FlowRate.value[x].code
         * Observation.component:FlowRate.value[x].system

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/blood_pressure_must_support_test.rb
@@ -22,14 +22,14 @@ module USCoreTestKit
         * Observation.component.code
         * Observation.component.valueQuantity
         * Observation.component:diastolic
-        * Observation.component:diastolic.code.coding.code
+        * Observation.component:diastolic.code
         * Observation.component:diastolic.valueQuantity
         * Observation.component:diastolic.valueQuantity.code
         * Observation.component:diastolic.valueQuantity.system
         * Observation.component:diastolic.valueQuantity.unit
         * Observation.component:diastolic.valueQuantity.value
         * Observation.component:systolic
-        * Observation.component:systolic.code.coding.code
+        * Observation.component:systolic.code
         * Observation.component:systolic.valueQuantity
         * Observation.component:systolic.valueQuantity.code
         * Observation.component:systolic.valueQuantity.system

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
@@ -186,8 +186,7 @@
   - :path: component.code
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component:systolic.code.coding.code
-    :fixed_value: 8480-6
+  - :path: component:systolic.code
   - :path: component:systolic.valueQuantity
     :original_path: component:systolic.value[x]
   - :path: component:systolic.valueQuantity.value
@@ -200,8 +199,7 @@
   - :path: component:systolic.valueQuantity.code
     :original_path: component:systolic.value[x].code
     :fixed_value: mm[Hg]
-  - :path: component:diastolic.code.coding.code
-    :fixed_value: 8462-4
+  - :path: component:diastolic.code
   - :path: component:diastolic.valueQuantity
     :original_path: component:diastolic.value[x]
   - :path: component:diastolic.valueQuantity.value

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -3059,8 +3059,7 @@
     - :path: component.code
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component:systolic.code.coding.code
-      :fixed_value: 8480-6
+    - :path: component:systolic.code
     - :path: component:systolic.valueQuantity
       :original_path: component:systolic.value[x]
     - :path: component:systolic.valueQuantity.value
@@ -3073,8 +3072,7 @@
     - :path: component:systolic.valueQuantity.code
       :original_path: component:systolic.value[x].code
       :fixed_value: mm[Hg]
-    - :path: component:diastolic.code.coding.code
-      :fixed_value: 8462-4
+    - :path: component:diastolic.code
     - :path: component:diastolic.valueQuantity
       :original_path: component:diastolic.value[x]
     - :path: component:diastolic.valueQuantity.value
@@ -5701,8 +5699,7 @@
     - :path: component.code
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component:FlowRate.code.coding.code
-      :fixed_value: 3151-8
+    - :path: component:FlowRate.code
     - :path: component:FlowRate.valueQuantity
       :original_path: component:FlowRate.value[x]
     - :path: component:FlowRate.valueQuantity.value
@@ -5715,8 +5712,7 @@
     - :path: component:FlowRate.valueQuantity.code
       :original_path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component:Concentration.code.coding.code
-      :fixed_value: 3150-0
+    - :path: component:Concentration.code
     - :path: component:Concentration.valueQuantity
       :original_path: component:Concentration.value[x]
     - :path: component:Concentration.valueQuantity.value
@@ -7245,10 +7241,8 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
-    - :path: agent:ProvenanceAuthor.type.coding.code
-      :fixed_value: author
-    - :path: agent:ProvenanceTransmitter.type.coding.code
-      :fixed_value: transmitter
+    - :path: agent:ProvenanceAuthor.type
+    - :path: agent:ProvenanceTransmitter.type
   :mandatory_elements:
   - Provenance.target
   - Provenance.target.reference

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
@@ -70,10 +70,8 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
-  - :path: agent:ProvenanceAuthor.type.coding.code
-    :fixed_value: author
-  - :path: agent:ProvenanceTransmitter.type.coding.code
-    :fixed_value: transmitter
+  - :path: agent:ProvenanceAuthor.type
+  - :path: agent:ProvenanceTransmitter.type
 :mandatory_elements:
 - Provenance.target
 - Provenance.target.reference

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/provenance_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/provenance_must_support_test.rb
@@ -17,9 +17,9 @@ module USCoreTestKit
         * Provenance.agent.type
         * Provenance.agent.who
         * Provenance.agent:ProvenanceAuthor
-        * Provenance.agent:ProvenanceAuthor.type.coding.code
+        * Provenance.agent:ProvenanceAuthor.type
         * Provenance.agent:ProvenanceTransmitter
-        * Provenance.agent:ProvenanceTransmitter.type.coding.code
+        * Provenance.agent:ProvenanceTransmitter.type
         * Provenance.recorded
         * Provenance.target
         * Provenance.target.reference

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
@@ -205,8 +205,7 @@
   - :path: component.code
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component:FlowRate.code.coding.code
-    :fixed_value: 3151-8
+  - :path: component:FlowRate.code
   - :path: component:FlowRate.valueQuantity
     :original_path: component:FlowRate.value[x]
   - :path: component:FlowRate.valueQuantity.value
@@ -219,8 +218,7 @@
   - :path: component:FlowRate.valueQuantity.code
     :original_path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component:Concentration.code.coding.code
-    :fixed_value: 3150-0
+  - :path: component:Concentration.code
   - :path: component:Concentration.valueQuantity
     :original_path: component:Concentration.value[x]
   - :path: component:Concentration.valueQuantity.value

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -25,14 +25,14 @@ module USCoreTestKit
         * Observation.component.code
         * Observation.component.valueQuantity
         * Observation.component:Concentration
-        * Observation.component:Concentration.code.coding.code
+        * Observation.component:Concentration.code
         * Observation.component:Concentration.valueQuantity
         * Observation.component:Concentration.valueQuantity.code
         * Observation.component:Concentration.valueQuantity.system
         * Observation.component:Concentration.valueQuantity.unit
         * Observation.component:Concentration.valueQuantity.value
         * Observation.component:FlowRate
-        * Observation.component:FlowRate.code.coding.code
+        * Observation.component:FlowRate.code
         * Observation.component:FlowRate.valueQuantity
         * Observation.component:FlowRate.valueQuantity.code
         * Observation.component:FlowRate.valueQuantity.system

--- a/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/blood_pressure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/blood_pressure_must_support_test.rb
@@ -23,7 +23,7 @@ module USCoreTestKit
         * Observation.component.dataAbsentReason
         * Observation.component.valueQuantity
         * Observation.component:diastolic
-        * Observation.component:diastolic.code.coding.code
+        * Observation.component:diastolic.code
         * Observation.component:diastolic.dataAbsentReason
         * Observation.component:diastolic.valueQuantity
         * Observation.component:diastolic.valueQuantity.code
@@ -31,7 +31,7 @@ module USCoreTestKit
         * Observation.component:diastolic.valueQuantity.unit
         * Observation.component:diastolic.valueQuantity.value
         * Observation.component:systolic
-        * Observation.component:systolic.code.coding.code
+        * Observation.component:systolic.code
         * Observation.component:systolic.dataAbsentReason
         * Observation.component:systolic.valueQuantity
         * Observation.component:systolic.valueQuantity.code

--- a/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
@@ -187,8 +187,7 @@
   - :path: component.valueQuantity
     :original_path: component.value[x]
   - :path: component.dataAbsentReason
-  - :path: component:systolic.code.coding.code
-    :fixed_value: 8480-6
+  - :path: component:systolic.code
   - :path: component:systolic.valueQuantity
     :original_path: component:systolic.value[x]
   - :path: component:systolic.valueQuantity.value
@@ -202,8 +201,7 @@
     :original_path: component:systolic.value[x].code
     :fixed_value: mm[Hg]
   - :path: component:systolic.dataAbsentReason
-  - :path: component:diastolic.code.coding.code
-    :fixed_value: 8462-4
+  - :path: component:diastolic.code
   - :path: component:diastolic.valueQuantity
     :original_path: component:diastolic.value[x]
   - :path: component:diastolic.valueQuantity.value

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -5214,8 +5214,7 @@
     - :path: component.code
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component:FlowRate.code.coding.code
-      :fixed_value: 3151-8
+    - :path: component:FlowRate.code
     - :path: component:FlowRate.valueQuantity
       :original_path: component:FlowRate.value[x]
     - :path: component:FlowRate.valueQuantity.value
@@ -5228,8 +5227,7 @@
     - :path: component:FlowRate.valueQuantity.code
       :original_path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component:Concentration.code.coding.code
-      :fixed_value: 3150-0
+    - :path: component:Concentration.code
     - :path: component:Concentration.valueQuantity
       :original_path: component:Concentration.value[x]
     - :path: component:Concentration.valueQuantity.value
@@ -6742,8 +6740,7 @@
     - :path: component.valueQuantity
       :original_path: component.value[x]
     - :path: component.dataAbsentReason
-    - :path: component:systolic.code.coding.code
-      :fixed_value: 8480-6
+    - :path: component:systolic.code
     - :path: component:systolic.valueQuantity
       :original_path: component:systolic.value[x]
     - :path: component:systolic.valueQuantity.value
@@ -6757,8 +6754,7 @@
       :original_path: component:systolic.value[x].code
       :fixed_value: mm[Hg]
     - :path: component:systolic.dataAbsentReason
-    - :path: component:diastolic.code.coding.code
-      :fixed_value: 8462-4
+    - :path: component:diastolic.code
     - :path: component:diastolic.valueQuantity
       :original_path: component:diastolic.value[x]
     - :path: component:diastolic.valueQuantity.value
@@ -9549,10 +9545,8 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
-    - :path: agent:ProvenanceAuthor.type.coding.code
-      :fixed_value: author
-    - :path: agent:ProvenanceTransmitter.type.coding.code
-      :fixed_value: transmitter
+    - :path: agent:ProvenanceAuthor.type
+    - :path: agent:ProvenanceTransmitter.type
   :mandatory_elements:
   - Provenance.target
   - Provenance.recorded

--- a/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
@@ -70,10 +70,8 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
-  - :path: agent:ProvenanceAuthor.type.coding.code
-    :fixed_value: author
-  - :path: agent:ProvenanceTransmitter.type.coding.code
-    :fixed_value: transmitter
+  - :path: agent:ProvenanceAuthor.type
+  - :path: agent:ProvenanceTransmitter.type
 :mandatory_elements:
 - Provenance.target
 - Provenance.recorded

--- a/lib/us_core_test_kit/generated/v5.0.1/provenance/provenance_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/provenance/provenance_must_support_test.rb
@@ -17,9 +17,9 @@ module USCoreTestKit
         * Provenance.agent.type
         * Provenance.agent.who
         * Provenance.agent:ProvenanceAuthor
-        * Provenance.agent:ProvenanceAuthor.type.coding.code
+        * Provenance.agent:ProvenanceAuthor.type
         * Provenance.agent:ProvenanceTransmitter
-        * Provenance.agent:ProvenanceTransmitter.type.coding.code
+        * Provenance.agent:ProvenanceTransmitter.type
         * Provenance.recorded
         * Provenance.target
         * Provenance.target.reference

--- a/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
@@ -205,8 +205,7 @@
   - :path: component.code
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component:FlowRate.code.coding.code
-    :fixed_value: 3151-8
+  - :path: component:FlowRate.code
   - :path: component:FlowRate.valueQuantity
     :original_path: component:FlowRate.value[x]
   - :path: component:FlowRate.valueQuantity.value
@@ -219,8 +218,7 @@
   - :path: component:FlowRate.valueQuantity.code
     :original_path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component:Concentration.code.coding.code
-    :fixed_value: 3150-0
+  - :path: component:Concentration.code
   - :path: component:Concentration.valueQuantity
     :original_path: component:Concentration.value[x]
   - :path: component:Concentration.valueQuantity.value

--- a/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -25,14 +25,14 @@ module USCoreTestKit
         * Observation.component.code
         * Observation.component.valueQuantity
         * Observation.component:Concentration
-        * Observation.component:Concentration.code.coding.code
+        * Observation.component:Concentration.code
         * Observation.component:Concentration.valueQuantity
         * Observation.component:Concentration.valueQuantity.code
         * Observation.component:Concentration.valueQuantity.system
         * Observation.component:Concentration.valueQuantity.unit
         * Observation.component:Concentration.valueQuantity.value
         * Observation.component:FlowRate
-        * Observation.component:FlowRate.code.coding.code
+        * Observation.component:FlowRate.code
         * Observation.component:FlowRate.valueQuantity
         * Observation.component:FlowRate.valueQuantity.code
         * Observation.component:FlowRate.valueQuantity.system

--- a/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/blood_pressure_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/blood_pressure_must_support_test.rb
@@ -23,7 +23,7 @@ module USCoreTestKit
         * Observation.component.dataAbsentReason
         * Observation.component.valueQuantity
         * Observation.component:diastolic
-        * Observation.component:diastolic.code.coding.code
+        * Observation.component:diastolic.code
         * Observation.component:diastolic.dataAbsentReason
         * Observation.component:diastolic.valueQuantity
         * Observation.component:diastolic.valueQuantity.code
@@ -31,7 +31,7 @@ module USCoreTestKit
         * Observation.component:diastolic.valueQuantity.unit
         * Observation.component:diastolic.valueQuantity.value
         * Observation.component:systolic
-        * Observation.component:systolic.code.coding.code
+        * Observation.component:systolic.code
         * Observation.component:systolic.dataAbsentReason
         * Observation.component:systolic.valueQuantity
         * Observation.component:systolic.valueQuantity.code

--- a/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
@@ -187,8 +187,7 @@
   - :path: component.valueQuantity
     :original_path: component.value[x]
   - :path: component.dataAbsentReason
-  - :path: component:systolic.code.coding.code
-    :fixed_value: 8480-6
+  - :path: component:systolic.code
   - :path: component:systolic.valueQuantity
     :original_path: component:systolic.value[x]
   - :path: component:systolic.valueQuantity.value
@@ -202,8 +201,7 @@
     :original_path: component:systolic.value[x].code
     :fixed_value: mm[Hg]
   - :path: component:systolic.dataAbsentReason
-  - :path: component:diastolic.code.coding.code
-    :fixed_value: 8462-4
+  - :path: component:diastolic.code
   - :path: component:diastolic.valueQuantity
     :original_path: component:diastolic.value[x]
   - :path: component:diastolic.valueQuantity.value

--- a/lib/us_core_test_kit/generated/v6.1.0/coverage/coverage_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/coverage/coverage_must_support_test.rb
@@ -22,7 +22,7 @@ module USCoreTestKit
         * Coverage.class:plan.value
         * Coverage.identifier
         * Coverage.identifier:memberid
-        * Coverage.identifier:memberid.type.coding.code
+        * Coverage.identifier:memberid.type
         * Coverage.payor
         * Coverage.period
         * Coverage.relationship

--- a/lib/us_core_test_kit/generated/v6.1.0/coverage/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/coverage/metadata.yml
@@ -80,8 +80,7 @@
       :system: http://terminology.hl7.org/CodeSystem/coverage-class
   :elements:
   - :path: identifier
-  - :path: identifier:memberid.type.coding.code
-    :fixed_value: MB
+  - :path: identifier:memberid.type
   - :path: status
   - :path: type
   - :path: subscriberId

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -1276,8 +1276,7 @@
         :system: http://terminology.hl7.org/CodeSystem/coverage-class
     :elements:
     - :path: identifier
-    - :path: identifier:memberid.type.coding.code
-      :fixed_value: MB
+    - :path: identifier:memberid.type
     - :path: status
     - :path: type
     - :path: subscriberId
@@ -4532,8 +4531,7 @@
       :types:
       - Reference
     - :path: component
-    - :path: component:industry.code.coding.code
-      :fixed_value: 86188-0
+    - :path: component:industry.code
     - :path: component:industry.value[x]
   :mandatory_elements:
   - Observation.status
@@ -6141,8 +6139,7 @@
     - :path: component.code
     - :path: component.valueQuantity
       :original_path: component.value[x]
-    - :path: component:FlowRate.code.coding.code
-      :fixed_value: 3151-8
+    - :path: component:FlowRate.code
     - :path: component:FlowRate.valueQuantity
       :original_path: component:FlowRate.value[x]
     - :path: component:FlowRate.valueQuantity.value
@@ -6155,8 +6152,7 @@
     - :path: component:FlowRate.valueQuantity.code
       :original_path: component:FlowRate.value[x].code
       :fixed_value: L/min
-    - :path: component:Concentration.code.coding.code
-      :fixed_value: 3150-0
+    - :path: component:Concentration.code
     - :path: component:Concentration.valueQuantity
       :original_path: component:Concentration.value[x]
     - :path: component:Concentration.valueQuantity.value
@@ -7960,8 +7956,7 @@
     - :path: component.valueQuantity
       :original_path: component.value[x]
     - :path: component.dataAbsentReason
-    - :path: component:systolic.code.coding.code
-      :fixed_value: 8480-6
+    - :path: component:systolic.code
     - :path: component:systolic.valueQuantity
       :original_path: component:systolic.value[x]
     - :path: component:systolic.valueQuantity.value
@@ -7975,8 +7970,7 @@
       :original_path: component:systolic.value[x].code
       :fixed_value: mm[Hg]
     - :path: component:systolic.dataAbsentReason
-    - :path: component:diastolic.code.coding.code
-      :fixed_value: 8462-4
+    - :path: component:diastolic.code
     - :path: component:diastolic.valueQuantity
       :original_path: component:diastolic.value[x]
     - :path: component:diastolic.valueQuantity.value
@@ -10156,10 +10150,8 @@
     - :path: agent.onBehalfOf
       :types:
       - Reference
-    - :path: agent:ProvenanceAuthor.type.coding.code
-      :fixed_value: author
-    - :path: agent:ProvenanceTransmitter.type.coding.code
-      :fixed_value: transmitter
+    - :path: agent:ProvenanceAuthor.type
+    - :path: agent:ProvenanceTransmitter.type
   :mandatory_elements:
   - Provenance.target
   - Provenance.recorded

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/metadata.yml
@@ -186,8 +186,7 @@
     :types:
     - Reference
   - :path: component
-  - :path: component:industry.code.coding.code
-    :fixed_value: 86188-0
+  - :path: component:industry.code
   - :path: component:industry.value[x]
 :mandatory_elements:
 - Observation.status

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/observation_occupation_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/observation_occupation_must_support_test.rb
@@ -17,7 +17,7 @@ module USCoreTestKit
         * Observation.code.coding.code
         * Observation.component
         * Observation.component:industry
-        * Observation.component:industry.code.coding.code
+        * Observation.component:industry.code
         * Observation.component:industry.value[x]
         * Observation.effective[x]:effectivePeriod
         * Observation.status

--- a/lib/us_core_test_kit/generated/v6.1.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/provenance/metadata.yml
@@ -70,10 +70,8 @@
   - :path: agent.onBehalfOf
     :types:
     - Reference
-  - :path: agent:ProvenanceAuthor.type.coding.code
-    :fixed_value: author
-  - :path: agent:ProvenanceTransmitter.type.coding.code
-    :fixed_value: transmitter
+  - :path: agent:ProvenanceAuthor.type
+  - :path: agent:ProvenanceTransmitter.type
 :mandatory_elements:
 - Provenance.target
 - Provenance.recorded

--- a/lib/us_core_test_kit/generated/v6.1.0/provenance/provenance_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/provenance/provenance_must_support_test.rb
@@ -17,9 +17,9 @@ module USCoreTestKit
         * Provenance.agent.type
         * Provenance.agent.who
         * Provenance.agent:ProvenanceAuthor
-        * Provenance.agent:ProvenanceAuthor.type.coding.code
+        * Provenance.agent:ProvenanceAuthor.type
         * Provenance.agent:ProvenanceTransmitter
-        * Provenance.agent:ProvenanceTransmitter.type.coding.code
+        * Provenance.agent:ProvenanceTransmitter.type
         * Provenance.recorded
         * Provenance.target
         * Provenance.target.reference

--- a/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
@@ -221,8 +221,7 @@
   - :path: component.code
   - :path: component.valueQuantity
     :original_path: component.value[x]
-  - :path: component:FlowRate.code.coding.code
-    :fixed_value: 3151-8
+  - :path: component:FlowRate.code
   - :path: component:FlowRate.valueQuantity
     :original_path: component:FlowRate.value[x]
   - :path: component:FlowRate.valueQuantity.value
@@ -235,8 +234,7 @@
   - :path: component:FlowRate.valueQuantity.code
     :original_path: component:FlowRate.value[x].code
     :fixed_value: L/min
-  - :path: component:Concentration.code.coding.code
-    :fixed_value: 3150-0
+  - :path: component:Concentration.code
   - :path: component:Concentration.valueQuantity
     :original_path: component:Concentration.value[x]
   - :path: component:Concentration.valueQuantity.value

--- a/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/pulse_oximetry_must_support_test.rb
@@ -25,14 +25,14 @@ module USCoreTestKit
         * Observation.component.code
         * Observation.component.valueQuantity
         * Observation.component:Concentration
-        * Observation.component:Concentration.code.coding.code
+        * Observation.component:Concentration.code
         * Observation.component:Concentration.valueQuantity
         * Observation.component:Concentration.valueQuantity.code
         * Observation.component:Concentration.valueQuantity.system
         * Observation.component:Concentration.valueQuantity.unit
         * Observation.component:Concentration.valueQuantity.value
         * Observation.component:FlowRate
-        * Observation.component:FlowRate.code.coding.code
+        * Observation.component:FlowRate.code
         * Observation.component:FlowRate.valueQuantity
         * Observation.component:FlowRate.valueQuantity.code
         * Observation.component:FlowRate.valueQuantity.system

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -36,7 +36,7 @@ module USCoreTestKit
       end
 
       def all_must_support_elements
-        profile_elements.select { |element| element.mustSupport || is_uscdi_requirement_element?(element) }
+        profile_elements.select { |element| (element.mustSupport || is_uscdi_requirement_element?(element))}
       end
 
       def must_support_extension_elements
@@ -211,18 +211,23 @@ module USCoreTestKit
       end
 
       def plain_must_support_elements
-        all_must_support_elements - must_support_extension_elements - must_support_slice_elements
+        plain_must_supports = all_must_support_elements - must_support_extension_elements - must_support_slice_elements
       end
+
+      def element_part_of_slice_discrimination?(element)
+        must_support_slice_elements.any? { |ms_slice| element.id.include?(ms_slice.id) }
+      end
+
 
       def handle_fixed_values(metadata, element)
         if element.fixedUri.present?
           metadata[:fixed_value] = element.fixedUri
-        elsif element.patternCodeableConcept.present?
+        elsif element.patternCodeableConcept.present? && !element_part_of_slice_discrimination?(element)
           metadata[:fixed_value] = element.patternCodeableConcept.coding.first.code
           metadata[:path] += '.coding.code'
         elsif element.fixedCode.present?
           metadata[:fixed_value] = element.fixedCode
-        elsif element.patternIdentifier.present?
+        elsif element.patternIdentifier.present? && !element_part_of_slice_discrimination?(element)
           metadata[:fixed_value] = element.patternIdentifier.system
           metadata[:path] += '.system'
         end


### PR DESCRIPTION
Added a check in `handle_fixed_values` that prevents appending unnecessary information to slice subelement must supports.

No change in test output or rspec tests.  Elements that are not related to slices that have fixed values are still handled with no changes (see Observation.code for observation_occupation/metadata.yml)
