### PR TITLE
FI-2611 Fix MustSupport issue on Coverage.identifier:membershipid.type

### DIFF
--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -84,7 +84,7 @@ module USCoreTestKit
             slice_value&.any? { |coding| coding.code == discriminator[:code] && coding.system == discriminator[:system] }
           when 'patternCoding'
             slice_value = discriminator[:path].present? ? slice.send(discriminator[:path]) : slice
-            slice_value&.code == discriminator[:code] && slice_value.system == discriminator[:system]
+            slice_value&.code == discriminator[:code] && slice_value&.system == discriminator[:system]
           when 'patternIdentifier'
             slice.identifier.system == discriminator[:system]
           when 'value'

--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -80,11 +80,11 @@ module USCoreTestKit
         slices.find do |slice|
           case discriminator[:type]
           when 'patternCodeableConcept'
-            slice_value = discriminator[:path].present? ? slice.send("#{discriminator[:path]}").coding : slice.coding
-            slice_value.any? { |coding| coding.code == discriminator[:code] && coding.system == discriminator[:system] }
+            slice_value = discriminator[:path].present? ? slice.send("#{discriminator[:path]}")&.coding : slice.coding
+            slice_value&.any? { |coding| coding.code == discriminator[:code] && coding.system == discriminator[:system] }
           when 'patternCoding'
             slice_value = discriminator[:path].present? ? slice.send(discriminator[:path]) : slice
-            slice_value.code == discriminator[:code] && slice_value.system == discriminator[:system]
+            slice_value&.code == discriminator[:code] && slice_value.system == discriminator[:system]
           when 'patternIdentifier'
             slice.identifier.system == discriminator[:system]
           when 'value'

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -102,7 +102,6 @@ module USCoreTestKit
           resources.none? do |resource|
             path = element_definition[:path] #.delete_suffix('[x]')
             value_found = find_a_value_at(resource, path) do |value|
-
               value_without_extensions =
                 value.respond_to?(:to_hash) ? value.to_hash.reject { |key, _| key == 'extension' } : value
 

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -101,9 +101,7 @@ module USCoreTestKit
         must_support_elements.select do |element_definition|
           resources.none? do |resource|
             path = element_definition[:path] #.delete_suffix('[x]')
-            #binding.pry if path == 'identifier:memberid.type'
             value_found = find_a_value_at(resource, path) do |value|
-              #binding.pry if path == 'identifier:memberid.type'
 
               value_without_extensions =
                 value.respond_to?(:to_hash) ? value.to_hash.reject { |key, _| key == 'extension' } : value
@@ -112,7 +110,6 @@ module USCoreTestKit
                 (element_definition[:fixed_value].blank? || value == element_definition[:fixed_value])
 
             end
-            #binding.pry if path == 'identifier:memberid.type'
             # Note that false.present? => false, which is why we need to add this extra check
             value_found.present? || value_found == false
           end

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -101,7 +101,10 @@ module USCoreTestKit
         must_support_elements.select do |element_definition|
           resources.none? do |resource|
             path = element_definition[:path] #.delete_suffix('[x]')
+            #binding.pry if path == 'identifier:memberid.type'
             value_found = find_a_value_at(resource, path) do |value|
+              #binding.pry if path == 'identifier:memberid.type'
+
               value_without_extensions =
                 value.respond_to?(:to_hash) ? value.to_hash.reject { |key, _| key == 'extension' } : value
 
@@ -109,6 +112,7 @@ module USCoreTestKit
                 (element_definition[:fixed_value].blank? || value == element_definition[:fixed_value])
 
             end
+            #binding.pry if path == 'identifier:memberid.type'
             # Note that false.present? => false, which is why we need to add this extra check
             value_found.present? || value_found == false
           end

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe USCoreTestKit::MustSupportTest do
   end
 
   describe 'must support test for slices' do
