### PR TITLE
FI-2231 Add searches for Practitioner test

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/allergy_intolerance/metadata.yml
@@ -10,6 +10,7 @@
 :title: AllergyIntolerance
 :short_description: Verify support for the server capabilities required by the US
   Core AllergyIntolerance Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyheight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyheight/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Height
 :short_description: Verify support for the server capabilities required by the Observation
   Body Height Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/bodytemp/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodytemp/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Temperature
 :short_description: Verify support for the server capabilities required by the Observation
   Body Temperature Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/bodyweight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bodyweight/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Weight
 :short_description: Verify support for the server capabilities required by the Observation
   Body Weight Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/bp/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/bp/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Blood Pressure
 :short_description: Verify support for the server capabilities required by the Observation
   Blood Pressure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/care_plan/metadata.yml
@@ -10,6 +10,7 @@
 :title: CarePlan
 :short_description: Verify support for the server capabilities required by the US
   Core CarePlan Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/care_team/metadata.yml
@@ -10,6 +10,7 @@
 :title: CareTeam
 :short_description: Verify support for the server capabilities required by the US
   Core CareTeam Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/condition/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/condition/metadata.yml
@@ -10,6 +10,7 @@
 :title: Condition
 :short_description: Verify support for the server capabilities required by the US
   Core Condition Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/device/metadata.yml
@@ -10,6 +10,7 @@
 :title: Implantable Device
 :short_description: Verify support for the server capabilities required by the US
   Core Implantable Device Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Laboratory Results Reporting
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Laboratory Results Reporting.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/diagnostic_report_note/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Report and Note exchange
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Report and Note exchange.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v3.1.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/document_reference/metadata.yml
@@ -10,6 +10,7 @@
 :title: DocumentReference
 :short_description: Verify support for the server capabilities required by the US
   Core DocumentReference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v3.1.1/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/encounter/metadata.yml
@@ -10,6 +10,7 @@
 :title: Encounter
 :short_description: Verify support for the server capabilities required by the US
   Core Encounter Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/goal/metadata.yml
@@ -10,6 +10,7 @@
 :title: Goal
 :short_description: Verify support for the server capabilities required by the US
   Core Goal Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/head_circumference/metadata.yml
@@ -10,6 +10,7 @@
 :title: Pediatric Head Occipital-frontal Circumference Percentile
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Head Occipital-frontal Circumference Percentile Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/heartrate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/heartrate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Heart Rate
 :short_description: Verify support for the server capabilities required by the Observation
   Heart Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/immunization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Immunization
 :short_description: Verify support for the server capabilities required by the US
   Core Immunization Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/medication_request/metadata.yml
@@ -10,6 +10,7 @@
 :title: MedicationRequest
 :short_description: Verify support for the server capabilities required by the US
   Core MedicationRequest Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -12,6 +12,7 @@
   :title: AllergyIntolerance
   :short_description: Verify support for the server capabilities required by the US
     Core AllergyIntolerance Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -146,6 +147,7 @@
   :title: CarePlan
   :short_description: Verify support for the server capabilities required by the US
     Core CarePlan Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -403,6 +405,7 @@
   :title: CareTeam
   :short_description: Verify support for the server capabilities required by the US
     Core CareTeam Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -520,6 +523,7 @@
   :title: Condition
   :short_description: Verify support for the server capabilities required by the US
     Core Condition Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -708,6 +712,7 @@
   :title: Implantable Device
   :short_description: Verify support for the server capabilities required by the US
     Core Implantable Device Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -836,6 +841,7 @@
   :title: DiagnosticReport for Report and Note exchange
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Report and Note exchange.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1057,6 +1063,7 @@
   :title: DiagnosticReport for Laboratory Results Reporting
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Laboratory Results Reporting.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1280,6 +1287,7 @@
   :title: DocumentReference
   :short_description: Verify support for the server capabilities required by the US
     Core DocumentReference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1556,6 +1564,7 @@
   :title: Encounter
   :short_description: Verify support for the server capabilities required by the US
     Core Encounter Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1830,6 +1839,7 @@
   :title: Goal
   :short_description: Verify support for the server capabilities required by the US
     Core Goal Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1979,6 +1989,7 @@
   :title: Immunization
   :short_description: Verify support for the server capabilities required by the US
     Core Immunization Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2130,6 +2141,7 @@
   :title: Location
   :short_description: Verify support for the server capabilities required by the US
     Core Location Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2354,6 +2366,7 @@
   :title: Medication
   :short_description: Verify support for the server capabilities required by the US
     Core Medication Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2408,6 +2421,7 @@
   :title: MedicationRequest
   :short_description: Verify support for the server capabilities required by the US
     Core MedicationRequest Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2652,6 +2666,7 @@
   :title: Smoking Status Observation
   :short_description: Verify support for the server capabilities required by the US
     Core Smoking Status Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2872,6 +2887,7 @@
   :title: Pediatric Weight for Height Observation
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Weight for Height Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3132,6 +3148,7 @@
   :title: Laboratory Result Observation
   :short_description: Verify support for the server capabilities required by the US
     Core Laboratory Result Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3355,6 +3372,7 @@
   :title: Pediatric BMI for Age Observation
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric BMI for Age Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3615,6 +3633,7 @@
   :title: Pulse Oximetry
   :short_description: Verify support for the server capabilities required by the US
     Core Pulse Oximetry Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3937,6 +3956,7 @@
   :title: Pediatric Head Occipital-frontal Circumference Percentile
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Head Occipital-frontal Circumference Percentile Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4197,6 +4217,7 @@
   :title: Observation Body Height
   :short_description: Verify support for the server capabilities required by the Observation
     Body Height Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4462,6 +4483,7 @@
   :title: Observation Body Temperature
   :short_description: Verify support for the server capabilities required by the Observation
     Body Temperature Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4727,6 +4749,7 @@
   :title: Observation Blood Pressure
   :short_description: Verify support for the server capabilities required by the Observation
     Blood Pressure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5019,6 +5042,7 @@
   :title: Observation Body Weight
   :short_description: Verify support for the server capabilities required by the Observation
     Body Weight Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5284,6 +5308,7 @@
   :title: Observation Heart Rate
   :short_description: Verify support for the server capabilities required by the Observation
     Heart Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5546,6 +5571,7 @@
   :title: Observation Respiratory Rate
   :short_description: Verify support for the server capabilities required by the Observation
     Respiratory Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5808,6 +5834,7 @@
   :title: Organization
   :short_description: Verify support for the server capabilities required by the US
     Core Organization Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5924,6 +5951,7 @@
   :title: Patient
   :short_description: Verify support for the server capabilities required by the US
     Core Patient Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6209,6 +6237,7 @@
   :title: Practitioner
   :short_description: Verify support for the server capabilities required by the US
     Core Practitioner Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6319,6 +6348,7 @@
   :title: PractitionerRole
   :short_description: Verify support for the server capabilities required by the US
     Core PractitionerRole Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6455,6 +6485,7 @@
   :title: Procedure
   :short_description: Verify support for the server capabilities required by the US
     Core Procedure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6661,6 +6692,7 @@
   :title: Provenance
   :short_description: Verify support for the server capabilities required by the US
     Core Provenance Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/observation_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: Laboratory Result Observation
 :short_description: Verify support for the server capabilities required by the US
   Core Laboratory Result Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/organization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Organization
 :short_description: Verify support for the server capabilities required by the US
   Core Organization Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/patient/metadata.yml
@@ -10,6 +10,7 @@
 :title: Patient
 :short_description: Verify support for the server capabilities required by the US
   Core Patient Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_bmi_for_age/metadata.yml
@@ -10,6 +10,7 @@
 :title: Pediatric BMI for Age Observation
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric BMI for Age Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pediatric_weight_for_height/metadata.yml
@@ -10,6 +10,7 @@
 :title: Pediatric Weight for Height Observation
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Weight for Height Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/practitioner/metadata.yml
@@ -10,6 +10,7 @@
 :title: Practitioner
 :short_description: Verify support for the server capabilities required by the US
   Core Practitioner Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/procedure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Procedure
 :short_description: Verify support for the server capabilities required by the US
   Core Procedure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/provenance/metadata.yml
@@ -10,6 +10,7 @@
 :title: Provenance
 :short_description: Verify support for the server capabilities required by the US
   Core Provenance Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/pulse_oximetry/metadata.yml
@@ -10,6 +10,7 @@
 :title: Pulse Oximetry
 :short_description: Verify support for the server capabilities required by the US
   Core Pulse Oximetry Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/resprate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/resprate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Respiratory Rate
 :short_description: Verify support for the server capabilities required by the Observation
   Respiratory Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/smokingstatus/metadata.yml
@@ -10,6 +10,7 @@
 :title: Smoking Status Observation
 :short_description: Verify support for the server capabilities required by the US
   Core Smoking Status Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/allergy_intolerance/metadata.yml
@@ -10,6 +10,7 @@
 :title: AllergyIntolerance
 :short_description: Verify support for the server capabilities required by the US
   Core AllergyIntolerance Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/blood_pressure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Blood Pressure
 :short_description: Verify support for the server capabilities required by the US
   Core Blood Pressure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/bmi/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation BMI
 :short_description: Verify support for the server capabilities required by the US
   Core BMI Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_height/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Height
 :short_description: Verify support for the server capabilities required by the US
   Core Body Height Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_temperature/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Temperature
 :short_description: Verify support for the server capabilities required by the US
   Core Body Temperature Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/body_weight/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Weight
 :short_description: Verify support for the server capabilities required by the US
   Core Body Weight Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_plan/metadata.yml
