### PR TITLE
Fix homepage url on RubyGems

### DIFF
--- a/us_core_test_kit.gemspec
+++ b/us_core_test_kit.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['inferno@groups.mitre.org']
   spec.summary       = 'US Core Inferno tests'
   spec.description   = 'US Core Inferno tests'
-  spec.homepage      = 'https://github.com/inferno_framework/us-core-test-kit'
+  spec.homepage      = 'https://github.com/inferno-framework/us-core-test-kit'
   spec.license       = 'Apache-2.0'
   spec.add_runtime_dependency 'inferno_core', '>= 0.4.2'
   spec.add_runtime_dependency 'smart_app_launch_test_kit', '>= 0.4.0'

--- a/us_core_test_kit.gemspec
+++ b/us_core_test_kit.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.11'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.1.2')
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/inferno_framework/us-core-test-kit'
+  spec.metadata['source_code_uri'] = 'https://github.com/inferno-framework/us-core-test-kit'
   spec.files = [
     Dir['lib/**/*.rb'],
     Dir['lib/**/*.json'],


### PR DESCRIPTION
# Summary

Underscore/dash shenanigans broke the homepage url link: <https://rubygems.org/gems/us_core_test_kit>.

Though I might be the only person using RubyGems search engine over Google's or GitHub's.

# Testing Guidance

`gem build us_core_test_kit.gemspec` for now. I'll check the link sometime after the next release.
