### PR TITLE
FI-2534 Fix US Core MS Support for Patient's previous name and previous address

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -6660,8 +6660,18 @@
     - :path: address.city
     - :path: address.state
     - :path: address.postalCode
+    - :path: address.period.end
+      :uscdi_only: true
     - :path: communication
     - :path: communication.language
+    - :path: name.period.end
+      :uscdi_only: true
+    - :path: name.use
+      :fixed_value: old
+      :uscdi_only: true
+    - :path: address.use
+      :fixed_value: old
+      :uscdi_only: true
     :choices:
     - :paths:
       - address.period.end

--- a/lib/us_core_test_kit/generated/v3.1.1/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/patient/metadata.yml
@@ -172,8 +172,18 @@
   - :path: address.city
   - :path: address.state
   - :path: address.postalCode
+  - :path: address.period.end
+    :uscdi_only: true
   - :path: communication
   - :path: communication.language
+  - :path: name.period.end
+    :uscdi_only: true
+  - :path: name.use
+    :fixed_value: old
+    :uscdi_only: true
+  - :path: address.use
+    :fixed_value: old
+    :uscdi_only: true
   :choices:
   - :paths:
     - address.period.end

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -7289,6 +7289,8 @@
     - :path: address.city
     - :path: address.state
     - :path: address.postalCode
+    - :path: address.period.end
+      :uscdi_only: true
     - :path: communication.language
       :uscdi_only: true
     - :path: name.suffix
@@ -7296,6 +7298,14 @@
     - :path: telecom
       :uscdi_only: true
     - :path: communication
+      :uscdi_only: true
+    - :path: name.period.end
+      :uscdi_only: true
+    - :path: name.use
+      :fixed_value: old
+      :uscdi_only: true
+    - :path: address.use
+      :fixed_value: old
       :uscdi_only: true
     :choices:
     - :paths:

--- a/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/patient/metadata.yml
@@ -177,6 +177,8 @@
   - :path: address.city
   - :path: address.state
   - :path: address.postalCode
+  - :path: address.period.end
+    :uscdi_only: true
   - :path: communication.language
     :uscdi_only: true
   - :path: name.suffix
@@ -184,6 +186,14 @@
   - :path: telecom
     :uscdi_only: true
   - :path: communication
+    :uscdi_only: true
+  - :path: name.period.end
+    :uscdi_only: true
+  - :path: name.use
+    :fixed_value: old
+    :uscdi_only: true
+  - :path: address.use
+    :fixed_value: old
     :uscdi_only: true
   :choices:
   - :paths:

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -9726,6 +9726,8 @@
     - :path: address.city
     - :path: address.state
     - :path: address.postalCode
+    - :path: address.period.end
+      :uscdi_only: true
     - :path: communication.language
       :uscdi_only: true
     - :path: name.suffix
@@ -9734,10 +9736,12 @@
       :uscdi_only: true
     - :path: communication
       :uscdi_only: true
-    - :path: address.use
-      :fixed_value: old
+    - :path: name.period.end
       :uscdi_only: true
     - :path: name.use
+      :fixed_value: old
+      :uscdi_only: true
+    - :path: address.use
       :fixed_value: old
       :uscdi_only: true
     :choices:

--- a/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/patient/metadata.yml
@@ -180,6 +180,8 @@
   - :path: address.city
   - :path: address.state
   - :path: address.postalCode
+  - :path: address.period.end
+    :uscdi_only: true
   - :path: communication.language
     :uscdi_only: true
   - :path: name.suffix
@@ -188,10 +190,12 @@
     :uscdi_only: true
   - :path: communication
     :uscdi_only: true
-  - :path: address.use
-    :fixed_value: old
+  - :path: name.period.end
     :uscdi_only: true
   - :path: name.use
+    :fixed_value: old
+    :uscdi_only: true
+  - :path: address.use
     :fixed_value: old
     :uscdi_only: true
   :choices:

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -10396,7 +10396,7 @@
     - :path: name.given
     - :path: name.suffix
       :uscdi_only: true
-    - :path: name.period
+    - :path: name.period.end
       :uscdi_only: true
     - :path: telecom
       :uscdi_only: true
@@ -10419,7 +10419,7 @@
     - :path: address.city
     - :path: address.state
     - :path: address.postalCode
-    - :path: address.period
+    - :path: address.period.end
       :uscdi_only: true
     - :path: communication
       :uscdi_only: true

--- a/lib/us_core_test_kit/generated/v6.1.0/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/patient/metadata.yml
@@ -200,7 +200,7 @@
   - :path: name.given
   - :path: name.suffix
     :uscdi_only: true
-  - :path: name.period
+  - :path: name.period.end
     :uscdi_only: true
   - :path: telecom
     :uscdi_only: true
@@ -223,7 +223,7 @@
   - :path: address.city
   - :path: address.state
   - :path: address.postalCode
-  - :path: address.period
+  - :path: address.period.end
     :uscdi_only: true
   - :path: communication
     :uscdi_only: true

--- a/lib/us_core_test_kit/generated/v6.1.0/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/patient/patient_must_support_test.rb
@@ -28,7 +28,6 @@ module USCoreTestKit
 
         For ONC USCDI requirements, each Patient must support the following additional elements:
 
-        * Patient.address.period
         * Patient.address.period.end or Patient.address.use
         * Patient.communication
         * Patient.communication.language
@@ -38,7 +37,6 @@ module USCoreTestKit
         * Patient.extension:race
         * Patient.extension:sex
         * Patient.extension:tribalAffiliation