@@ -10,6 +10,7 @@
 :title: CarePlan
 :short_description: Verify support for the server capabilities required by the US
   Core CarePlan Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/care_team/metadata.yml
@@ -10,6 +10,7 @@
 :title: CareTeam
 :short_description: Verify support for the server capabilities required by the US
   Core CareTeam Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/condition/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/condition/metadata.yml
@@ -10,6 +10,7 @@
 :title: Condition
 :short_description: Verify support for the server capabilities required by the US
   Core Condition Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/device/metadata.yml
@@ -10,6 +10,7 @@
 :title: Implantable Device
 :short_description: Verify support for the server capabilities required by the US
   Core Implantable Device Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Laboratory Results Reporting
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Laboratory Results Reporting.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/diagnostic_report_note/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Report and Note exchange
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Report and Note exchange.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/document_reference/metadata.yml
@@ -10,6 +10,7 @@
 :title: DocumentReference
 :short_description: Verify support for the server capabilities required by the US
   Core DocumentReference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
@@ -10,6 +10,7 @@
 :title: Encounter
 :short_description: Verify support for the server capabilities required by the US
   Core Encounter Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/goal/metadata.yml
@@ -10,6 +10,7 @@
 :title: Goal
 :short_description: Verify support for the server capabilities required by the US
   Core Goal Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Head Circumference
 :short_description: Verify support for the server capabilities required by the US
   Core Head Circumference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/head_circumference_percentile/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric Head Occipital-frontal Circumference Percentile
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Head Occipital-frontal Circumference Percentile Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/heart_rate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Heart Rate
 :short_description: Verify support for the server capabilities required by the US
   Core Heart Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/immunization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Immunization
 :short_description: Verify support for the server capabilities required by the US
   Core Immunization Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/medication_request/metadata.yml
@@ -10,6 +10,7 @@
 :title: MedicationRequest
 :short_description: Verify support for the server capabilities required by the US
   Core MedicationRequest Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -12,6 +12,7 @@
   :title: AllergyIntolerance
   :short_description: Verify support for the server capabilities required by the US
     Core AllergyIntolerance Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -148,6 +149,7 @@
   :title: CarePlan
   :short_description: Verify support for the server capabilities required by the US
     Core CarePlan Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -408,6 +410,7 @@
   :title: CareTeam
   :short_description: Verify support for the server capabilities required by the US
     Core CareTeam Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -533,6 +536,7 @@
   :title: Condition
   :short_description: Verify support for the server capabilities required by the US
     Core Condition Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -726,6 +730,7 @@
   :title: Implantable Device
   :short_description: Verify support for the server capabilities required by the US
     Core Implantable Device Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -851,6 +856,7 @@
   :title: DiagnosticReport for Laboratory Results Reporting
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Laboratory Results Reporting.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1085,6 +1091,7 @@
   :title: DiagnosticReport for Report and Note exchange
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Report and Note exchange.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1316,6 +1323,7 @@
   :title: DocumentReference
   :short_description: Verify support for the server capabilities required by the US
     Core DocumentReference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1599,6 +1607,7 @@
   :title: Encounter
   :short_description: Verify support for the server capabilities required by the US
     Core Encounter Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1900,6 +1909,7 @@
   :title: Goal
   :short_description: Verify support for the server capabilities required by the US
     Core Goal Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2047,6 +2057,7 @@
   :title: Immunization
   :short_description: Verify support for the server capabilities required by the US
     Core Immunization Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2201,6 +2212,7 @@
   :title: Location
   :short_description: Verify support for the server capabilities required by the US
     Core Location Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2370,6 +2382,7 @@
   :title: Medication
   :short_description: Verify support for the server capabilities required by the US
     Core Medication Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2424,6 +2437,7 @@
   :title: MedicationRequest
   :short_description: Verify support for the server capabilities required by the US
     Core MedicationRequest Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2690,6 +2704,7 @@
   :title: Observation Laboratory Result
   :short_description: Verify support for the server capabilities required by the US
     Core Laboratory Result Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2922,6 +2937,7 @@
   :title: Observation Blood Pressure
   :short_description: Verify support for the server capabilities required by the US
     Core Blood Pressure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3219,6 +3235,7 @@
   :title: Observation BMI
   :short_description: Verify support for the server capabilities required by the US
     Core BMI Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3478,6 +3495,7 @@
   :title: Observation Head Circumference
   :short_description: Verify support for the server capabilities required by the US
     Core Head Circumference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3740,6 +3758,7 @@
   :title: Observation Body Height
   :short_description: Verify support for the server capabilities required by the US
     Core Body Height Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4002,6 +4021,7 @@
   :title: Observation Body Weight
   :short_description: Verify support for the server capabilities required by the US
     Core Body Weight Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4264,6 +4284,7 @@
   :title: Observation Body Temperature
   :short_description: Verify support for the server capabilities required by the US
     Core Body Temperature Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4526,6 +4547,7 @@
   :title: Observation Heart Rate
   :short_description: Verify support for the server capabilities required by the US
     Core Heart Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4785,6 +4807,7 @@
   :title: Observation Pediatric BMI for Age
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric BMI for Age Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5045,6 +5068,7 @@
   :title: Observation Pediatric Head Occipital-frontal Circumference Percentile
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Head Occipital-frontal Circumference Percentile Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5304,6 +5328,7 @@
   :title: Observation Pediatric Weight for Height
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Weight for Height Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5563,6 +5588,7 @@
   :title: Observation Pulse Oximetry
   :short_description: Verify support for the server capabilities required by the US
     Core Pulse Oximetry Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5879,6 +5905,7 @@
   :title: Observation Respiratory Rate
   :short_description: Verify support for the server capabilities required by the US
     Core Respiratory Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6138,6 +6165,7 @@
   :title: Observation Smoking Status
   :short_description: Verify support for the server capabilities required by the US
     Core Smoking Status Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6370,6 +6398,7 @@
   :title: Organization
   :short_description: Verify support for the server capabilities required by the US
     Core Organization Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6498,6 +6527,7 @@
   :title: Patient
   :short_description: Verify support for the server capabilities required by the US
     Core Patient Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6794,6 +6824,7 @@
   :title: Practitioner
   :short_description: Verify support for the server capabilities required by the US
     Core Practitioner Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6904,6 +6935,7 @@
   :title: PractitionerRole
   :short_description: Verify support for the server capabilities required by the US
     Core PractitionerRole Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7042,6 +7074,7 @@
   :title: Procedure
   :short_description: Verify support for the server capabilities required by the US
     Core Procedure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7251,6 +7284,7 @@
   :title: Provenance
   :short_description: Verify support for the server capabilities required by the US
     Core Provenance Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/observation_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Laboratory Result
 :short_description: Verify support for the server capabilities required by the US
   Core Laboratory Result Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/organization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Organization
 :short_description: Verify support for the server capabilities required by the US
   Core Organization Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -10,6 +10,7 @@
 :title: Patient
 :short_description: Verify support for the server capabilities required by the US
   Core Patient Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_bmi_for_age/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric BMI for Age
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric BMI for Age Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pediatric_weight_for_height/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric Weight for Height
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Weight for Height Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/practitioner/metadata.yml
@@ -10,6 +10,7 @@
 :title: Practitioner
 :short_description: Verify support for the server capabilities required by the US
   Core Practitioner Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/procedure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Procedure
 :short_description: Verify support for the server capabilities required by the US
   Core Procedure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/provenance/metadata.yml
@@ -10,6 +10,7 @@
 :title: Provenance
 :short_description: Verify support for the server capabilities required by the US
   Core Provenance Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/pulse_oximetry/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pulse Oximetry
 :short_description: Verify support for the server capabilities required by the US
   Core Pulse Oximetry Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/respiratory_rate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Respiratory Rate
 :short_description: Verify support for the server capabilities required by the US
   Core Respiratory Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/smokingstatus/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Smoking Status
 :short_description: Verify support for the server capabilities required by the US
   Core Smoking Status Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/allergy_intolerance/metadata.yml
@@ -10,6 +10,7 @@
 :title: AllergyIntolerance
 :short_description: Verify support for the server capabilities required by the US
   Core AllergyIntolerance Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/blood_pressure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Blood Pressure
 :short_description: Verify support for the server capabilities required by the US
   Core Blood Pressure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/bmi/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation BMI
 :short_description: Verify support for the server capabilities required by the US
   Core BMI Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_height/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Height
 :short_description: Verify support for the server capabilities required by the US
   Core Body Height Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_temperature/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Temperature
 :short_description: Verify support for the server capabilities required by the US
   Core Body Temperature Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/body_weight/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Weight
 :short_description: Verify support for the server capabilities required by the US
   Core Body Weight Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/care_plan/metadata.yml
@@ -10,6 +10,7 @@
 :title: CarePlan
 :short_description: Verify support for the server capabilities required by the US
   Core CarePlan Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/care_team/metadata.yml
@@ -10,6 +10,7 @@
 :title: CareTeam
 :short_description: Verify support for the server capabilities required by the US
   Core CareTeam Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_encounter_diagnosis/metadata.yml
@@ -10,6 +10,7 @@
 :title: Condition Encounter Diagnosis
 :short_description: Verify support for the server capabilities required by the US
   Core Condition Encounter Diagnosis Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
