### PR TITLE
FI-2425: Ignore validator error for L/min unit on Pulse Ox profile

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -64,7 +64,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Rule provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve} # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -66,7 +66,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Rule provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve} # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -76,7 +76,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Rule provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve} # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -82,7 +82,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Rule provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve} # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/us_core_test_suite.rb
@@ -86,7 +86,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Rule provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve} # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -37,7 +37,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Rule provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve} # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = <%=version_specific_message_filters%>.freeze


### PR DESCRIPTION
# Summary
This PR ignores this validator error regarding the L/min unit on the Pulse Oximetry profile.
![image](https://github.com/inferno-framework/us-core-test-kit/assets/13512036/e11a88e3-abef-4825-bcfe-4dc948b0f3ef)


This error is a known issue since US Core 3.1.1 and is documented in the IG itself: https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-pulse-oximetry.html
> STU Note
> This profile is technically non-conformant with the base FHIR ver 4.0.1 vitals profile which defines a required binding that excludes the concept for L/min for `Observation.component.value(x)`. This is a known issue in and it means validation errors may occur when validating against this version of the US Core Pulse Oximetry Profile. A change request to correct this has been applied to the base FHIR ver 4.3.0 (“Release 4B”).


This error comes from the terminology lookup so it does not occur in g10.

# Testing Guidance
In production the reference server will fail this test on every version. Confirm the appropriate test passes for the Pulse Ox profile in each version.
Should the message filter be made more specific?
