### PR TITLE
FI-2494 POST capability added to granular scopes

### DIFF
--- a/lib/us_core_test_kit/granular_scope_checker.rb
+++ b/lib/us_core_test_kit/granular_scope_checker.rb
@@ -84,7 +84,6 @@ module USCoreTestKit
         granular_scopes.map do |scope|
           _, granular_scope = scope.split('?')
           name, value = granular_scope.split('=')
-
           {
             name:,
             value:

--- a/lib/us_core_test_kit/granular_scope_checker.rb
+++ b/lib/us_core_test_kit/granular_scope_checker.rb
@@ -16,7 +16,6 @@ module USCoreTestKit
       previous_request_resources.each do |previous_request, all_previous_resources|
         search_method = previous_request.verb.to_sym
         params = search_method == :get ? previous_request.query_parameters : Hash[URI.decode_www_form(previous_request.request_body)]
-        binding.pry if search_method == :post
         fhir_search(resource_type, params:, search_method:)
 
         found_resources =

--- a/lib/us_core_test_kit/granular_scope_checker.rb
+++ b/lib/us_core_test_kit/granular_scope_checker.rb
@@ -14,8 +14,8 @@ module USCoreTestKit
               "No #{resource_type} searches with search params #{search_param_names.join(' & ')} found"
 
       previous_request_resources.each do |previous_request, all_previous_resources|
-        params = previous_request.query_parameters
         search_method = previous_request.verb.to_sym
+        params = search_method == :get ? previous_request.query_parameters : JSON.parse(previous_request.request_body)
         fhir_search(resource_type, params:, search_method:)
 
         found_resources =

--- a/lib/us_core_test_kit/granular_scope_checker.rb
+++ b/lib/us_core_test_kit/granular_scope_checker.rb
@@ -15,7 +15,8 @@ module USCoreTestKit
 
       previous_request_resources.each do |previous_request, all_previous_resources|
         search_method = previous_request.verb.to_sym
-        params = search_method == :get ? previous_request.query_parameters : JSON.parse(previous_request.request_body)
+        params = search_method == :get ? previous_request.query_parameters : Hash[URI.decode_www_form(previous_request.request_body)]
+        binding.pry if search_method == :post
         fhir_search(resource_type, params:, search_method:)
 
         found_resources =

--- a/lib/us_core_test_kit/granular_scope_checker.rb
+++ b/lib/us_core_test_kit/granular_scope_checker.rb
@@ -84,7 +84,7 @@ module USCoreTestKit
         granular_scopes.map do |scope|
           _, granular_scope = scope.split('?')
           name, value = granular_scope.split('=')
-          
+
           {
             name:,
             value:

--- a/lib/us_core_test_kit/granular_scope_checker.rb
+++ b/lib/us_core_test_kit/granular_scope_checker.rb
@@ -16,6 +16,7 @@ module USCoreTestKit
       previous_request_resources.each do |previous_request, all_previous_resources|
         search_method = previous_request.verb.to_sym
         params = search_method == :get ? previous_request.query_parameters : Hash[URI.decode_www_form(previous_request.request_body)]
+        binding.pry if search_method == :post
         fhir_search(resource_type, params:, search_method:)
 
         found_resources =

--- a/lib/us_core_test_kit/granular_scope_checker.rb
+++ b/lib/us_core_test_kit/granular_scope_checker.rb
@@ -84,6 +84,7 @@ module USCoreTestKit
         granular_scopes.map do |scope|
           _, granular_scope = scope.split('?')
           name, value = granular_scope.split('=')
+          
           {
             name:,
             value:

--- a/spec/us_core/granular_scope_checker_spec.rb
+++ b/spec/us_core/granular_scope_checker_spec.rb
@@ -134,7 +134,6 @@ RSpec.describe USCoreTestKit::GranularScopeChecker do
         )
       end
       
-
       it 'fails if resources which match the received scopes are not returned' do
         stub_request(request.verb.to_sym, request.url.split('?').first)
           .with(query: request.query_parameters)
@@ -261,12 +260,12 @@ RSpec.describe USCoreTestKit::GranularScopeChecker do
 
         it 'correctly pulls parameters from POST body' do
           response_body =
-          FHIR::Bundle.new(
-            entry: [
-              { resource: matching_resource.to_hash },
-              { resource: matching_resource2.to_hash }
-            ]
-          ).to_json
+            FHIR::Bundle.new(
+              entry: [
+                { resource: matching_resource.to_hash },
+                { resource: matching_resource2.to_hash }
+              ]
+            ).to_json
 
           stub_request(:post, post_request.url)
             .with(body: {patient: patient_ids})

--- a/spec/us_core/granular_scope_checker_spec.rb
+++ b/spec/us_core/granular_scope_checker_spec.rb
@@ -260,12 +260,13 @@ RSpec.describe USCoreTestKit::GranularScopeChecker do
 
         it 'correctly pulls parameters from POST body' do
           response_body =
-            FHIR::Bundle.new(
-              entry: [
-                { resource: matching_resource.to_hash },
-                { resource: matching_resource2.to_hash }
-              ]
-            ).to_json
+          FHIR::Bundle.new(
+            entry: [
+              { resource: matching_resource.to_hash },
+              { resource: matching_resource2.to_hash }
+            ]
+          ).to_json
+
           stub_request(:post, post_request.url)
             .with(body: {patient: patient_ids})
             .to_return(body: response_body)

--- a/spec/us_core/granular_scope_checker_spec.rb
+++ b/spec/us_core/granular_scope_checker_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe USCoreTestKit::GranularScopeChecker do
           ).to_json
         )
       end