@@ -10,6 +10,7 @@
 :title: Condition Problems and Health Concerns
 :short_description: Verify support for the server capabilities required by the US
   Core Condition Problems and Health Concerns Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/device/metadata.yml
@@ -10,6 +10,7 @@
 :title: Implantable Device
 :short_description: Verify support for the server capabilities required by the US
   Core Implantable Device Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Laboratory Results Reporting
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Laboratory Results Reporting.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Report and Note Exchange
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Report and Note Exchange.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
@@ -10,6 +10,7 @@
 :title: DocumentReference
 :short_description: Verify support for the server capabilities required by the US
   Core DocumentReference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v5.0.1/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/encounter/metadata.yml
@@ -10,6 +10,7 @@
 :title: Encounter
 :short_description: Verify support for the server capabilities required by the US
   Core Encounter Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/goal/metadata.yml
@@ -10,6 +10,7 @@
 :title: Goal
 :short_description: Verify support for the server capabilities required by the US
   Core Goal Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Head Circumference
 :short_description: Verify support for the server capabilities required by the US
   Core Head Circumference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/head_circumference_percentile/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric Head Occipital-frontal Circumference Percentile
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Head Occipital-frontal Circumference Percentile Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/heart_rate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Heart Rate
 :short_description: Verify support for the server capabilities required by the US
   Core Heart Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/immunization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Immunization
 :short_description: Verify support for the server capabilities required by the US
   Core Immunization Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
@@ -10,6 +10,7 @@
 :title: MedicationRequest
 :short_description: Verify support for the server capabilities required by the US
   Core MedicationRequest Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -12,6 +12,7 @@
   :title: AllergyIntolerance
   :short_description: Verify support for the server capabilities required by the US
     Core AllergyIntolerance Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -148,6 +149,7 @@
   :title: CarePlan
   :short_description: Verify support for the server capabilities required by the US
     Core CarePlan Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -408,6 +410,7 @@
   :title: CareTeam
   :short_description: Verify support for the server capabilities required by the US
     Core CareTeam Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -566,6 +569,7 @@
   :title: Condition Encounter Diagnosis
   :short_description: Verify support for the server capabilities required by the US
     Core Condition Encounter Diagnosis Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -877,6 +881,7 @@
   :title: Condition Problems and Health Concerns
   :short_description: Verify support for the server capabilities required by the US
     Core Condition Problems and Health Concerns Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1199,6 +1204,7 @@
   :title: Implantable Device
   :short_description: Verify support for the server capabilities required by the US
     Core Implantable Device Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1324,6 +1330,7 @@
   :title: DiagnosticReport for Report and Note Exchange
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Report and Note Exchange.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1576,6 +1583,7 @@
   :title: DiagnosticReport for Laboratory Results Reporting
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Laboratory Results Reporting.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1807,6 +1815,7 @@
   :title: DocumentReference
   :short_description: Verify support for the server capabilities required by the US
     Core DocumentReference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -2096,6 +2105,7 @@
   :title: Encounter
   :short_description: Verify support for the server capabilities required by the US
     Core Encounter Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2432,6 +2442,7 @@
   :title: Goal
   :short_description: Verify support for the server capabilities required by the US
     Core Goal Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2595,6 +2606,7 @@
   :title: Immunization
   :short_description: Verify support for the server capabilities required by the US
     Core Immunization Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2749,6 +2761,7 @@
   :title: Location
   :short_description: Verify support for the server capabilities required by the US
     Core Location Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2918,6 +2931,7 @@
   :title: Medication
   :short_description: Verify support for the server capabilities required by the US
     Core Medication Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2972,6 +2986,7 @@
   :title: MedicationRequest
   :short_description: Verify support for the server capabilities required by the US
     Core MedicationRequest Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3248,6 +3263,7 @@
   :title: Observation Laboratory Result
   :short_description: Verify support for the server capabilities required by the US
     Core Laboratory Result Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3480,6 +3496,7 @@
   :title: Observation SDOH Assessment
   :short_description: Verify support for the server capabilities required by the US
     Core Observation SDOH Assessment Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3784,6 +3801,7 @@
   :title: Observation Respiratory Rate
   :short_description: Verify support for the server capabilities required by the US
     Core Respiratory Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4043,6 +4061,7 @@
   :title: Observation Social History
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Social History Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4294,6 +4313,7 @@
   :title: Observation Heart Rate
   :short_description: Verify support for the server capabilities required by the US
     Core Heart Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4553,6 +4573,7 @@
   :title: Observation Body Temperature
   :short_description: Verify support for the server capabilities required by the US
     Core Body Temperature Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4815,6 +4836,7 @@
   :title: Observation Pediatric Weight for Height
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Weight for Height Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5074,6 +5096,7 @@
   :title: Observation Pulse Oximetry
   :short_description: Verify support for the server capabilities required by the US
     Core Pulse Oximetry Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5390,6 +5413,7 @@
   :title: Observation Smoking Status
   :short_description: Verify support for the server capabilities required by the US
     Core Smoking Status Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5622,6 +5646,7 @@
   :title: Observation Sexual Orientation
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Sexual Orientation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5847,6 +5872,7 @@
   :title: Observation Head Circumference
   :short_description: Verify support for the server capabilities required by the US
     Core Head Circumference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6109,6 +6135,7 @@
   :title: Observation Body Height
   :short_description: Verify support for the server capabilities required by the US
     Core Body Height Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6371,6 +6398,7 @@
   :title: Observation BMI
   :short_description: Verify support for the server capabilities required by the US
     Core BMI Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6630,6 +6658,7 @@
   :title: Observation Blood Pressure
   :short_description: Verify support for the server capabilities required by the US
     Core Blood Pressure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6930,6 +6959,7 @@
   :title: Observation Imaging Result
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Imaging Result Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7161,6 +7191,7 @@
   :title: Observation Clinical Test Result
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Clinical Test Result Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7853,6 +7884,7 @@
   :title: Observation Pediatric BMI for Age
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric BMI for Age Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8113,6 +8145,7 @@
   :title: Observation Pediatric Head Occipital-frontal Circumference Percentile
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Head Occipital-frontal Circumference Percentile Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8372,6 +8405,7 @@
   :title: Observation Body Weight
   :short_description: Verify support for the server capabilities required by the US
     Core Body Weight Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8634,6 +8668,7 @@
   :title: Organization
   :short_description: Verify support for the server capabilities required by the US
     Core Organization Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8762,6 +8797,7 @@
   :title: Patient
   :short_description: Verify support for the server capabilities required by the US
     Core Patient Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9073,6 +9109,7 @@
   :title: Practitioner
   :short_description: Verify support for the server capabilities required by the US
     Core Practitioner Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9223,6 +9260,7 @@
   :title: PractitionerRole
   :short_description: Verify support for the server capabilities required by the US
     Core PractitionerRole Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9361,6 +9399,7 @@
   :title: Procedure
   :short_description: Verify support for the server capabilities required by the US
     Core Procedure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9569,6 +9608,7 @@
   :title: Provenance
   :short_description: Verify support for the server capabilities required by the US
     Core Provenance Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9720,6 +9760,7 @@
   :title: QuestionnaireResponse
   :short_description: Verify support for the server capabilities required by the US
     Core QuestionnaireResponse Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9964,6 +10005,7 @@
   :title: RelatedPerson
   :short_description: Verify support for the server capabilities required by the US
     Core RelatedPerson Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10059,6 +10101,7 @@
   :title: ServiceRequest
   :short_description: Verify support for the server capabilities required by the US
     Core ServiceRequest Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_clinical_test/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_clinical_test/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Clinical Test Result
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Clinical Test Result Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_imaging/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_imaging/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Imaging Result
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Imaging Result Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Laboratory Result
 :short_description: Verify support for the server capabilities required by the US
   Core Laboratory Result Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sdoh_assessment/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation SDOH Assessment
 :short_description: Verify support for the server capabilities required by the US
   Core Observation SDOH Assessment Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_sexual_orientation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_sexual_orientation/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Sexual Orientation
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Sexual Orientation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/observation_social_history/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Social History
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Social History Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/organization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Organization
 :short_description: Verify support for the server capabilities required by the US
   Core Organization Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
@@ -10,6 +10,7 @@
 :title: Patient
 :short_description: Verify support for the server capabilities required by the US
   Core Patient Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_bmi_for_age/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric BMI for Age
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric BMI for Age Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pediatric_weight_for_height/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric Weight for Height
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Weight for Height Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/practitioner/metadata.yml
@@ -10,6 +10,7 @@
 :title: Practitioner
 :short_description: Verify support for the server capabilities required by the US
   Core Practitioner Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/procedure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Procedure
 :short_description: Verify support for the server capabilities required by the US
   Core Procedure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/provenance/metadata.yml
@@ -10,6 +10,7 @@
 :title: Provenance
 :short_description: Verify support for the server capabilities required by the US
   Core Provenance Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/pulse_oximetry/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pulse Oximetry
 :short_description: Verify support for the server capabilities required by the US
   Core Pulse Oximetry Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/questionnaire_response/metadata.yml
@@ -10,6 +10,7 @@
 :title: QuestionnaireResponse
 :short_description: Verify support for the server capabilities required by the US
   Core QuestionnaireResponse Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/related_person/metadata.yml
@@ -10,6 +10,7 @@
 :title: RelatedPerson
 :short_description: Verify support for the server capabilities required by the US
   Core RelatedPerson Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/respiratory_rate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Respiratory Rate
 :short_description: Verify support for the server capabilities required by the US
   Core Respiratory Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
