### PR TITLE
FI-2370: Add SMART App Launch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     us_core_test_kit (0.6.2)
       inferno_core (>= 0.4.2)
+      smart_app_launch_test_kit (>= 0.4.0)
       tls_test_kit (~> 0.2.0)
 
 GEM
@@ -249,6 +250,10 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    smart_app_launch_test_kit (0.4.0)
+      inferno_core (>= 0.4.2)
+      jwt (~> 2.6)
+      tls_test_kit (~> 0.2.0)
     sqlite3 (1.6.9)
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.6.9-arm64-darwin)

--- a/config/presets/inferno_reference_server_311_preset.json
+++ b/config/presets/inferno_reference_server_311_preset.json
@@ -18,6 +18,31 @@
       "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
     },
     {
+      "name": "standalone_client_id",
+      "type": "text",
+      "title": "Standalone Client ID",
+      "description": "Client ID provided during registration of Inferno as a standalone application",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
+    },
+    {
+      "name": "standalone_client_secret",
+      "type": "text",
+      "title": "Standalone Client Secret",
+      "description": "Client Secret provided during registration of Inferno as a standalone application",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
+    },
+    {
+      "name": "ehr_client_id",
+      "type": "text",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
+    },
+    {
+      "name": "ehr_client_secret",
+      "type": "text",
+      "optional": false,
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
+    },
+    {
       "name": "patient_ids",
       "type": "text",
       "title": "Patient IDs",

--- a/config/presets/inferno_reference_server_311_preset.json
+++ b/config/presets/inferno_reference_server_311_preset.json
@@ -43,6 +43,11 @@
       "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
     },
     {
+      "name": "client_auth_type",
+      "type": "text",
+      "value": "confidential_symmetric"
+    },
+    {
       "name": "patient_ids",
       "type": "text",
       "title": "Patient IDs",

--- a/config/presets/inferno_reference_server_400_preset.json
+++ b/config/presets/inferno_reference_server_400_preset.json
@@ -18,6 +18,31 @@
       "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
     },
     {
+      "name": "standalone_client_id",
+      "type": "text",
+      "title": "Standalone Client ID",
+      "description": "Client ID provided during registration of Inferno as a standalone application",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
+    },
+    {
+      "name": "standalone_client_secret",
+      "type": "text",
+      "title": "Standalone Client Secret",
+      "description": "Client Secret provided during registration of Inferno as a standalone application",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
+    },
+    {
+      "name": "ehr_client_id",
+      "type": "text",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
+    },
+    {
+      "name": "ehr_client_secret",
+      "type": "text",
+      "optional": false,
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
+    },
+    {
       "name": "patient_ids",
       "type": "text",
       "title": "Patient IDs",

--- a/config/presets/inferno_reference_server_400_preset.json
+++ b/config/presets/inferno_reference_server_400_preset.json
@@ -43,6 +43,11 @@
       "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
     },
     {
+      "name": "client_auth_type",
+      "type": "text",
+      "value": "confidential_symmetric"
+    },
+    {
       "name": "patient_ids",
       "type": "text",
       "title": "Patient IDs",

--- a/config/presets/inferno_reference_server_501_preset.json
+++ b/config/presets/inferno_reference_server_501_preset.json
@@ -18,6 +18,31 @@
       "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
     },
     {
+      "name": "standalone_client_id",
+      "type": "text",
+      "title": "Standalone Client ID",
+      "description": "Client ID provided during registration of Inferno as a standalone application",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
+    },
+    {
+      "name": "standalone_client_secret",
+      "type": "text",
+      "title": "Standalone Client Secret",
+      "description": "Client Secret provided during registration of Inferno as a standalone application",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
+    },
+    {
+      "name": "ehr_client_id",
+      "type": "text",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
+    },
+    {
+      "name": "ehr_client_secret",
+      "type": "text",
+      "optional": false,
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
+    },
+    {
       "name": "patient_ids",
       "type": "text",
       "title": "Patient IDs",

--- a/config/presets/inferno_reference_server_501_preset.json
+++ b/config/presets/inferno_reference_server_501_preset.json
@@ -43,6 +43,11 @@
       "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
     },
     {
+      "name": "client_auth_type",
+      "type": "text",
+      "value": "confidential_symmetric"
+    },
+    {
       "name": "patient_ids",
       "type": "text",
       "title": "Patient IDs",

--- a/config/presets/inferno_reference_server_610_preset.json
+++ b/config/presets/inferno_reference_server_610_preset.json
@@ -18,6 +18,31 @@
       "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
     },
     {
+      "name": "standalone_client_id",
+      "type": "text",
+      "title": "Standalone Client ID",
+      "description": "Client ID provided during registration of Inferno as a standalone application",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
+    },
+    {
+      "name": "standalone_client_secret",
+      "type": "text",
+      "title": "Standalone Client Secret",
+      "description": "Client Secret provided during registration of Inferno as a standalone application",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
+    },
+    {
+      "name": "ehr_client_id",
+      "type": "text",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
+    },
+    {
+      "name": "ehr_client_secret",
+      "type": "text",
+      "optional": false,
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
+    },
+    {
       "name": "patient_ids",
       "type": "text",
       "title": "Patient IDs",

--- a/config/presets/inferno_reference_server_610_preset.json
+++ b/config/presets/inferno_reference_server_610_preset.json
@@ -43,6 +43,11 @@
       "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
     },
     {
+      "name": "client_auth_type",
+      "type": "text",
+      "value": "confidential_symmetric"
+    },
+    {
       "name": "patient_ids",
       "type": "text",
       "title": "Patient IDs",

--- a/lib/us_core_test_kit/custom_groups/smart_app_launch_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_app_launch_group.rb
@@ -5,17 +5,20 @@ module USCoreTestKit
   class SmartAppLaunchGroup < Inferno::TestGroup
     id :us_core_smart_app_launch
     title 'SMART App Launch'
-    
+
     group do
       required_suite_options USCoreOptions::SMART_1_REQUIREMENT
       id :us_core_smart_standalone_launch_stu1
       title 'Standalone Launch'
       optional
 
-      group from: :smart_discovery
-      group from: :smart_standalone_launch
-      
+      group from: :smart_discovery,
+            run_as_group: true
+      group from: :smart_standalone_launch,
+            run_as_group: true
+
       group from: :smart_openid_connect do
+        run_as_group
         optional
         config(
           inputs: {
@@ -29,6 +32,7 @@ module USCoreTestKit
       end
 
       group from: :smart_token_refresh do
+        run_as_group
         optional
         config(
           inputs: {
@@ -47,10 +51,13 @@ module USCoreTestKit
       title 'EHR Launch'
       optional
 
-      group from: :smart_discovery
-      group from: :smart_ehr_launch
-      
+      group from: :smart_discovery,
+            run_as_group: true
+      group from: :smart_ehr_launch,
+            run_as_group: true
+
       group from: :smart_openid_connect do
+        run_as_group
         optional
         config(
           inputs: {
@@ -64,6 +71,7 @@ module USCoreTestKit
       end
 
       group from: :smart_token_refresh do
+        run_as_group
         optional
         config(
           inputs: {
@@ -82,10 +90,13 @@ module USCoreTestKit
       title 'Standalone Launch'
       optional
 
-      group from: :smart_discovery_stu2
-      group from: :smart_standalone_launch_stu2
-      
+      group from: :smart_discovery_stu2,
+            run_as_group: true
+      group from: :smart_standalone_launch_stu2,
+            run_as_group: true
+
       group from: :smart_openid_connect do
+        run_as_group
         optional
         config(
           inputs: {
@@ -99,6 +110,7 @@ module USCoreTestKit
       end
 
       group from: :smart_token_refresh do
+        run_as_group
         optional
         config(
           inputs: {
@@ -117,10 +129,13 @@ module USCoreTestKit
       title 'EHR Launch'
       optional
 
-      group from: :smart_discovery_stu2
-      group from: :smart_ehr_launch_stu2
-      
+      group from: :smart_discovery_stu2,
+            run_as_group: true
+      group from: :smart_ehr_launch_stu2,
+            run_as_group: true
+
       group from: :smart_openid_connect do
+        run_as_group
         optional
         config(
           inputs: {
@@ -134,6 +149,7 @@ module USCoreTestKit
       end
 
       group from: :smart_token_refresh do
+        run_as_group
         optional
         config(
           inputs: {
@@ -147,4 +163,3 @@ module USCoreTestKit
     end
   end
 end
-        

--- a/lib/us_core_test_kit/custom_groups/smart_app_launch_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_app_launch_group.rb
@@ -1,0 +1,150 @@
+require 'smart_app_launch_test_kit'
+require_relative '../us_core_options'
+
+module USCoreTestKit
+  class SmartAppLaunchGroup < Inferno::TestGroup
+    id :us_core_smart_app_launch
+    title 'SMART App Launch'
+    
+    group do
+      required_suite_options USCoreOptions::SMART_1_REQUIREMENT
+      id :us_core_smart_standalone_launch_stu1
+      title 'Standalone Launch'
+      optional
+
+      group from: :smart_discovery
+      group from: :smart_standalone_launch
+      
+      group from: :smart_openid_connect do
+        optional
+        config(
+          inputs: {
+            id_token: { name: :standalone_id_token },
+            client_id: { name: :standalone_client_id },
+            requested_scopes: { name: :standalone_requested_scopes },
+            access_token: { name: :standalone_access_token },
+            smart_credentials: { name: :standalone_smart_credentials }
+          }
+        )
+      end
+
+      group from: :smart_token_refresh do
+        optional
+        config(
+          inputs: {
+            refresh_token: { name: :standalone_refresh_token },
+            client_id: { name: :standalone_client_id },
+            client_secret: { name: :standalone_client_secret },
+            received_scopes: { name: :standalone_received_scopes }
+          }
+        )
+      end
+    end
+
+    group do
+      required_suite_options USCoreOptions::SMART_1_REQUIREMENT
+      id :us_core_smart_ehr_launch_stu1
+      title 'EHR Launch'
+      optional
+
+      group from: :smart_discovery
+      group from: :smart_ehr_launch
+      
+      group from: :smart_openid_connect do
+        optional
+        config(
+          inputs: {
+            id_token: { name: :ehr_id_token },
+            client_id: { name: :ehr_client_id },
+            requested_scopes: { name: :ehr_requested_scopes },
+            access_token: { name: :ehr_access_token },
+            smart_credentials: { name: :ehr_smart_credentials }
+          }
+        )
+      end
+
+      group from: :smart_token_refresh do
+        optional
+        config(
+          inputs: {
+            refresh_token: { name: :ehr_refresh_token },
+            client_id: { name: :ehr_client_id },
+            client_secret: { name: :ehr_client_secret },
+            received_scopes: { name: :ehr_received_scopes }
+          }
+        )
+      end
+    end
+
+    group do
+      required_suite_options USCoreOptions::SMART_2_REQUIREMENT
+      id :us_core_smart_standalone_launch_stu2
+      title 'Standalone Launch'
+      optional
+
+      group from: :smart_discovery_stu2
+      group from: :smart_standalone_launch_stu2
+      
+      group from: :smart_openid_connect do
+        optional
+        config(
+          inputs: {
+            id_token: { name: :standalone_id_token },
+            client_id: { name: :standalone_client_id },
+            requested_scopes: { name: :standalone_requested_scopes },
+            access_token: { name: :standalone_access_token },
+            smart_credentials: { name: :standalone_smart_credentials }
+          }
+        )
+      end
+
+      group from: :smart_token_refresh do
+        optional
+        config(
+          inputs: {
+            refresh_token: { name: :standalone_refresh_token },
+            client_id: { name: :standalone_client_id },
+            client_secret: { name: :standalone_client_secret },
+            received_scopes: { name: :standalone_received_scopes }
+          }
+        )
+      end
+    end
+
+    group do
+      required_suite_options USCoreOptions::SMART_2_REQUIREMENT
+      id :us_core_smart_ehr_launch_stu2
+      title 'EHR Launch'
+      optional
+
+      group from: :smart_discovery_stu2
+      group from: :smart_ehr_launch_stu2
+      
+      group from: :smart_openid_connect do
+        optional
+        config(
+          inputs: {
+            id_token: { name: :ehr_id_token },
+            client_id: { name: :ehr_client_id },
+            requested_scopes: { name: :ehr_requested_scopes },
+            access_token: { name: :ehr_access_token },
+            smart_credentials: { name: :ehr_smart_credentials }
+          }
+        )
+      end
+
+      group from: :smart_token_refresh do
+        optional
+        config(
+          inputs: {
+            refresh_token: { name: :ehr_refresh_token },
+            client_id: { name: :ehr_client_id },
+            client_secret: { name: :ehr_client_secret },
+            received_scopes: { name: :ehr_received_scopes }
+          }
+        )
+      end
+    end
+  end
+end
+        

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -99,39 +99,66 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
-      group from: :us_core_v311_capability_statement
-  
-      group from: :us_core_v311_patient
-      group from: :us_core_v311_allergy_intolerance
-      group from: :us_core_v311_care_plan
-      group from: :us_core_v311_care_team
-      group from: :us_core_v311_condition
-      group from: :us_core_v311_device
-      group from: :us_core_v311_diagnostic_report_note
-      group from: :us_core_v311_diagnostic_report_lab
-      group from: :us_core_v311_document_reference
-      group from: :us_core_v311_goal
-      group from: :us_core_v311_immunization
-      group from: :us_core_v311_medication_request
-      group from: :us_core_v311_smokingstatus
-      group from: :us_core_v311_pediatric_weight_for_height
-      group from: :us_core_v311_observation_lab
-      group from: :us_core_v311_pediatric_bmi_for_age
-      group from: :us_core_v311_pulse_oximetry
-      group from: :us_core_v311_head_circumference
-      group from: :us_core_v311_bodyheight
-      group from: :us_core_v311_bodytemp
-      group from: :us_core_v311_bp
-      group from: :us_core_v311_bodyweight
-      group from: :us_core_v311_heartrate
-      group from: :us_core_v311_resprate
-      group from: :us_core_v311_procedure
-      group from: :us_core_v311_encounter
-      group from: :us_core_v311_organization
-      group from: :us_core_v311_practitioner
-      group from: :us_core_v311_provenance
-      group from: :us_core_v311_clinical_notes_guidance
-      group from: :us_core_311_data_absent_reason
+      group do
+        title 'SMART App Launch'
+        group do
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { assert false }
+          end
+        end
+      end
+
+      group do
+        title 'US Core FHIR API'
+
+        group from: :us_core_v311_capability_statement
+      
+        group from: :us_core_v311_patient
+        group from: :us_core_v311_allergy_intolerance
+        group from: :us_core_v311_care_plan
+        group from: :us_core_v311_care_team
+        group from: :us_core_v311_condition
+        group from: :us_core_v311_device
+        group from: :us_core_v311_diagnostic_report_note
+        group from: :us_core_v311_diagnostic_report_lab
+        group from: :us_core_v311_document_reference
+        group from: :us_core_v311_goal
+        group from: :us_core_v311_immunization
+        group from: :us_core_v311_medication_request
+        group from: :us_core_v311_smokingstatus
+        group from: :us_core_v311_pediatric_weight_for_height
+        group from: :us_core_v311_observation_lab
+        group from: :us_core_v311_pediatric_bmi_for_age
+        group from: :us_core_v311_pulse_oximetry
+        group from: :us_core_v311_head_circumference
+        group from: :us_core_v311_bodyheight
+        group from: :us_core_v311_bodytemp
+        group from: :us_core_v311_bp
+        group from: :us_core_v311_bodyweight
+        group from: :us_core_v311_heartrate
+        group from: :us_core_v311_resprate
+        group from: :us_core_v311_procedure
+        group from: :us_core_v311_encounter
+        group from: :us_core_v311_organization
+        group from: :us_core_v311_practitioner
+        group from: :us_core_v311_provenance
+        group from: :us_core_v311_clinical_notes_guidance
+        group from: :us_core_311_data_absent_reason
+      end
     end
   end
 end

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -1,4 +1,5 @@
 require 'inferno/dsl/oauth_credentials'
+require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '../../custom_groups/v3.1.1/capability_statement_group'
 require_relative '../../custom_groups/v3.1.1/clinical_notes_guidance_group'
@@ -123,9 +124,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery
+          group from: :smart_standalone_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -134,9 +158,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery
+          group from: :smart_ehr_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
 
@@ -145,9 +192,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery_stu2
+          group from: :smart_standalone_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -156,9 +226,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery_stu2
+          group from: :smart_ehr_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
       end

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -4,6 +4,8 @@ require_relative '../../custom_groups/v3.1.1/capability_statement_group'
 require_relative '../../custom_groups/v3.1.1/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
 require_relative '../../provenance_validator'
+require_relative '../../us_core_options'
+
 require_relative 'patient_group'
 require_relative 'allergy_intolerance_group'
 require_relative 'care_plan_group'
@@ -99,9 +101,25 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
+
+      suite_option :smart_app_launch_version,
+      title: 'SMART App Launch Version',
+      list_options: [
+        {
+          label: 'SMART App Launch 1.0.0',
+          value: USCoreOptions::SMART_1
+        },
+        {
+          label: 'SMART App Launch 2.0.0',
+          value: USCoreOptions::SMART_2
+        }
+      ]
+
       group do
         title 'SMART App Launch'
+        
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
           title 'Standalone Launch'
           optional
 
@@ -112,6 +130,29 @@ module USCoreTestKit
         end
 
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { assert false }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
           title 'EHR Launch'
           optional
 

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -104,22 +104,23 @@ module USCoreTestKit
 
 
       suite_option :smart_app_launch_version,
-      title: 'SMART App Launch Version',
-      list_options: [
-        {
-          label: 'SMART App Launch 1.0.0',
-          value: USCoreOptions::SMART_1
-        },
-        {
-          label: 'SMART App Launch 2.0.0',
-          value: USCoreOptions::SMART_2
-        }
-      ]
+        title: 'SMART App Launch Version',
+        list_options: [
+          {
+            label: 'SMART App Launch 1.0.0',
+            value: USCoreOptions::SMART_1
+          },
+          {
+            label: 'SMART App Launch 2.0.0',
+            value: USCoreOptions::SMART_2
+          }
+        ]
 
       group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'
+        id :us_core_v311_fhir_api
 
         group from: :us_core_v311_capability_statement
       

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -1,9 +1,9 @@
 require 'inferno/dsl/oauth_credentials'
-require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '../../custom_groups/v3.1.1/capability_statement_group'
 require_relative '../../custom_groups/v3.1.1/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
+require_relative '../../custom_groups/smart_app_launch_group'
 require_relative '../../provenance_validator'
 require_relative '../../us_core_options'
 
@@ -116,145 +116,7 @@ module USCoreTestKit
         }
       ]
 
-      group do
-        title 'SMART App Launch'
-        
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_standalone_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_ehr_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_standalone_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_ehr_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-      end
+      group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -1,4 +1,5 @@
 require 'inferno/dsl/oauth_credentials'
+require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '../../custom_groups/v4.0.0/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
@@ -125,9 +126,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery
+          group from: :smart_standalone_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -136,9 +160,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery
+          group from: :smart_ehr_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
 
@@ -147,9 +194,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery_stu2
+          group from: :smart_standalone_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -158,9 +228,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery_stu2
+          group from: :smart_ehr_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
       end

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -101,41 +101,68 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
-      group from: :us_core_v400_capability_statement
-  
-      group from: :us_core_v400_patient
-      group from: :us_core_v400_allergy_intolerance
-      group from: :us_core_v400_care_plan
-      group from: :us_core_v400_care_team
-      group from: :us_core_v400_condition
-      group from: :us_core_v400_device
-      group from: :us_core_v400_diagnostic_report_lab
-      group from: :us_core_v400_diagnostic_report_note
-      group from: :us_core_v400_document_reference
-      group from: :us_core_v400_goal
-      group from: :us_core_v400_immunization
-      group from: :us_core_v400_medication_request
-      group from: :us_core_v400_observation_lab
-      group from: :us_core_v400_blood_pressure
-      group from: :us_core_v400_bmi
-      group from: :us_core_v400_head_circumference
-      group from: :us_core_v400_body_height
-      group from: :us_core_v400_body_weight
-      group from: :us_core_v400_body_temperature
-      group from: :us_core_v400_heart_rate
-      group from: :us_core_v400_pediatric_bmi_for_age
-      group from: :us_core_v400_head_circumference_percentile
-      group from: :us_core_v400_pediatric_weight_for_height
-      group from: :us_core_v400_pulse_oximetry
-      group from: :us_core_v400_respiratory_rate
-      group from: :us_core_v400_smokingstatus
-      group from: :us_core_v400_procedure
-      group from: :us_core_v400_encounter
-      group from: :us_core_v400_organization
-      group from: :us_core_v400_practitioner
-      group from: :us_core_v400_provenance
-      group from: :us_core_v400_clinical_notes_guidance
-      group from: :us_core_311_data_absent_reason
+      group do
+        title 'SMART App Launch'
+        group do
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { assert false }
+          end
+        end
+      end
+
+      group do
+        title 'US Core FHIR API'
+
+        group from: :us_core_v400_capability_statement
+      
+        group from: :us_core_v400_patient
+        group from: :us_core_v400_allergy_intolerance
+        group from: :us_core_v400_care_plan
+        group from: :us_core_v400_care_team
+        group from: :us_core_v400_condition
+        group from: :us_core_v400_device
+        group from: :us_core_v400_diagnostic_report_lab
+        group from: :us_core_v400_diagnostic_report_note
+        group from: :us_core_v400_document_reference
+        group from: :us_core_v400_goal
+        group from: :us_core_v400_immunization
+        group from: :us_core_v400_medication_request
+        group from: :us_core_v400_observation_lab
+        group from: :us_core_v400_blood_pressure
+        group from: :us_core_v400_bmi
+        group from: :us_core_v400_head_circumference
+        group from: :us_core_v400_body_height
+        group from: :us_core_v400_body_weight
+        group from: :us_core_v400_body_temperature
+        group from: :us_core_v400_heart_rate
+        group from: :us_core_v400_pediatric_bmi_for_age
+        group from: :us_core_v400_head_circumference_percentile
+        group from: :us_core_v400_pediatric_weight_for_height
+        group from: :us_core_v400_pulse_oximetry
+        group from: :us_core_v400_respiratory_rate
+        group from: :us_core_v400_smokingstatus
+        group from: :us_core_v400_procedure
+        group from: :us_core_v400_encounter
+        group from: :us_core_v400_organization
+        group from: :us_core_v400_practitioner
+        group from: :us_core_v400_provenance
+        group from: :us_core_v400_clinical_notes_guidance
+        group from: :us_core_311_data_absent_reason
+      end
     end
   end
 end

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -4,6 +4,8 @@ require_relative '../../custom_groups/v4.0.0/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
 require_relative '../../provenance_validator'
+require_relative '../../us_core_options'
+
 require_relative 'patient_group'
 require_relative 'allergy_intolerance_group'
 require_relative 'care_plan_group'
@@ -101,9 +103,25 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
+
+      suite_option :smart_app_launch_version,
+      title: 'SMART App Launch Version',
+      list_options: [
+        {
+          label: 'SMART App Launch 1.0.0',
+          value: USCoreOptions::SMART_1
+        },
+        {
+          label: 'SMART App Launch 2.0.0',
+          value: USCoreOptions::SMART_2
+        }
+      ]
+
       group do
         title 'SMART App Launch'
+        
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
           title 'Standalone Launch'
           optional
 
@@ -114,6 +132,29 @@ module USCoreTestKit
         end
 
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { assert false }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
           title 'EHR Launch'
           optional
 

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -106,22 +106,23 @@ module USCoreTestKit
 
 
       suite_option :smart_app_launch_version,
-      title: 'SMART App Launch Version',
-      list_options: [
-        {
-          label: 'SMART App Launch 1.0.0',
-          value: USCoreOptions::SMART_1
-        },
-        {
-          label: 'SMART App Launch 2.0.0',
-          value: USCoreOptions::SMART_2
-        }
-      ]
+        title: 'SMART App Launch Version',
+        list_options: [
+          {
+            label: 'SMART App Launch 1.0.0',
+            value: USCoreOptions::SMART_1
+          },
+          {
+            label: 'SMART App Launch 2.0.0',
+            value: USCoreOptions::SMART_2
+          }
+        ]
 
       group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'
+        id :us_core_v400_fhir_api
 
         group from: :us_core_v400_capability_statement
       

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -1,9 +1,9 @@
 require 'inferno/dsl/oauth_credentials'
-require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '../../custom_groups/v4.0.0/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
+require_relative '../../custom_groups/smart_app_launch_group'
 require_relative '../../provenance_validator'
 require_relative '../../us_core_options'
 
@@ -118,145 +118,7 @@ module USCoreTestKit
         }
       ]
 
-      group do
-        title 'SMART App Launch'
-        
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_standalone_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_ehr_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_standalone_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_ehr_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-      end
+      group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -1,4 +1,5 @@
 require 'inferno/dsl/oauth_credentials'
+require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '../../custom_groups/v5.0.1/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
@@ -134,9 +135,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery
+          group from: :smart_standalone_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -145,9 +169,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery
+          group from: :smart_ehr_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
 
@@ -156,9 +203,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery_stu2
+          group from: :smart_standalone_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -167,9 +237,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery_stu2
+          group from: :smart_ehr_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
       end

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -110,50 +110,77 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
-      group from: :us_core_v501_capability_statement
-  
-      group from: :us_core_v501_patient
-      group from: :us_core_v501_allergy_intolerance
-      group from: :us_core_v501_care_plan
-      group from: :us_core_v501_care_team
-      group from: :us_core_v501_condition_encounter_diagnosis
-      group from: :us_core_v501_condition_problems_health_concerns
-      group from: :us_core_v501_device
-      group from: :us_core_v501_diagnostic_report_note
-      group from: :us_core_v501_diagnostic_report_lab
-      group from: :us_core_v501_document_reference
-      group from: :us_core_v501_encounter
-      group from: :us_core_v501_goal
-      group from: :us_core_v501_immunization
-      group from: :us_core_v501_medication_request
-      group from: :us_core_v501_observation_lab
-      group from: :us_core_v501_observation_sdoh_assessment
-      group from: :us_core_v501_respiratory_rate
-      group from: :us_core_v501_observation_social_history
-      group from: :us_core_v501_heart_rate
-      group from: :us_core_v501_body_temperature
-      group from: :us_core_v501_pediatric_weight_for_height
-      group from: :us_core_v501_pulse_oximetry
-      group from: :us_core_v501_smokingstatus
-      group from: :us_core_v501_observation_sexual_orientation
-      group from: :us_core_v501_head_circumference
-      group from: :us_core_v501_body_height
-      group from: :us_core_v501_bmi
-      group from: :us_core_v501_blood_pressure
-      group from: :us_core_v501_observation_imaging
-      group from: :us_core_v501_observation_clinical_test
-      group from: :us_core_v501_pediatric_bmi_for_age
-      group from: :us_core_v501_head_circumference_percentile
-      group from: :us_core_v501_body_weight
-      group from: :us_core_v501_procedure
-      group from: :us_core_v501_questionnaire_response
-      group from: :us_core_v501_service_request
-      group from: :us_core_v501_organization
-      group from: :us_core_v501_practitioner
-      group from: :us_core_v501_provenance
-      group from: :us_core_v501_related_person
-      group from: :us_core_v400_clinical_notes_guidance
-      group from: :us_core_311_data_absent_reason
+      group do
+        title 'SMART App Launch'
+        group do
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { assert false }
+          end
+        end
+      end
+
+      group do
+        title 'US Core FHIR API'
+
+        group from: :us_core_v501_capability_statement
+      
+        group from: :us_core_v501_patient
+        group from: :us_core_v501_allergy_intolerance
+        group from: :us_core_v501_care_plan
+        group from: :us_core_v501_care_team
+        group from: :us_core_v501_condition_encounter_diagnosis
+        group from: :us_core_v501_condition_problems_health_concerns
+        group from: :us_core_v501_device
+        group from: :us_core_v501_diagnostic_report_note
+        group from: :us_core_v501_diagnostic_report_lab
+        group from: :us_core_v501_document_reference
+        group from: :us_core_v501_encounter
+        group from: :us_core_v501_goal
+        group from: :us_core_v501_immunization
+        group from: :us_core_v501_medication_request
+        group from: :us_core_v501_observation_lab
+        group from: :us_core_v501_observation_sdoh_assessment
+        group from: :us_core_v501_respiratory_rate
+        group from: :us_core_v501_observation_social_history
+        group from: :us_core_v501_heart_rate
+        group from: :us_core_v501_body_temperature
+        group from: :us_core_v501_pediatric_weight_for_height
+        group from: :us_core_v501_pulse_oximetry
+        group from: :us_core_v501_smokingstatus
+        group from: :us_core_v501_observation_sexual_orientation
+        group from: :us_core_v501_head_circumference
+        group from: :us_core_v501_body_height
+        group from: :us_core_v501_bmi
+        group from: :us_core_v501_blood_pressure
+        group from: :us_core_v501_observation_imaging
+        group from: :us_core_v501_observation_clinical_test
+        group from: :us_core_v501_pediatric_bmi_for_age
+        group from: :us_core_v501_head_circumference_percentile
+        group from: :us_core_v501_body_weight
+        group from: :us_core_v501_procedure
+        group from: :us_core_v501_questionnaire_response
+        group from: :us_core_v501_service_request
+        group from: :us_core_v501_organization
+        group from: :us_core_v501_practitioner
+        group from: :us_core_v501_provenance
+        group from: :us_core_v501_related_person
+        group from: :us_core_v400_clinical_notes_guidance
+        group from: :us_core_311_data_absent_reason
+      end
     end
   end
 end

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -1,9 +1,9 @@
 require 'inferno/dsl/oauth_credentials'
-require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '../../custom_groups/v5.0.1/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
+require_relative '../../custom_groups/smart_app_launch_group'
 require_relative '../../provenance_validator'
 require_relative '../../us_core_options'
 
@@ -127,145 +127,7 @@ module USCoreTestKit
         }
       ]
 
-      group do
-        title 'SMART App Launch'
-        
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_standalone_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_ehr_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_standalone_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_ehr_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-      end
+      group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -4,6 +4,8 @@ require_relative '../../custom_groups/v5.0.1/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
 require_relative '../../provenance_validator'
+require_relative '../../us_core_options'
+
 require_relative 'patient_group'
 require_relative 'allergy_intolerance_group'
 require_relative 'care_plan_group'
@@ -110,9 +112,25 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
+
+      suite_option :smart_app_launch_version,
+      title: 'SMART App Launch Version',
+      list_options: [
+        {
+          label: 'SMART App Launch 1.0.0',
+          value: USCoreOptions::SMART_1
+        },
+        {
+          label: 'SMART App Launch 2.0.0',
+          value: USCoreOptions::SMART_2
+        }
+      ]
+
       group do
         title 'SMART App Launch'
+        
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
           title 'Standalone Launch'
           optional
 
@@ -123,6 +141,29 @@ module USCoreTestKit
         end
 
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { assert false }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
           title 'EHR Launch'
           optional
 

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -115,22 +115,23 @@ module USCoreTestKit
 
 
       suite_option :smart_app_launch_version,
-      title: 'SMART App Launch Version',
-      list_options: [
-        {
-          label: 'SMART App Launch 1.0.0',
-          value: USCoreOptions::SMART_1
-        },
-        {
-          label: 'SMART App Launch 2.0.0',
-          value: USCoreOptions::SMART_2
-        }
-      ]
+        title: 'SMART App Launch Version',
+        list_options: [
+          {
+            label: 'SMART App Launch 1.0.0',
+            value: USCoreOptions::SMART_1
+          },
+          {
+            label: 'SMART App Launch 2.0.0',
+            value: USCoreOptions::SMART_2
+          }
+        ]
 
       group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'
+        id :us_core_v501_fhir_api
 
         group from: :us_core_v501_capability_statement
       

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -120,22 +120,23 @@ module USCoreTestKit
 
 
       suite_option :smart_app_launch_version,
-      title: 'SMART App Launch Version',
-      list_options: [
-        {
-          label: 'SMART App Launch 1.0.0',
-          value: USCoreOptions::SMART_1
-        },
-        {
-          label: 'SMART App Launch 2.0.0',
-          value: USCoreOptions::SMART_2
-        }
-      ]
+        title: 'SMART App Launch Version',
+        list_options: [
+          {
+            label: 'SMART App Launch 1.0.0',
+            value: USCoreOptions::SMART_1
+          },
+          {
+            label: 'SMART App Launch 2.0.0',
+            value: USCoreOptions::SMART_2
+          }
+        ]
 
       group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'
+        id :us_core_v610_fhir_api
 
         group from: :us_core_v610_capability_statement
       

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -1,4 +1,5 @@
 require 'inferno/dsl/oauth_credentials'
+require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '../../custom_groups/v6.1.0/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
@@ -139,9 +140,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery
+          group from: :smart_standalone_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -150,9 +174,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery
+          group from: :smart_ehr_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
 
@@ -161,9 +208,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery_stu2
+          group from: :smart_standalone_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -172,9 +242,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery_stu2
+          group from: :smart_ehr_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
       end

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -115,55 +115,82 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
-      group from: :us_core_v610_capability_statement
-  
-      group from: :us_core_v610_patient
-      group from: :us_core_v610_allergy_intolerance
-      group from: :us_core_v610_care_plan
-      group from: :us_core_v610_care_team
-      group from: :us_core_v610_condition_encounter_diagnosis
-      group from: :us_core_v610_condition_problems_health_concerns
-      group from: :us_core_v610_coverage
-      group from: :us_core_v610_device
-      group from: :us_core_v610_diagnostic_report_note
-      group from: :us_core_v610_diagnostic_report_lab
-      group from: :us_core_v610_document_reference
-      group from: :us_core_v610_encounter
-      group from: :us_core_v610_goal
-      group from: :us_core_v610_immunization
-      group from: :us_core_v610_medication_dispense
-      group from: :us_core_v610_medication_request
-      group from: :us_core_v610_observation_lab
-      group from: :us_core_v610_observation_pregnancystatus
-      group from: :us_core_v610_observation_pregnancyintent
-      group from: :us_core_v610_observation_occupation
-      group from: :us_core_v610_respiratory_rate
-      group from: :us_core_v610_simple_observation
-      group from: :us_core_v610_heart_rate
-      group from: :us_core_v610_body_temperature
-      group from: :us_core_v610_pediatric_weight_for_height
-      group from: :us_core_v610_pulse_oximetry
-      group from: :us_core_v610_smokingstatus
-      group from: :us_core_v610_observation_sexual_orientation
-      group from: :us_core_v610_head_circumference
-      group from: :us_core_v610_body_height
-      group from: :us_core_v610_bmi
-      group from: :us_core_v610_observation_screening_assessment
-      group from: :us_core_v610_blood_pressure
-      group from: :us_core_v610_observation_clinical_result
-      group from: :us_core_v610_pediatric_bmi_for_age
-      group from: :us_core_v610_head_circumference_percentile
-      group from: :us_core_v610_body_weight
-      group from: :us_core_v610_procedure
-      group from: :us_core_v610_questionnaire_response
-      group from: :us_core_v610_service_request
-      group from: :us_core_v610_organization
-      group from: :us_core_v610_practitioner
-      group from: :us_core_v610_provenance
-      group from: :us_core_v610_related_person
-      group from: :us_core_v610_specimen
-      group from: :us_core_v400_clinical_notes_guidance
-      group from: :us_core_311_data_absent_reason
+      group do
+        title 'SMART App Launch'
+        group do
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { assert false }
+          end
+        end
+      end
+
+      group do
+        title 'US Core FHIR API'
+
+        group from: :us_core_v610_capability_statement
+      
+        group from: :us_core_v610_patient
+        group from: :us_core_v610_allergy_intolerance
+        group from: :us_core_v610_care_plan
+        group from: :us_core_v610_care_team
+        group from: :us_core_v610_condition_encounter_diagnosis
+        group from: :us_core_v610_condition_problems_health_concerns
+        group from: :us_core_v610_coverage
+        group from: :us_core_v610_device
+        group from: :us_core_v610_diagnostic_report_note
+        group from: :us_core_v610_diagnostic_report_lab
+        group from: :us_core_v610_document_reference
+        group from: :us_core_v610_encounter
+        group from: :us_core_v610_goal
+        group from: :us_core_v610_immunization
+        group from: :us_core_v610_medication_dispense
+        group from: :us_core_v610_medication_request
+        group from: :us_core_v610_observation_lab
+        group from: :us_core_v610_observation_pregnancystatus
+        group from: :us_core_v610_observation_pregnancyintent
+        group from: :us_core_v610_observation_occupation
+        group from: :us_core_v610_respiratory_rate
+        group from: :us_core_v610_simple_observation
+        group from: :us_core_v610_heart_rate
+        group from: :us_core_v610_body_temperature
+        group from: :us_core_v610_pediatric_weight_for_height
+        group from: :us_core_v610_pulse_oximetry
+        group from: :us_core_v610_smokingstatus
+        group from: :us_core_v610_observation_sexual_orientation
+        group from: :us_core_v610_head_circumference
+        group from: :us_core_v610_body_height
+        group from: :us_core_v610_bmi
+        group from: :us_core_v610_observation_screening_assessment
+        group from: :us_core_v610_blood_pressure
+        group from: :us_core_v610_observation_clinical_result
+        group from: :us_core_v610_pediatric_bmi_for_age
+        group from: :us_core_v610_head_circumference_percentile
+        group from: :us_core_v610_body_weight
+        group from: :us_core_v610_procedure
+        group from: :us_core_v610_questionnaire_response
+        group from: :us_core_v610_service_request
+        group from: :us_core_v610_organization
+        group from: :us_core_v610_practitioner
+        group from: :us_core_v610_provenance
+        group from: :us_core_v610_related_person
+        group from: :us_core_v610_specimen
+        group from: :us_core_v400_clinical_notes_guidance
+        group from: :us_core_311_data_absent_reason
+      end
     end
   end
 end

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -1,9 +1,9 @@
 require 'inferno/dsl/oauth_credentials'
-require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '../../custom_groups/v6.1.0/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
+require_relative '../../custom_groups/smart_app_launch_group'
 require_relative '../../provenance_validator'
 require_relative '../../us_core_options'
 
@@ -132,145 +132,7 @@ module USCoreTestKit
         }
       ]
 
-      group do
-        title 'SMART App Launch'
-        
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_standalone_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_ehr_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_standalone_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_ehr_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-      end
+      group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -4,6 +4,8 @@ require_relative '../../custom_groups/v6.1.0/capability_statement_group'
 require_relative '../../custom_groups/v4.0.0/clinical_notes_guidance_group'
 require_relative '../../custom_groups/data_absent_reason_group'
 require_relative '../../provenance_validator'
+require_relative '../../us_core_options'
+
 require_relative 'patient_group'
 require_relative 'allergy_intolerance_group'
 require_relative 'care_plan_group'
@@ -115,9 +117,25 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
+
+      suite_option :smart_app_launch_version,
+      title: 'SMART App Launch Version',
+      list_options: [
+        {
+          label: 'SMART App Launch 1.0.0',
+          value: USCoreOptions::SMART_1
+        },
+        {
+          label: 'SMART App Launch 2.0.0',
+          value: USCoreOptions::SMART_2
+        }
+      ]
+
       group do
         title 'SMART App Launch'
+        
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
           title 'Standalone Launch'
           optional
 
@@ -128,6 +146,29 @@ module USCoreTestKit
         end
 
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { assert false }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
           title 'EHR Launch'
           optional
 

--- a/lib/us_core_test_kit/generator/suite_generator.rb
+++ b/lib/us_core_test_kit/generator/suite_generator.rb
@@ -49,6 +49,10 @@ module USCoreTestKit
         "us_core_#{ig_metadata.reformatted_version}"
       end
 
+      def fhir_api_group_id
+        "us_core_#{ig_metadata.reformatted_version}_fhir_api"
+      end
+
       def title
         "US Core #{ig_metadata.ig_version}"
       end

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -76,22 +76,23 @@ module USCoreTestKit
 
 
       suite_option :smart_app_launch_version,
-      title: 'SMART App Launch Version',
-      list_options: [
-        {
-          label: 'SMART App Launch 1.0.0',
-          value: USCoreOptions::SMART_1
-        },
-        {
-          label: 'SMART App Launch 2.0.0',
-          value: USCoreOptions::SMART_2
-        }
-      ]
+        title: 'SMART App Launch Version',
+        list_options: [
+          {
+            label: 'SMART App Launch 1.0.0',
+            value: USCoreOptions::SMART_1
+          },
+          {
+            label: 'SMART App Launch 2.0.0',
+            value: USCoreOptions::SMART_2
+          }
+        ]
 
       group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'
+        id :<%= fhir_api_group_id %>
 
         group from: :<%= capability_statement_group_id %>
       <% group_id_list.each do |id| %>

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -89,7 +89,7 @@ module USCoreTestKit
 
           test do
             title 'TODO'
-            run { pass }
+            run { assert false }
           end
         end
       end

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -1,9 +1,9 @@
 require 'inferno/dsl/oauth_credentials'
-require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '<%= capability_statement_file_name %>'
 require_relative '<%= clinical_notes_guidance_file_name %>'
 require_relative '../../custom_groups/data_absent_reason_group'
+require_relative '../../custom_groups/smart_app_launch_group'
 require_relative '../../provenance_validator'
 require_relative '../../us_core_options'
 
@@ -88,145 +88,7 @@ module USCoreTestKit
         }
       ]
 
-      group do
-        title 'SMART App Launch'
-        
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_standalone_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery
-          group from: :smart_ehr_launch
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'Standalone Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_standalone_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :standalone_id_token },
-                client_id: { name: :standalone_client_id },
-                requested_scopes: { name: :standalone_requested_scopes },
-                access_token: { name: :standalone_access_token },
-                smart_credentials: { name: :standalone_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :standalone_refresh_token },
-                client_id: { name: :standalone_client_id },
-                client_secret: { name: :standalone_client_secret },
-                received_scopes: { name: :standalone_received_scopes }
-              }
-            )
-          end
-        end
-
-        group do
-          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
-          title 'EHR Launch'
-          optional
-
-          group from: :smart_discovery_stu2
-          group from: :smart_ehr_launch_stu2
-          
-          group from: :smart_openid_connect do
-            optional
-            config(
-              inputs: {
-                id_token: { name: :ehr_id_token },
-                client_id: { name: :ehr_client_id },
-                requested_scopes: { name: :ehr_requested_scopes },
-                access_token: { name: :ehr_access_token },
-                smart_credentials: { name: :ehr_smart_credentials }
-              }
-            )
-          end
-
-          group from: :smart_token_refresh do
-            optional
-            config(
-              inputs: {
-                refresh_token: { name: :ehr_refresh_token },
-                client_id: { name: :ehr_client_id },
-                client_secret: { name: :ehr_client_secret },
-                received_scopes: { name: :ehr_received_scopes }
-              }
-            )
-          end
-        end
-      end
+      group from: :us_core_smart_app_launch
 
       group do
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -1,4 +1,5 @@
 require 'inferno/dsl/oauth_credentials'
+require 'smart_app_launch_test_kit'
 require_relative '../../version'
 require_relative '<%= capability_statement_file_name %>'
 require_relative '<%= clinical_notes_guidance_file_name %>'
@@ -95,9 +96,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery
+          group from: :smart_standalone_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -106,9 +130,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery
+          group from: :smart_ehr_launch
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
 
@@ -117,9 +164,32 @@ module USCoreTestKit
           title 'Standalone Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { pass }
+          group from: :smart_discovery_stu2
+          group from: :smart_standalone_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :standalone_id_token },
+                client_id: { name: :standalone_client_id },
+                requested_scopes: { name: :standalone_requested_scopes },
+                access_token: { name: :standalone_access_token },
+                smart_credentials: { name: :standalone_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :standalone_refresh_token },
+                client_id: { name: :standalone_client_id },
+                client_secret: { name: :standalone_client_secret },
+                received_scopes: { name: :standalone_received_scopes }
+              }
+            )
           end
         end
 
@@ -128,9 +198,32 @@ module USCoreTestKit
           title 'EHR Launch'
           optional
 
-          test do
-            title 'TODO'
-            run { assert false }
+          group from: :smart_discovery_stu2
+          group from: :smart_ehr_launch_stu2
+          
+          group from: :smart_openid_connect do
+            optional
+            config(
+              inputs: {
+                id_token: { name: :ehr_id_token },
+                client_id: { name: :ehr_client_id },
+                requested_scopes: { name: :ehr_requested_scopes },
+                access_token: { name: :ehr_access_token },
+                smart_credentials: { name: :ehr_smart_credentials }
+              }
+            )
+          end
+
+          group from: :smart_token_refresh do
+            optional
+            config(
+              inputs: {
+                refresh_token: { name: :ehr_refresh_token },
+                client_id: { name: :ehr_client_id },
+                client_secret: { name: :ehr_client_secret },
+                received_scopes: { name: :ehr_received_scopes }
+              }
+            )
           end
         end
       end

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -71,11 +71,38 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
-      group from: :<%= capability_statement_group_id %>
-  <% group_id_list.each do |id| %>
-      group from: :<%= id %><% end %>
-      group from: :<%= clinical_notes_guidance_group_id %>
-      group from: :us_core_311_data_absent_reason
+      group do
+        title 'SMART App Launch'
+        group do
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+      end
+
+      group do
+        title 'US Core FHIR API'
+
+        group from: :<%= capability_statement_group_id %>
+      <% group_id_list.each do |id| %>
+        group from: :<%= id %><% end %>
+        group from: :<%= clinical_notes_guidance_group_id %>
+        group from: :us_core_311_data_absent_reason
+      end
     end
   end
 end

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -4,6 +4,8 @@ require_relative '<%= capability_statement_file_name %>'
 require_relative '<%= clinical_notes_guidance_file_name %>'
 require_relative '../../custom_groups/data_absent_reason_group'
 require_relative '../../provenance_validator'
+require_relative '../../us_core_options'
+
 <% group_file_list.each do |file_name| %>require_relative '<%= file_name %>'
 <% end %>
 module USCoreTestKit
@@ -71,9 +73,25 @@ module USCoreTestKit
         oauth_credentials :smart_credentials
       end
 
+
+      suite_option :smart_app_launch_version,
+      title: 'SMART App Launch Version',
+      list_options: [
+        {
+          label: 'SMART App Launch 1.0.0',
+          value: USCoreOptions::SMART_1
+        },
+        {
+          label: 'SMART App Launch 2.0.0',
+          value: USCoreOptions::SMART_2
+        }
+      ]
+
       group do
         title 'SMART App Launch'
+        
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
           title 'Standalone Launch'
           optional
 
@@ -84,6 +102,29 @@ module USCoreTestKit
         end
 
         group do
+          required_suite_options USCoreOptions::SMART_1_REQUIREMENT
+          title 'EHR Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { assert false }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
+          title 'Standalone Launch'
+          optional
+
+          test do
+            title 'TODO'
+            run { pass }
+          end
+        end
+
+        group do
+          required_suite_options USCoreOptions::SMART_2_REQUIREMENT
           title 'EHR Launch'
           optional
 

--- a/lib/us_core_test_kit/us_core_options.rb
+++ b/lib/us_core_test_kit/us_core_options.rb
@@ -1,0 +1,10 @@
+module USCoreTestKit
+    module USCoreOptions
+      SMART_1 = 'smart_app_launch_1'.freeze
+      SMART_2 = 'smart_app_launch_2'.freeze
+  
+      SMART_1_REQUIREMENT = { smart_app_launch_version: SMART_1 }.freeze
+      SMART_2_REQUIREMENT = { smart_app_launch_version: SMART_2 }.freeze
+    end
+  end
+  

--- a/us_core_test_kit.gemspec
+++ b/us_core_test_kit.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inferno_framework/us-core-test-kit'
   spec.license       = 'Apache-2.0'
   spec.add_runtime_dependency 'inferno_core', '>= 0.4.2'
+  spec.add_runtime_dependency 'smart_app_launch_test_kit', '>= 0.4.0'
   spec.add_runtime_dependency 'tls_test_kit', '~> 0.2.0'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'


### PR DESCRIPTION
# Summary
Added SMART App Launch tests to US Core test kit since support for SMART App Launch has been a US Core requirement since at least version 3.1.1, but SMART tests are not included in the test kit. Added Standalone and EHR launch tests as optional tests, each containing 4 test groups: SMART discovery (required), SMART ehr/standalone launch (required), SMART openid connect (optional), and smart token refresh (optional). Updated the US core presets so that it contains all the inputs for the SMART app launch tickets as well.

# Testing Guidance
Run the Inferno US Core test kit locally, and run the SMART App Launch tests using the Inferno Reference server preset, and make sure everything passes.