-    context 'slicing with pattern' do
+    context 'slicing with patternCodeableConcept' do
       let(:care_plan_must_support_test) { Inferno::Repositories::Tests.new.find('us_core_v311_care_plan_must_support_test')}
       let(:careplan) do
         FHIR::CarePlan.new(
@@ -205,6 +205,99 @@ RSpec.describe USCoreTestKit::MustSupportTest do
 
         expect(result.result).to eq('skip')
         expect(result.result_message).to include('CarePlan.category:AssessPlan')
+      end
+    end
+
+    context 'slicing with patternCodeableConcept and mulitple codings' do
+      let(:test_class) { USCoreTestKit::USCoreV610::CoverageMustSupportTest }
+      let(:coverage) do
+        FHIR::Coverage.new(
+          identifier: [
+            {
+              system: 'urn:oid:1.2.840.114350.1.13.1545.1.7.2.678671',
+              value: '1967'
+            },
+            {
+              type: {
+                coding: [
+                  {
+                    system: 'http://terminology.hl7.org/CodeSystem/v2-0203',
+                    code: 'MB',
+                    display: 'Member Number'
+                  }
+                ]
+              },
+              value: '421800514A'
+            }
+          ],
+          status: 'active',
+          type: {
+            coding: [
+              {
+                system: 'http://open.epic.com/FHIR/StructureDefinition/coverage-type',
+                code: 'medicare'
+              }
+            ]
+          },
+          subscriberId: '421800514A',
+          beneficiary: {
+            reference: 'Patient/eYYYYYYYYYYYYYYYYYYYYYY3'
+          },
+          relationship: {
+            coding: [
+              {
+                system: 'urn:oid:1.2.840.114350.1.13.1545.1.7.10.678671.305',
+                code: '01'
+              }
+            ]
+          },
+          period: {
+            start: '2022-03-04'
+          },
+          payor: [
+            {
+              reference: 'Organization/eFFFFFFFFFFFFFFFFFFFFFF3'
+            }
+          ],
+          class: [
+            {
+              type: {
+                coding: [
+                  {
+                    system: 'http://terminology.hl7.org/CodeSystem/coverage-class',
+                    code: 'plan'
+                  }
+                ]
+              },
+              value: '10603',
+              name: 'MEDICARE PART A & B'
+            },
+            {
+              type: {
+                coding: [
+                  {
+                    system: 'http://terminology.hl7.org/CodeSystem/coverage-class',
+                    code: 'group'
+                  }
+                ]
+              },
+              value: '123',
+              name: 'group'
+            }
+          ],
+        )
+      end
+
+      it 'passes if server suports all MS slices' do
+        allow_any_instance_of(test_class)
+          .to receive(:scratch_resources).and_return(
+            {
+              all: [coverage]
+            }
+          )
+
+        result = run(test_class)
+        expect(result.result).to eq('pass')
       end
     end
 
@@ -593,17 +686,17 @@ RSpec.describe USCoreTestKit::MustSupportTest do
       USCoreTestKit::USCoreV610::CoverageMustSupportTest
     }
     let (:group_class) {
-      FHIR::Coverage::Class.new.tap{ |loc_class|
-        loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
-          code_concept.coding = [FHIR::Coding.new.tap{ |coding|
-            coding.system = "http://terminology.hl7.org/CodeSystem/coverage-class"
-            coding.code = "group"
-          }]
-        }
-        loc_class.value = "group-class-value"
-        loc_class.name = "group-class-name"
-        }
-    }
+        FHIR::Coverage::Class.new.tap{ |loc_class|
+          loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
+            code_concept.coding = [FHIR::Coding.new.tap{ |coding|
+              coding.system = "http://terminology.hl7.org/CodeSystem/coverage-class"
+              coding.code = "group"
+            }]
+          }
+          loc_class.value = "group-class-value"
+          loc_class.name = "group-class-name"
+          }
+      }
     let (:plan_class) {
       FHIR::Coverage::Class.new.tap{ |loc_class|
         loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
@@ -709,5 +802,4 @@ RSpec.describe USCoreTestKit::MustSupportTest do
         expect(result.result).to eq('pass')
     end
   end
-
 end

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -214,8 +214,8 @@ RSpec.describe USCoreTestKit::MustSupportTest do
         FHIR::Coverage.new(
           identifier: [
             {
-              system: 'urn:oid:1.2.840.114350.1.13.1545.1.7.2.678671',
-              value: '1967'
+              system: 'local-id',
+              value: '123'
             },
             {
               type: {
@@ -227,26 +227,26 @@ RSpec.describe USCoreTestKit::MustSupportTest do
                   }
                 ]
               },
-              value: '421800514A'
+              value: 'member-id'
             }
           ],
           status: 'active',
           type: {
             coding: [
               {
-                system: 'http://open.epic.com/FHIR/StructureDefinition/coverage-type',
+                system: 'local-type',
                 code: 'medicare'
               }
             ]
           },
-          subscriberId: '421800514A',
+          subscriberId: 'abc',
           beneficiary: {
-            reference: 'Patient/eYYYYYYYYYYYYYYYYYYYYYY3'
+            reference: 'Patient/1'
           },
           relationship: {
             coding: [
               {
-                system: 'urn:oid:1.2.840.114350.1.13.1545.1.7.10.678671.305',
+                system: 'local-relationship',
                 code: '01'
               }
             ]
@@ -256,7 +256,7 @@ RSpec.describe USCoreTestKit::MustSupportTest do
           },
           payor: [
             {
-              reference: 'Organization/eFFFFFFFFFFFFFFFFFFFFFF3'
+              reference: 'Organization/1'
             }
           ],
           class: [

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -686,17 +686,17 @@ RSpec.describe USCoreTestKit::MustSupportTest do
       USCoreTestKit::USCoreV610::CoverageMustSupportTest
     }
     let (:group_class) {
-        FHIR::Coverage::Class.new.tap{ |loc_class|
-          loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
-            code_concept.coding = [FHIR::Coding.new.tap{ |coding|
-              coding.system = "http://terminology.hl7.org/CodeSystem/coverage-class"
-              coding.code = "group"
-            }]
-          }
-          loc_class.value = "group-class-value"
-          loc_class.name = "group-class-name"
-          }
+      FHIR::Coverage::Class.new.tap{ |loc_class|
+        loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|
+          code_concept.coding = [FHIR::Coding.new.tap{ |coding|
+            coding.system = "http://terminology.hl7.org/CodeSystem/coverage-class"
+            coding.code = "group"
+          }]
+        }
+        loc_class.value = "group-class-value"
+        loc_class.name = "group-class-name"
       }
+    }
     let (:plan_class) {
       FHIR::Coverage::Class.new.tap{ |loc_class|
         loc_class.type = FHIR::CodeableConcept.new.tap{ |code_concept|


### PR DESCRIPTION
# Summary
This PR fixes https://oncprojectracking.healthit.gov/support/browse/FI-2611

# Change Log:
* Avoid NoMethodFound error when an element does not have expected children path 
* Add unit test with specific usecase

# Testing Guidance
* All unit tests SHALL pass