-      
+
       it 'fails if resources which match the received scopes are not returned' do
         stub_request(request.verb.to_sym, request.url.split('?').first)
           .with(query: request.query_parameters)

--- a/spec/us_core/granular_scope_checker_spec.rb
+++ b/spec/us_core/granular_scope_checker_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe USCoreTestKit::GranularScopeChecker do
 
         expect(result.result).to eq('pass')
       end
-      
+
       context 'with POST requests' do
         let!(:post_request) do
           repo_create(
@@ -266,11 +266,10 @@ RSpec.describe USCoreTestKit::GranularScopeChecker do
                 { resource: matching_resource2.to_hash }
               ]
             ).to_json
-
           stub_request(:post, post_request.url)
             .with(body: {patient: patient_ids})
             .to_return(body: response_body)
-  
+
           result = run(granular_scope_test, url:, received_scopes:)
 
           expect(result.result).to eq('pass')

--- a/spec/us_core/granular_scope_checker_spec.rb
+++ b/spec/us_core/granular_scope_checker_spec.rb
@@ -260,12 +260,12 @@ RSpec.describe USCoreTestKit::GranularScopeChecker do
 
         it 'correctly pulls parameters from POST body' do
           response_body =
-          FHIR::Bundle.new(
-            entry: [
-              { resource: matching_resource.to_hash },
-              { resource: matching_resource2.to_hash }
-            ]
-          ).to_json
+            FHIR::Bundle.new(
+              entry: [
+                { resource: matching_resource.to_hash },
+                { resource: matching_resource2.to_hash }
+              ]
+            ).to_json
 
           stub_request(:post, post_request.url)
             .with(body: {patient: patient_ids})

--- a/spec/us_core/granular_scope_checker_spec.rb
+++ b/spec/us_core/granular_scope_checker_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe USCoreTestKit::GranularScopeChecker do
               test_session_id: test_session.id
             ),
             tags: ['Condition?patient'],
-            request_body: {patient: patient_ids}.to_json,
+            request_body: URI.encode_www_form({patient: patient_ids}),
             response_body: FHIR::Bundle.new(
               entry: [
                 { resource: matching_resource.to_hash },


### PR DESCRIPTION
# Summary
Added inspection of request body if it is a POST request for query parameters.

Wondering about if we will ever expect more in the body than query parameters, i.e. should there be more thorough parsing/decision making here?

Also want to check that POST searches are made to an endpoint that ends in `\_search` every time?  The current spec test uses that endpoint, and I don't think it would impact the functionality, but the spec test wouldn't pass until I added that into the url (fhir_search must automatically add the route when it sees it's a POST?)

# Testing Guidance
Added a spec test that stubs a post request and returns correct resources, and expects test to pass.  