@@ -10,6 +10,7 @@
 :title: ServiceRequest
 :short_description: Verify support for the server capabilities required by the US
   Core ServiceRequest Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/smokingstatus/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Smoking Status
 :short_description: Verify support for the server capabilities required by the US
   Core Smoking Status Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/allergy_intolerance/metadata.yml
@@ -10,6 +10,7 @@
 :title: AllergyIntolerance
 :short_description: Verify support for the server capabilities required by the US
   Core AllergyIntolerance Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/blood_pressure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Blood Pressure
 :short_description: Verify support for the server capabilities required by the US
   Core Blood Pressure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/bmi/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation BMI
 :short_description: Verify support for the server capabilities required by the US
   Core BMI Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_height/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Height
 :short_description: Verify support for the server capabilities required by the US
   Core Body Height Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_temperature/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Temperature
 :short_description: Verify support for the server capabilities required by the US
   Core Body Temperature Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/body_weight/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Weight
 :short_description: Verify support for the server capabilities required by the US
   Core Body Weight Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/care_plan/metadata.yml
@@ -10,6 +10,7 @@
 :title: CarePlan
 :short_description: Verify support for the server capabilities required by the US
   Core CarePlan Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/care_team/metadata.yml
@@ -10,6 +10,7 @@
 :title: CareTeam
 :short_description: Verify support for the server capabilities required by the US
   Core CareTeam Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_encounter_diagnosis/metadata.yml
@@ -10,6 +10,7 @@
 :title: Condition Encounter Diagnosis
 :short_description: Verify support for the server capabilities required by the US
   Core Condition Encounter Diagnosis Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_problems_health_concerns/metadata.yml
@@ -10,6 +10,7 @@
 :title: Condition Problems and Health Concerns
 :short_description: Verify support for the server capabilities required by the US
   Core Condition Problems and Health Concerns Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/coverage/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/coverage/metadata.yml
@@ -10,6 +10,7 @@
 :title: Coverage
 :short_description: Verify support for the server capabilities required by the US
   Core Coverage Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/device/metadata.yml
@@ -10,6 +10,7 @@
 :title: Implantable Device
 :short_description: Verify support for the server capabilities required by the US
   Core Implantable Device Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Laboratory Results Reporting
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Laboratory Results Reporting.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Report and Note Exchange
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Report and Note Exchange.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v6.1.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/document_reference/metadata.yml
@@ -10,6 +10,7 @@
 :title: DocumentReference
 :short_description: Verify support for the server capabilities required by the US
   Core DocumentReference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v6.1.0/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/encounter/metadata.yml
@@ -10,6 +10,7 @@
 :title: Encounter
 :short_description: Verify support for the server capabilities required by the US
   Core Encounter Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/goal/metadata.yml
@@ -10,6 +10,7 @@
 :title: Goal
 :short_description: Verify support for the server capabilities required by the US
   Core Goal Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/head_circumference/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Head Circumference
 :short_description: Verify support for the server capabilities required by the US
   Core Head Circumference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/head_circumference_percentile/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric Head Occipital Frontal Circumference Percentile
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Head Occipital Frontal Circumference Percentile Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/heart_rate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Heart Rate
 :short_description: Verify support for the server capabilities required by the US
   Core Heart Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/immunization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Immunization
 :short_description: Verify support for the server capabilities required by the US
   Core Immunization Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/medication_dispense/metadata.yml
@@ -10,6 +10,7 @@
 :title: MedicationDispense
 :short_description: Verify support for the server capabilities required by the US
   Core MedicationDispense Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/medication_request/metadata.yml
@@ -10,6 +10,7 @@
 :title: MedicationRequest
 :short_description: Verify support for the server capabilities required by the US
   Core MedicationRequest Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -12,6 +12,7 @@
   :title: AllergyIntolerance
   :short_description: Verify support for the server capabilities required by the US
     Core AllergyIntolerance Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -148,6 +149,7 @@
   :title: CarePlan
   :short_description: Verify support for the server capabilities required by the US
     Core CarePlan Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -407,6 +409,7 @@
   :title: CareTeam
   :short_description: Verify support for the server capabilities required by the US
     Core CareTeam Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -564,6 +567,7 @@
   :title: Condition Encounter Diagnosis
   :short_description: Verify support for the server capabilities required by the US
     Core Condition Encounter Diagnosis Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -882,6 +886,7 @@
   :title: Condition Problems and Health Concerns
   :short_description: Verify support for the server capabilities required by the US
     Core Condition Problems and Health Concerns Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1214,6 +1219,7 @@
   :title: Coverage
   :short_description: Verify support for the server capabilities required by the US
     Core Coverage Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1364,6 +1370,7 @@
   :title: Implantable Device
   :short_description: Verify support for the server capabilities required by the US
     Core Implantable Device Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1510,6 +1517,7 @@
   :title: DiagnosticReport for Report and Note Exchange
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Report and Note Exchange.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1761,6 +1769,7 @@
   :title: DiagnosticReport for Laboratory Results Reporting
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Laboratory Results Reporting.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1992,6 +2001,7 @@
   :title: DocumentReference
   :short_description: Verify support for the server capabilities required by the US
     Core DocumentReference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -2282,6 +2292,7 @@
   :title: Encounter
   :short_description: Verify support for the server capabilities required by the US
     Core Encounter Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2618,6 +2629,7 @@
   :title: Goal
   :short_description: Verify support for the server capabilities required by the US
     Core Goal Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2787,6 +2799,7 @@
   :title: Immunization
   :short_description: Verify support for the server capabilities required by the US
     Core Immunization Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2940,6 +2953,7 @@
   :title: Location
   :short_description: Verify support for the server capabilities required by the US
     Core Location Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3109,6 +3123,7 @@
   :title: Medication
   :short_description: Verify support for the server capabilities required by the US
     Core Medication Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3163,6 +3178,7 @@
   :title: MedicationDispense
   :short_description: Verify support for the server capabilities required by the US
     Core MedicationDispense Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3377,6 +3393,7 @@
   :title: MedicationRequest
   :short_description: Verify support for the server capabilities required by the US
     Core MedicationRequest Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3669,6 +3686,7 @@
   :title: Observation Laboratory Result
   :short_description: Verify support for the server capabilities required by the US
     Core Laboratory Result Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3914,6 +3932,7 @@
   :title: Observation Pregnancy Status
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Pregnancy Status Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4152,6 +4171,7 @@
   :title: Observation Pregnancy Intent
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Pregnancy Intent Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4390,6 +4410,7 @@
   :title: Observation Occupation
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Occupation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4639,6 +4660,7 @@
   :title: Observation Respiratory Rate
   :short_description: Verify support for the server capabilities required by the US
     Core Respiratory Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4903,6 +4925,7 @@
   :title: Observation Simple
   :short_description: Verify support for the server capabilities required by the US
     Core Simple Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5172,6 +5195,7 @@
   :title: Observation Heart Rate
   :short_description: Verify support for the server capabilities required by the US
     Core Heart Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5436,6 +5460,7 @@
   :title: Observation Body Temperature
   :short_description: Verify support for the server capabilities required by the US
     Core Body Temperature Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5703,6 +5728,7 @@
   :title: Observation Pediatric Weight for Height
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Weight for Height Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5967,6 +5993,7 @@
   :title: Observation Pulse Oximetry
   :short_description: Verify support for the server capabilities required by the US
     Core Pulse Oximetry Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6307,6 +6334,7 @@
   :title: Observation Smoking Status
   :short_description: Verify support for the server capabilities required by the US
     Core Smoking Status Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6535,6 +6563,7 @@
   :title: Observation Sexual Orientation
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Sexual Orientation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6760,6 +6789,7 @@
   :title: Observation Head Circumference
   :short_description: Verify support for the server capabilities required by the US
     Core Head Circumference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7027,6 +7057,7 @@
   :title: Observation Body Height
   :short_description: Verify support for the server capabilities required by the US
     Core Body Height Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7294,6 +7325,7 @@
   :title: Observation BMI
   :short_description: Verify support for the server capabilities required by the US
     Core BMI Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7558,6 +7590,7 @@
   :title: Observation Screening Assessment
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Screening Assessment Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7823,6 +7856,7 @@
   :title: Observation Blood Pressure
   :short_description: Verify support for the server capabilities required by the US
     Core Blood Pressure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8123,6 +8157,7 @@
   :title: Observation Clinical Result
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Clinical Result Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8366,6 +8401,7 @@
   :title: Observation Pediatric BMI for Age
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric BMI for Age Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8631,6 +8667,7 @@
   :title: Observation Pediatric Head Occipital Frontal Circumference Percentile
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Head Occipital Frontal Circumference Percentile Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8895,6 +8932,7 @@
   :title: Observation Body Weight
   :short_description: Verify support for the server capabilities required by the US
     Core Body Weight Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9162,6 +9200,7 @@
   :title: Organization
   :short_description: Verify support for the server capabilities required by the US
     Core Organization Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9290,6 +9329,7 @@
   :title: Patient
   :short_description: Verify support for the server capabilities required by the US
     Core Patient Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9649,6 +9689,7 @@
   :title: Practitioner
   :short_description: Verify support for the server capabilities required by the US
     Core Practitioner Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9799,6 +9840,7 @@
   :title: PractitionerRole
   :short_description: Verify support for the server capabilities required by the US
     Core PractitionerRole Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9937,6 +9979,7 @@
   :title: Procedure
   :short_description: Verify support for the server capabilities required by the US
     Core Procedure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10149,6 +10192,7 @@
   :title: Provenance
   :short_description: Verify support for the server capabilities required by the US
     Core Provenance Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10300,6 +10344,7 @@
   :title: QuestionnaireResponse
   :short_description: Verify support for the server capabilities required by the US
     Core QuestionnaireResponse Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10509,6 +10554,7 @@
   :title: RelatedPerson
   :short_description: Verify support for the server capabilities required by the US
     Core RelatedPerson Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10625,6 +10671,7 @@
   :title: ServiceRequest
   :short_description: Verify support for the server capabilities required by the US
     Core ServiceRequest Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10921,6 +10968,7 @@
   :title: Specimen
   :short_description: Verify support for the server capabilities required by the US
     Core Specimen Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_clinical_result/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_clinical_result/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Clinical Result
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Clinical Result Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Laboratory Result
 :short_description: Verify support for the server capabilities required by the US
   Core Laboratory Result Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_occupation/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Occupation
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Occupation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancyintent/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancyintent/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pregnancy Intent
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Pregnancy Intent Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancystatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_pregnancystatus/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pregnancy Status
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Pregnancy Status Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_screening_assessment/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Screening Assessment
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Screening Assessment Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_sexual_orientation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_sexual_orientation/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Sexual Orientation
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Sexual Orientation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/organization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Organization
 :short_description: Verify support for the server capabilities required by the US
   Core Organization Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/patient/metadata.yml