-        * Patient.name.period
         * Patient.name.period.end or Patient.name.use
         * Patient.name.suffix
         * Patient.telecom

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/metadata.yml
@@ -11416,7 +11416,7 @@
     - :path: name.given
     - :path: name.suffix
       :uscdi_only: true
-    - :path: name.period
+    - :path: name.period.end
       :uscdi_only: true
     - :path: telecom
       :uscdi_only: true
@@ -11439,7 +11439,7 @@
     - :path: address.city
     - :path: address.state
     - :path: address.postalCode
-    - :path: address.period
+    - :path: address.period.end
       :uscdi_only: true
     - :path: communication
       :uscdi_only: true

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/patient/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/patient/metadata.yml
@@ -200,7 +200,7 @@
   - :path: name.given
   - :path: name.suffix
     :uscdi_only: true
-  - :path: name.period
+  - :path: name.period.end
     :uscdi_only: true
   - :path: telecom
     :uscdi_only: true
@@ -223,7 +223,7 @@
   - :path: address.city
   - :path: address.state
   - :path: address.postalCode
-  - :path: address.period
+  - :path: address.period.end
     :uscdi_only: true
   - :path: communication
     :uscdi_only: true

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/patient/patient_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/patient/patient_must_support_test.rb
@@ -28,7 +28,6 @@ module USCoreTestKit
 
         For ONC USCDI requirements, each Patient must support the following additional elements:
 
-        * Patient.address.period
         * Patient.address.period.end or Patient.address.use
         * Patient.communication
         * Patient.communication.language
@@ -38,7 +37,6 @@ module USCoreTestKit
         * Patient.extension:race
         * Patient.extension:sex
         * Patient.extension:tribalAffiliation
-        * Patient.name.period
         * Patient.name.period.end or Patient.name.use
         * Patient.name.suffix
         * Patient.telecom

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_4.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_4.rb
@@ -16,7 +16,6 @@ module USCoreTestKit
 
       def handle_special_cases
         add_must_support_choices
-        remove_patient_address_period
         add_device_distinct_identifier
         add_patient_uscdi_elements
       end
@@ -32,26 +31,9 @@ module USCoreTestKit
           choices << { paths: ['location.location', 'serviceProvider'] }
         when 'MedicationRequest'
           choices << { paths: ['reportedBoolean', 'reportedReference'] }
-        when 'Patient'
-          # FHIR-40299 adds USCDI MustSupport choices for:
-          # * address.period.end and address.use,
-          # * name.period.end and name.use
-          choices << {
-            paths: ['address.period.end', 'address.use'],
-            uscdi_only: true
-          }
-
-          choices << {
-            paths: ['name.period.end', 'name.use'],
-            uscdi_only: true
-          }
         end
 
         must_supports[:choices] = choices if choices.present?
-      end
-
-      def remove_patient_address_period
-        us_core_3_extractor.remove_patient_address_period
       end
 
       def add_device_distinct_identifier
@@ -97,6 +79,7 @@ module USCoreTestKit
         }
 
         add_patient_telecom_communication_uscdi
+        us_core_3_extractor.update_patient_previous_name_address
       end
 
       def add_patient_telecom_communication_uscdi

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_5.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_5.rb
@@ -17,7 +17,6 @@ module USCoreTestKit
 
       def handle_special_cases
         add_must_support_choices
-        remove_patient_address_period
         add_patient_uscdi_elements
         remove_survey_questionnaire_response
       end
@@ -48,10 +47,6 @@ module USCoreTestKit
         end
       end
 
-      def remove_patient_address_period
-        us_core_4_extractor.remove_patient_address_period
-      end
-
       def add_patient_uscdi_elements
         return unless profile.type == 'Patient'
 
@@ -60,16 +55,6 @@ module USCoreTestKit
         must_supports[:extensions] << {
           id: 'Patient.extension:genderIdentity',
           url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity',
-          uscdi_only: true
-        }
-        must_supports[:elements] << {
-          path: 'address.use',
-          fixed_value: 'old',
-          uscdi_only: true
-        }
-        must_supports[:elements] << {
-          path: 'name.use',
-          fixed_value: 'old',
           uscdi_only: true
         }
       end

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
@@ -12,6 +12,10 @@ module USCoreTestKit
         self.must_supports = must_supports
       end
 
+      def us_core_3_extractor
+        @us_core_3_extractor ||= MustSupportMetadataExtractorUsCore3.new(profile, must_supports)
+      end
+
       def us_core_4_extractor
         @us_core_4_extractor ||= MustSupportMetadataExtractorUsCore4.new(profile, must_supports)
       end
@@ -66,11 +70,10 @@ module USCoreTestKit
         return unless profile.type == 'Patient'
 
         us_core_4_extractor.add_patient_telecom_communication_uscdi
+        us_core_3_extractor.update_patient_previous_name_address
 
         must_supports[:elements].each do |element|
           case element[:path]
-          when 'address.use', 'name.use'
-            element[:fixed_value] = 'old'
           when 'deceased[x]'
             element[:original_path] = element[:path]
             element[:path] = 'deceasedDateTime'


### PR DESCRIPTION
# Summary
This PR fix GitHub issue: https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/496. 

This PR fixed several issues in our current MustSupport test for Patient's previous name and previous address:
* US Core 3/4/5: Add Patient's `name.use`, `name.period.end`, `address.use`, `address.period.end` as USCDI_ONLY MustSpport elements
* US Core 6/7: Change MustSupport element `name.period` to `name.period.end`, and MustSupport element `address.period` to `address.period.end`
* Update unit tests.

# Testing Guidance
All unit tests shall pass
