### PR TITLE
fix exclude_search_tests

### DIFF
--- a/lib/us_core_test_kit/generator/group_metadata.rb
+++ b/lib/us_core_test_kit/generator/group_metadata.rb
@@ -50,7 +50,7 @@ module USCoreTestKit
       end
 
       def exclude_search_tests?
-        delayed? && !searchable_delayed_resource
+        delayed? && !searchable_delayed_resource?
       end
 
       def no_patient_searches?


### PR DESCRIPTION
# Summary
This method is not used currently but better to fix for futhure usage

# Testing Guidance