@@ -10,6 +10,7 @@
 :title: Patient
 :short_description: Verify support for the server capabilities required by the US
   Core Patient Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pediatric_bmi_for_age/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric BMI for Age
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric BMI for Age Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pediatric_weight_for_height/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric Weight for Height
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Weight for Height Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/practitioner/metadata.yml
@@ -10,6 +10,7 @@
 :title: Practitioner
 :short_description: Verify support for the server capabilities required by the US
   Core Practitioner Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/procedure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Procedure
 :short_description: Verify support for the server capabilities required by the US
   Core Procedure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/provenance/metadata.yml
@@ -10,6 +10,7 @@
 :title: Provenance
 :short_description: Verify support for the server capabilities required by the US
   Core Provenance Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/pulse_oximetry/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pulse Oximetry
 :short_description: Verify support for the server capabilities required by the US
   Core Pulse Oximetry Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/questionnaire_response/metadata.yml
@@ -10,6 +10,7 @@
 :title: QuestionnaireResponse
 :short_description: Verify support for the server capabilities required by the US
   Core QuestionnaireResponse Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/related_person/metadata.yml
@@ -10,6 +10,7 @@
 :title: RelatedPerson
 :short_description: Verify support for the server capabilities required by the US
   Core RelatedPerson Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/respiratory_rate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Respiratory Rate
 :short_description: Verify support for the server capabilities required by the US
   Core Respiratory Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/service_request/metadata.yml
@@ -10,6 +10,7 @@
 :title: ServiceRequest
 :short_description: Verify support for the server capabilities required by the US
   Core ServiceRequest Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/simple_observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/simple_observation/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Simple
 :short_description: Verify support for the server capabilities required by the US
   Core Simple Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Smoking Status
 :short_description: Verify support for the server capabilities required by the US
   Core Smoking Status Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v6.1.0/specimen/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/specimen/metadata.yml
@@ -10,6 +10,7 @@
 :title: Specimen
 :short_description: Verify support for the server capabilities required by the US
   Core Specimen Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/allergy_intolerance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/allergy_intolerance/metadata.yml
@@ -10,6 +10,7 @@
 :title: AllergyIntolerance
 :short_description: Verify support for the server capabilities required by the US
   Core AllergyIntolerance Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/average_blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/average_blood_pressure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Average Blood Pressure
 :short_description: Verify support for the server capabilities required by the US
   Core Average Blood Pressure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/blood_pressure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/blood_pressure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Blood Pressure
 :short_description: Verify support for the server capabilities required by the US
   Core Blood Pressure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/bmi/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/bmi/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation BMI
 :short_description: Verify support for the server capabilities required by the US
   Core BMI Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/body_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/body_height/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Height
 :short_description: Verify support for the server capabilities required by the US
   Core Body Height Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/body_temperature/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/body_temperature/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Temperature
 :short_description: Verify support for the server capabilities required by the US
   Core Body Temperature Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/body_weight/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/body_weight/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Body Weight
 :short_description: Verify support for the server capabilities required by the US
   Core Body Weight Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/care_experience_preference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/care_experience_preference/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Care Experience Preference
 :short_description: Verify support for the server capabilities required by the US
   Core Care Experience Preference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/care_plan/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/care_plan/metadata.yml
@@ -10,6 +10,7 @@
 :title: CarePlan
 :short_description: Verify support for the server capabilities required by the US
   Core CarePlan Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/care_team/metadata.yml
@@ -10,6 +10,7 @@
 :title: CareTeam
 :short_description: Verify support for the server capabilities required by the US
   Core CareTeam Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/care_team/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/care_team/metadata.yml
@@ -176,3 +176,4 @@
   - Practitioner
   - Organization
   - PractitionerRole
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/condition_encounter_diagnosis/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/condition_encounter_diagnosis/metadata.yml
@@ -10,6 +10,7 @@
 :title: Condition Encounter Diagnosis
 :short_description: Verify support for the server capabilities required by the US
   Core Condition Encounter Diagnosis Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/condition_problems_health_concerns/metadata.yml
@@ -10,6 +10,7 @@
 :title: Condition Problems and Health Concerns
 :short_description: Verify support for the server capabilities required by the US
   Core Condition Problems and Health Concerns Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/coverage/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/coverage/metadata.yml
@@ -10,6 +10,7 @@
 :title: Coverage
 :short_description: Verify support for the server capabilities required by the US
   Core Coverage Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/coverage/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/coverage/metadata.yml
@@ -164,3 +164,4 @@
 - :path: payor
   :resources:
   - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/device/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/device/metadata.yml
@@ -10,6 +10,7 @@
 :title: Implantable Device
 :short_description: Verify support for the server capabilities required by the US
   Core Implantable Device Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/diagnostic_report_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/diagnostic_report_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Laboratory Results Reporting
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Laboratory Results Reporting.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/diagnostic_report_note/metadata.yml
@@ -10,6 +10,7 @@
 :title: DiagnosticReport for Report and Note Exchange
 :short_description: Verify support for the server capabilities required by the US
   Core DiagnosticReport Profile for Report and Note Exchange.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/document_reference/metadata.yml
@@ -321,3 +321,4 @@
   - Practitioner
   - Organization
   - PractitionerRole
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/document_reference/metadata.yml
@@ -10,6 +10,7 @@
 :title: DocumentReference
 :short_description: Verify support for the server capabilities required by the US
   Core DocumentReference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: SHALL

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/encounter/metadata.yml
@@ -366,6 +366,7 @@
   :resources:
   - Practitioner
   - PractitionerRole
+  - RelatedPerson
 - :path: location.location
   :resources:
   - Location

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/encounter/metadata.yml
@@ -10,6 +10,7 @@
 :title: Encounter
 :short_description: Verify support for the server capabilities required by the US
   Core Encounter Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/goal/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/goal/metadata.yml
@@ -10,6 +10,7 @@
 :title: Goal
 :short_description: Verify support for the server capabilities required by the US
   Core Goal Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/head_circumference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/head_circumference/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Head Circumference
 :short_description: Verify support for the server capabilities required by the US
   Core Head Circumference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/head_circumference_percentile/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/head_circumference_percentile/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric Head Occipital Frontal Circumference Percentile
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Head Occipital Frontal Circumference Percentile Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/heart_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/heart_rate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Heart Rate
 :short_description: Verify support for the server capabilities required by the US
   Core Heart Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/immunization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/immunization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Immunization
 :short_description: Verify support for the server capabilities required by the US
   Core Immunization Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/medication_dispense/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/medication_dispense/metadata.yml
@@ -238,3 +238,4 @@
   - Practitioner
   - Organization
   - PractitionerRole
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/medication_dispense/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/medication_dispense/metadata.yml
@@ -10,6 +10,7 @@
 :title: MedicationDispense
 :short_description: Verify support for the server capabilities required by the US
   Core MedicationDispense Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/medication_request/metadata.yml
@@ -325,3 +325,4 @@
   - Practitioner
   - Organization
   - PractitionerRole
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/medication_request/metadata.yml
@@ -10,6 +10,7 @@
 :title: MedicationRequest
 :short_description: Verify support for the server capabilities required by the US
   Core MedicationRequest Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/metadata.yml
@@ -12,6 +12,7 @@
   :title: AllergyIntolerance
   :short_description: Verify support for the server capabilities required by the US
     Core AllergyIntolerance Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -148,6 +149,7 @@
   :title: CarePlan
   :short_description: Verify support for the server capabilities required by the US
     Core CarePlan Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -408,6 +410,7 @@
   :title: CareTeam
   :short_description: Verify support for the server capabilities required by the US
     Core CareTeam Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -565,6 +568,7 @@
   :title: Condition Encounter Diagnosis
   :short_description: Verify support for the server capabilities required by the US
     Core Condition Encounter Diagnosis Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -884,6 +888,7 @@
   :title: Condition Problems and Health Concerns
   :short_description: Verify support for the server capabilities required by the US
     Core Condition Problems and Health Concerns Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1219,6 +1224,7 @@
   :title: Coverage
   :short_description: Verify support for the server capabilities required by the US
     Core Coverage Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1368,6 +1374,7 @@
   :title: Implantable Device
   :short_description: Verify support for the server capabilities required by the US
     Core Implantable Device Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -1514,6 +1521,7 @@
   :title: DiagnosticReport for Report and Note Exchange
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Report and Note Exchange.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -1771,6 +1779,7 @@
   :title: DiagnosticReport for Laboratory Results Reporting
   :short_description: Verify support for the server capabilities required by the US
     Core DiagnosticReport Profile for Laboratory Results Reporting.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -2013,6 +2022,7 @@
   :title: DocumentReference
   :short_description: Verify support for the server capabilities required by the US
     Core DocumentReference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: SHALL
@@ -2305,6 +2315,7 @@
   :title: Encounter
   :short_description: Verify support for the server capabilities required by the US
     Core Encounter Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2646,6 +2657,7 @@
   :title: Goal
   :short_description: Verify support for the server capabilities required by the US
     Core Goal Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2817,6 +2829,7 @@
   :title: Immunization
   :short_description: Verify support for the server capabilities required by the US
     Core Immunization Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -2983,6 +2996,7 @@
   :title: Location
   :short_description: Verify support for the server capabilities required by the US
     Core Location Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3154,6 +3168,7 @@
   :title: Medication
   :short_description: Verify support for the server capabilities required by the US
     Core Medication Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3208,6 +3223,7 @@
   :title: MedicationDispense
   :short_description: Verify support for the server capabilities required by the US
     Core MedicationDispense Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3427,6 +3443,7 @@
   :title: MedicationRequest
   :short_description: Verify support for the server capabilities required by the US
     Core MedicationRequest Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3729,6 +3746,7 @@
   :title: Observation Laboratory Result
   :short_description: Verify support for the server capabilities required by the US
     Core Laboratory Result Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -3984,6 +4002,7 @@
   :title: Observation Pregnancy Status
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Pregnancy Status Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4222,6 +4241,7 @@
   :title: Observation Pregnancy Intent
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Pregnancy Intent Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4460,6 +4480,7 @@
   :title: Observation Occupation
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Occupation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4709,6 +4730,7 @@
   :title: Observation Respiratory Rate
   :short_description: Verify support for the server capabilities required by the US
     Core Respiratory Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -4973,6 +4995,7 @@
   :title: Observation Simple
   :short_description: Verify support for the server capabilities required by the US
     Core Simple Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5251,6 +5274,7 @@
   :title: Observation Treatment Intervention Preference
   :short_description: Verify support for the server capabilities required by the US
     Core Treatment Intervention Preference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5481,6 +5505,7 @@
   :title: Observation Care Experience Preference
   :short_description: Verify support for the server capabilities required by the US
     Core Care Experience Preference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5711,6 +5736,7 @@
   :title: Observation Heart Rate
   :short_description: Verify support for the server capabilities required by the US
     Core Heart Rate Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -5975,6 +6001,7 @@
   :title: Observation Body Temperature
   :short_description: Verify support for the server capabilities required by the US
     Core Body Temperature Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6242,6 +6269,7 @@
   :title: Observation Pediatric Weight for Height
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Weight for Height Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6506,6 +6534,7 @@
   :title: Observation Pulse Oximetry
   :short_description: Verify support for the server capabilities required by the US
     Core Pulse Oximetry Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -6846,6 +6875,7 @@
   :title: Observation Smoking Status
   :short_description: Verify support for the server capabilities required by the US
     Core Smoking Status Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7074,6 +7104,7 @@
   :title: Observation Sexual Orientation
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Sexual Orientation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7299,6 +7330,7 @@
   :title: Observation Head Circumference
   :short_description: Verify support for the server capabilities required by the US
     Core Head Circumference Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7566,6 +7598,7 @@
   :title: Observation Body Height
   :short_description: Verify support for the server capabilities required by the US
     Core Body Height Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -7833,6 +7866,7 @@
   :title: Observation BMI
   :short_description: Verify support for the server capabilities required by the US
     Core BMI Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8097,6 +8131,7 @@
   :title: Observation Screening Assessment
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Screening Assessment Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8369,6 +8404,7 @@
   :title: Observation Average Blood Pressure
   :short_description: Verify support for the server capabilities required by the US
     Core Average Blood Pressure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -8700,6 +8736,7 @@
   :title: Observation Blood Pressure
   :short_description: Verify support for the server capabilities required by the US
     Core Blood Pressure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9000,6 +9037,7 @@
   :title: Observation Clinical Result
   :short_description: Verify support for the server capabilities required by the US
     Core Observation Clinical Result Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9254,6 +9292,7 @@
   :title: Observation Pediatric BMI for Age
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric BMI for Age Observation Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9519,6 +9558,7 @@
   :title: Observation Pediatric Head Occipital Frontal Circumference Percentile
   :short_description: Verify support for the server capabilities required by the US
     Core Pediatric Head Occipital Frontal Circumference Percentile Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -9783,6 +9823,7 @@
   :title: Observation Body Weight
   :short_description: Verify support for the server capabilities required by the US
     Core Body Weight Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10050,6 +10091,7 @@
   :title: Observation Vital Signs
   :short_description: Verify support for the server capabilities required by the US
     Core Vital Signs Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10297,6 +10339,7 @@
   :title: Organization
   :short_description: Verify support for the server capabilities required by the US
     Core Organization Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10425,6 +10468,7 @@
   :title: Patient
   :short_description: Verify support for the server capabilities required by the US
     Core Patient Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10784,6 +10828,7 @@
   :title: Practitioner
   :short_description: Verify support for the server capabilities required by the US
     Core Practitioner Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -10934,6 +10979,7 @@
   :title: PractitionerRole
   :short_description: Verify support for the server capabilities required by the US
     Core PractitionerRole Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -11077,6 +11123,7 @@
   :title: Procedure
   :short_description: Verify support for the server capabilities required by the US
     Core Procedure Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -11306,6 +11353,7 @@
   :title: Provenance
   :short_description: Verify support for the server capabilities required by the US
     Core Provenance Profile.
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -11456,6 +11504,7 @@
   :title: QuestionnaireResponse
   :short_description: Verify support for the server capabilities required by the US
     Core QuestionnaireResponse Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -11665,6 +11714,7 @@
   :title: RelatedPerson
   :short_description: Verify support for the server capabilities required by the US
     Core RelatedPerson Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -11781,6 +11831,7 @@
   :title: ServiceRequest
   :short_description: Verify support for the server capabilities required by the US
     Core ServiceRequest Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY
@@ -12091,6 +12142,7 @@
   :title: Specimen
   :short_description: Verify support for the server capabilities required by the US
     Core Specimen Profile.
+  :is_delayed: false
   :interactions:
   - :code: create
     :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/metadata.yml
@@ -557,6 +557,7 @@
     - Practitioner
     - Organization
     - PractitionerRole
+    - RelatedPerson
 - :name: us_core_condition_encounter_diagnosis
   :class_name: USCorev700_ballotConditionEncounterDiagnosisSequence
   :version: v7.0.0-ballot
@@ -1363,6 +1364,7 @@
   - :path: payor
     :resources:
     - Organization
+    - RelatedPerson
 - :name: us_core_implantable_device
   :class_name: USCorev700_ballotImplantableDeviceSequence
   :version: v7.0.0-ballot
@@ -2304,6 +2306,7 @@
     - Practitioner
     - Organization
     - PractitionerRole
+    - RelatedPerson
 - :name: us_core_encounter
   :class_name: USCorev700_ballotEncounterSequence
   :version: v7.0.0-ballot
@@ -2640,6 +2643,7 @@
     :resources:
     - Practitioner
     - PractitionerRole
+    - RelatedPerson
   - :path: location.location
     :resources:
     - Location
@@ -3432,6 +3436,7 @@
     - Practitioner
     - Organization
     - PractitionerRole
+    - RelatedPerson
 - :name: us_core_medicationrequest
   :class_name: USCorev700_ballotMedicationrequestSequence
   :version: v7.0.0-ballot
@@ -3735,6 +3740,7 @@
     - Practitioner
     - Organization
     - PractitionerRole
+    - RelatedPerson
 - :name: us_core_observation_lab
   :class_name: USCorev700_ballotObservationLabSequence
   :version: v7.0.0-ballot
@@ -3991,6 +3997,9 @@
   - :path: subject
     :resources:
     - Location
+  - :path: specimen
+    :resources:
+    - Specimen
 - :name: us_core_observation_pregnancystatus
   :class_name: USCorev700_ballotObservationPregnancystatusSequence
   :version: v7.0.0-ballot
@@ -5263,6 +5272,7 @@
     :resources:
     - Practitioner
     - Organization
+    - RelatedPerson
 - :name: us_core_treatment_intervention_preference
   :class_name: USCorev700_ballotTreatmentInterventionPreferenceSequence
   :version: v7.0.0-ballot
@@ -8393,6 +8403,7 @@
     :resources:
     - Practitioner
     - Organization
+    - RelatedPerson
 - :name: us_core_average_blood_pressure
   :class_name: USCorev700_ballotAverageBloodPressureSequence
   :version: v7.0.0-ballot
@@ -11490,6 +11501,7 @@
     - Organization
     - Practitioner
     - PractitionerRole
+    - RelatedPerson
   - :path: agent.onBehalfOf
     :resources:
     - Organization
@@ -11703,6 +11715,7 @@
     :resources:
     - Practitioner
     - Organization
+    - RelatedPerson
 - :name: us_core_relatedperson
   :class_name: USCorev700_ballotRelatedpersonSequence
   :version: v7.0.0-ballot
@@ -11714,7 +11727,7 @@
   :title: RelatedPerson
   :short_description: Verify support for the server capabilities required by the US
     Core RelatedPerson Profile.
-  :is_delayed: false
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY
@@ -12131,6 +12144,7 @@
     :resources:
     - Practitioner
     - Organization
+    - RelatedPerson
 - :name: us_core_specimen
   :class_name: USCorev700_ballotSpecimenSequence
   :version: v7.0.0-ballot
@@ -12142,7 +12156,7 @@
   :title: Specimen
   :short_description: Verify support for the server capabilities required by the US
     Core Specimen Profile.
-  :is_delayed: false
+  :is_delayed: true
   :interactions:
   - :code: create
     :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_clinical_result/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_clinical_result/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Clinical Result
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Clinical Result Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_lab/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Laboratory Result
 :short_description: Verify support for the server capabilities required by the US
   Core Laboratory Result Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_lab/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_lab/metadata.yml
@@ -278,3 +278,6 @@
 - :path: subject
   :resources:
   - Location
+- :path: specimen
+  :resources:
+  - Specimen

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_occupation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_occupation/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Occupation
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Occupation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_pregnancyintent/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_pregnancyintent/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pregnancy Intent
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Pregnancy Intent Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_pregnancystatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_pregnancystatus/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pregnancy Status
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Pregnancy Status Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_screening_assessment/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Screening Assessment
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Screening Assessment Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_screening_assessment/metadata.yml
@@ -296,3 +296,4 @@
   :resources:
   - Practitioner
   - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_sexual_orientation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/observation_sexual_orientation/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Sexual Orientation
 :short_description: Verify support for the server capabilities required by the US
   Core Observation Sexual Orientation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/organization/metadata.yml
@@ -10,6 +10,7 @@
 :title: Organization
 :short_description: Verify support for the server capabilities required by the US
   Core Organization Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/patient/metadata.yml
@@ -10,6 +10,7 @@
 :title: Patient
 :short_description: Verify support for the server capabilities required by the US
   Core Patient Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/pediatric_bmi_for_age/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/pediatric_bmi_for_age/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric BMI for Age
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric BMI for Age Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/pediatric_weight_for_height/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/pediatric_weight_for_height/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pediatric Weight for Height
 :short_description: Verify support for the server capabilities required by the US
   Core Pediatric Weight for Height Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/practitioner/metadata.yml
@@ -10,6 +10,7 @@
 :title: Practitioner
 :short_description: Verify support for the server capabilities required by the US
   Core Practitioner Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/procedure/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/procedure/metadata.yml
@@ -10,6 +10,7 @@
 :title: Procedure
 :short_description: Verify support for the server capabilities required by the US
   Core Procedure Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/provenance/metadata.yml
@@ -10,6 +10,7 @@
 :title: Provenance
 :short_description: Verify support for the server capabilities required by the US
   Core Provenance Profile.
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/provenance/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/provenance/metadata.yml
@@ -158,6 +158,7 @@
   - Organization
   - Practitioner
   - PractitionerRole
+  - RelatedPerson
 - :path: agent.onBehalfOf
   :resources:
   - Organization

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/pulse_oximetry/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/pulse_oximetry/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Pulse Oximetry
 :short_description: Verify support for the server capabilities required by the US
   Core Pulse Oximetry Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/questionnaire_response/metadata.yml
@@ -10,6 +10,7 @@
 :title: QuestionnaireResponse
 :short_description: Verify support for the server capabilities required by the US
   Core QuestionnaireResponse Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/questionnaire_response/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/questionnaire_response/metadata.yml
@@ -232,3 +232,4 @@
   :resources:
   - Practitioner
   - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/related_person/metadata.yml
@@ -10,7 +10,7 @@
 :title: RelatedPerson
 :short_description: Verify support for the server capabilities required by the US
   Core RelatedPerson Profile.
-:is_delayed: false
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY
@@ -116,6 +116,8 @@
   :profiles:
   - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :tests:
+- :id: us_core_v700_ballot_related_person_read_test
+  :file_name: related_person_read_test.rb
 - :id: us_core_v700_ballot_related_person_patient_search_test
   :file_name: related_person_patient_search_test.rb
 - :id: us_core_v700_ballot_related_person__id_search_test
@@ -124,8 +126,6 @@
   :file_name: related_person_name_search_test.rb
 - :id: us_core_v700_ballot_related_person_patient_name_search_test
   :file_name: related_person_patient_name_search_test.rb
-- :id: us_core_v700_ballot_related_person_read_test
-  :file_name: related_person_read_test.rb
 - :id: us_core_v700_ballot_related_person_provenance_revinclude_search_test
   :file_name: related_person_provenance_revinclude_search_test.rb
 - :id: us_core_v700_ballot_related_person_validation_test

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/related_person/metadata.yml
@@ -10,6 +10,7 @@
 :title: RelatedPerson
 :short_description: Verify support for the server capabilities required by the US
   Core RelatedPerson Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/related_person/related_person_read_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/related_person/related_person_read_test.rb
@@ -19,7 +19,7 @@ module USCoreTestKit
       end
 
       run do
-        perform_read_test(all_scratch_resources)
+        perform_read_test(scratch.dig(:references, 'RelatedPerson'))
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/related_person_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/related_person_group.rb
@@ -1,8 +1,8 @@
+require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_patient_search_test'
 require_relative 'related_person/related_person_id_search_test'
 require_relative 'related_person/related_person_name_search_test'
 require_relative 'related_person/related_person_patient_name_search_test'
-require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_provenance_revinclude_search_test'
 require_relative 'related_person/related_person_validation_test'
 require_relative 'related_person/related_person_must_support_test'
@@ -78,11 +78,11 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'related_person', 'metadata.yml'), aliases: true))
       end
   
+      test from: :us_core_v700_ballot_related_person_read_test
       test from: :us_core_v700_ballot_related_person_patient_search_test
       test from: :us_core_v700_ballot_related_person__id_search_test
       test from: :us_core_v700_ballot_related_person_name_search_test
       test from: :us_core_v700_ballot_related_person_patient_name_search_test
-      test from: :us_core_v700_ballot_related_person_read_test
       test from: :us_core_v700_ballot_related_person_provenance_revinclude_search_test
       test from: :us_core_v700_ballot_related_person_validation_test
       test from: :us_core_v700_ballot_related_person_must_support_test

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/respiratory_rate/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/respiratory_rate/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Respiratory Rate
 :short_description: Verify support for the server capabilities required by the US
   Core Respiratory Rate Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/service_request/metadata.yml
@@ -337,3 +337,4 @@
   :resources:
   - Practitioner
   - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/service_request/metadata.yml
@@ -10,6 +10,7 @@
 :title: ServiceRequest
 :short_description: Verify support for the server capabilities required by the US
   Core ServiceRequest Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/simple_observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/simple_observation/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Simple
 :short_description: Verify support for the server capabilities required by the US
   Core Simple Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/simple_observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/simple_observation/metadata.yml
@@ -302,3 +302,4 @@
   :resources:
   - Practitioner
   - Organization
+  - RelatedPerson

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/smokingstatus/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Smoking Status
 :short_description: Verify support for the server capabilities required by the US
   Core Smoking Status Observation Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/specimen/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/specimen/metadata.yml
@@ -10,7 +10,7 @@
 :title: Specimen
 :short_description: Verify support for the server capabilities required by the US
   Core Specimen Profile.
-:is_delayed: false
+:is_delayed: true
 :interactions:
 - :code: create
   :expectation: MAY
@@ -112,12 +112,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Substance
 :tests:
+- :id: us_core_v700_ballot_specimen_read_test
+  :file_name: specimen_read_test.rb
 - :id: us_core_v700_ballot_specimen_patient_search_test
   :file_name: specimen_patient_search_test.rb
 - :id: us_core_v700_ballot_specimen__id_search_test
   :file_name: specimen_id_search_test.rb
-- :id: us_core_v700_ballot_specimen_read_test
-  :file_name: specimen_read_test.rb
 - :id: us_core_v700_ballot_specimen_validation_test
   :file_name: specimen_validation_test.rb
 - :id: us_core_v700_ballot_specimen_must_support_test

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/specimen/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/specimen/metadata.yml
@@ -10,6 +10,7 @@
 :title: Specimen
 :short_description: Verify support for the server capabilities required by the US
   Core Specimen Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/specimen/specimen_read_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/specimen/specimen_read_test.rb
@@ -19,7 +19,7 @@ module USCoreTestKit
       end
 
       run do
-        perform_read_test(all_scratch_resources)
+        perform_read_test(scratch.dig(:references, 'Specimen'))
       end
     end
   end

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/specimen_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/specimen_group.rb
@@ -1,6 +1,6 @@
+require_relative 'specimen/specimen_read_test'
 require_relative 'specimen/specimen_patient_search_test'
 require_relative 'specimen/specimen_id_search_test'
-require_relative 'specimen/specimen_read_test'
 require_relative 'specimen/specimen_validation_test'
 require_relative 'specimen/specimen_must_support_test'
 require_relative 'specimen/specimen_reference_resolution_test'
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'specimen', 'metadata.yml'), aliases: true))
       end
   
+      test from: :us_core_v700_ballot_specimen_read_test
       test from: :us_core_v700_ballot_specimen_patient_search_test
       test from: :us_core_v700_ballot_specimen__id_search_test
-      test from: :us_core_v700_ballot_specimen_read_test
       test from: :us_core_v700_ballot_specimen_validation_test
       test from: :us_core_v700_ballot_specimen_must_support_test
       test from: :us_core_v700_ballot_specimen_reference_resolution_test

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/treatment_intervention_preference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/treatment_intervention_preference/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Treatment Intervention Preference
 :short_description: Verify support for the server capabilities required by the US
   Core Treatment Intervention Preference Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/us_core_test_suite.rb
@@ -50,12 +50,12 @@ require_relative 'body_weight_group'
 require_relative 'vital_signs_group'
 require_relative 'procedure_group'
 require_relative 'questionnaire_response_group'
-require_relative 'related_person_group'
 require_relative 'service_request_group'
-require_relative 'specimen_group'
 require_relative 'organization_group'
 require_relative 'practitioner_group'
 require_relative 'provenance_group'
+require_relative 'related_person_group'
+require_relative 'specimen_group'
 
 module USCoreTestKit
   module USCoreV700_BALLOT
@@ -189,12 +189,12 @@ module USCoreTestKit
         group from: :us_core_v700_ballot_vital_signs
         group from: :us_core_v700_ballot_procedure
         group from: :us_core_v700_ballot_questionnaire_response
-        group from: :us_core_v700_ballot_related_person
         group from: :us_core_v700_ballot_service_request
-        group from: :us_core_v700_ballot_specimen
         group from: :us_core_v700_ballot_organization
         group from: :us_core_v700_ballot_practitioner
         group from: :us_core_v700_ballot_provenance
+        group from: :us_core_v700_ballot_related_person
+        group from: :us_core_v700_ballot_specimen
         group from: :us_core_v400_clinical_notes_guidance
         group from: :us_core_311_data_absent_reason
       end

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/vital_signs/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/vital_signs/metadata.yml
@@ -10,6 +10,7 @@
 :title: Observation Vital Signs
 :short_description: Verify support for the server capabilities required by the US
   Core Vital Signs Profile.
+:is_delayed: false
 :interactions:
 - :code: create
   :expectation: MAY

--- a/lib/us_core_test_kit/generator/group_metadata.rb
+++ b/lib/us_core_test_kit/generator/group_metadata.rb
@@ -44,8 +44,12 @@ module USCoreTestKit
         @is_delayed ||= if resource == 'Patient'
                           false
                         else
-                          no_patient_searches? || non_uscdi_resource?
+                          no_patient_searches? || non_uscdi_resource? || searchable_non_uscdi_resource?
                         end
+      end
+
+      def exclude_search_tests?
+        delayed? && !searchable_non_uscdi_resource
       end
 
       def no_patient_searches?

--- a/lib/us_core_test_kit/generator/group_metadata.rb
+++ b/lib/us_core_test_kit/generator/group_metadata.rb
@@ -12,6 +12,7 @@ module USCoreTestKit
         :profile_version,
         :title,
         :short_description,
+        :is_delayed,
         :interactions,
         :operations,
         :searches,
@@ -29,18 +30,6 @@ module USCoreTestKit
         :delayed_references
       ].freeze
 
-      NON_USCDI_RESOURCES = {
-        'Encounter' => ['v311', 'v400'],
-        'Location' => ['v311', 'v400', 'v501', 'v610'],
-        'Organization' => ['v311', 'v400', 'v501', 'v610'],
-        'Practitioner' => ['v311', 'v400', 'v501', 'v610'],
-        'PractitionerRole' => ['v311', 'v400', 'v501', 'v610'],
-        'Provenance' => ['v311', 'v400', 'v501', 'v610'],
-        'RelatedPerson' => ['v501', 'v610'],
-        'Specimen' => ['v610']
-      }.freeze
-
-
       ATTRIBUTES.each { |name| attr_accessor name }
 
       def initialize(metadata)
@@ -52,9 +41,11 @@ module USCoreTestKit
       end
 
       def delayed?
-        return false if resource == 'Patient'
-
-        no_patient_searches? || non_uscdi_resource?
+        @is_delayed ||= if resource == 'Patient'
+                          false
+                        else
+                          no_patient_searches? || non_uscdi_resource?
+                        end
       end
 
       def no_patient_searches?
@@ -62,7 +53,11 @@ module USCoreTestKit
       end
 
       def non_uscdi_resource?
-        NON_USCDI_RESOURCES.key?(resource) && NON_USCDI_RESOURCES[resource].include?(reformatted_version)
+        SpecialCases::NON_USCDI_RESOURCES.key?(resource) && SpecialCases::NON_USCDI_RESOURCES[resource].include?(reformatted_version)
+      end
+
+      def searchable_non_uscdi_resource?
+        SpecialCases::SEARCHABLE_NON_USCDI_RESOURCES.key?(resource) && SpecialCases::SEARCHABLE_NON_USCDI_RESOURCES[resource].include?(reformatted_version)
       end
 
       def add_test(id:, file_name:)

--- a/lib/us_core_test_kit/generator/group_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/group_metadata_extractor.rb
@@ -94,30 +94,9 @@ module USCoreTestKit
       end
 
       ### BEGIN SPECIAL CASES ###
-
-      ALL_VERSION_CATEGORY_FIRST_PROFILES = [
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-result',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-test',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-imaging',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-screening-assessment',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-sdoh-assessment',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-social-history',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-survey',
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-simple-observation'
-      ]
-
-      VERSION_SPECIFIC_CATEGORY_FIRST_PROFILES = {
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis' => ['v610', 'v700_ballot'],
-        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns' => ['v610', 'v700_ballot']
-      }
-
       def category_first_profile?
-        ALL_VERSION_CATEGORY_FIRST_PROFILES.include?(profile_url) ||
-        VERSION_SPECIFIC_CATEGORY_FIRST_PROFILES[profile_url]&.include?(reformatted_version)
+        SpecialCases::ALL_VERSION_CATEGORY_FIRST_PROFILES.include?(profile_url) ||
+        SpecialCases::VERSION_SPECIFIC_CATEGORY_FIRST_PROFILES[profile_url]&.include?(reformatted_version)
       end
 
       def first_search_params

--- a/lib/us_core_test_kit/generator/special_cases.rb
+++ b/lib/us_core_test_kit/generator/special_cases.rb
@@ -12,6 +12,41 @@ module USCoreTestKit
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs'
       ].freeze
 
+      NON_USCDI_RESOURCES = {
+        'Encounter' => ['v311', 'v400'],
+        'Location' => ['v311', 'v400', 'v501', 'v610', 'v700_ballot'],
+        'Organization' => ['v311', 'v400', 'v501', 'v610', 'v700_ballot'],
+        'Practitioner' => ['v311', 'v400'],
+        'PractitionerRole' => ['v311', 'v400', 'v501', 'v610', 'v700_ballot'],
+        'Provenance' => ['v311', 'v400', 'v501', 'v610', 'v700_ballot'],
+        'RelatedPerson' => ['v501', 'v610', 'v700_ballot'],
+        'Specimen' => ['v610', 'v700_ballot']
+      }.freeze
+
+      SEARCHABLE_NON_USCDI_RESOURCES = {
+        'Practitioner' => ['v501', 'v610', 'v700_ballot']
+      }.freeze
+
+      ALL_VERSION_CATEGORY_FIRST_PROFILES = [
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-result',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-test',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-imaging',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-screening-assessment',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-sdoh-assessment',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-social-history',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-survey',
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-simple-observation'
+      ].freeze
+
+      VERSION_SPECIFIC_CATEGORY_FIRST_PROFILES = {
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis' => ['v610', 'v700_ballot'],
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns' => ['v610', 'v700_ballot']
+      }.freeze
+
       class << self
         def exclude_group?(group)
           RESOURCES_TO_EXCLUDE.include?(group.resource)


### PR DESCRIPTION
# Summary
This PR fixes JIRA ticket FI-2231. Practitioner is a delayed resource because it does not have patient search parameter and it is not an USCDI data class/data element. (g)(10) test kit excludes search tests for all delayed resources. 

To add search tests back for Practitioner in (g)(10) test kit, we split the original "delayed" resources into to part for (g)(10) test kit: delayed resources with searches and delayed resources without searches. The second category is identified by exclude_search_tests? metadata property.

# Change Log
* Expose is_delayed into metadata.yml (Note: I am still debating if this is necessary. I could remove this from metadata.yml if there're other opinions)
* Move some version specific constants to SpecialCase module
* Add Practitioner to SEARCHABLE_NON_USCDI_RESOURCES 
* Add logic of exclude_search_tests?

# Testing Guidance
This PR does not affect US Core Test Kit. Corresponding changes are also applied in (g)(10) test kit so that when (g)(10) loads US Core Test Suites, it uses the exclude_search_tests? property instead of delayed? property to decide if group's search tests shall be included/excluded.


