### PR TITLE
FI-2687 Skip find search values from primitive extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ WORKDIR $INSTALL_PATH
 ADD *.gemspec $INSTALL_PATH
 ADD Gemfile* $INSTALL_PATH
 ADD lib/us_core_test_kit/version.rb $INSTALL_PATH/lib/us_core_test_kit/version.rb
+RUN gem update --system
 RUN gem install bundler
-# The below RUN line is commented out for development purposes, because any change to the 
+# The below RUN line is commented out for development purposes, because any change to the
 # required gems will break the dockerfile build process.
-# If you want to run in Deploy mode, just run `bundle install` locally to update 
+# If you want to run in Deploy mode, just run `bundle install` locally to update
 # Gemfile.lock, and uncomment the following line.
 # RUN bundle config set --local deployment 'true'
 RUN bundle install

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -676,6 +676,8 @@ module USCoreTestKit
         (element.family || element.given&.first || element.text).present?
       when FHIR::Address
         (element.text || element.city || element.state || element.postalCode || element.country).present?
+      when FHIR::Element
+        false
       else
         true
       end

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -796,6 +796,65 @@ RSpec.describe USCoreTestKit::SearchTest do
       expect(params['category']).to be_nil
       expect(params['date']).to be_nil
     end
+
+    it 'skips primitive with extensions' do
+      resource_with_category.source_hash['_date'] = {
+        'extension' => [
+          {
+            'url' => 'http://example.com/extension',
+            'valueString' => 'value'
+          }
+        ]
+      }
+
+      new_resource = FHIR::DocumentReference.new(resource_with_category.source_hash)
+
+      expect(new_resource.source_hash).to have_key('_date')
+
+      allow_any_instance_of(test_class)
+        .to receive(:scratch_resources_for_patient).and_return(
+          [
+            new_resource
+          ]
+        )
+
+      params = test.search_params_with_values(test.search_param_names, patient_id)
+
+      expect(params).to_not be_empty
+      expect(params['patient']).to eq(patient_id)
+      expect(params['category']).to eq(new_resource.category.first.coding.first.code)
+      expect(params['date']).to be_nil
+    end
+
+    it 'skips primitive with extensions and returns value from another resource' do
+      resource_with_category.source_hash['_date'] = {
+        'extension' => [
+          {
+            'url' => 'http://example.com/extension',
+            'valueString' => 'value'
+          }
+        ]
+      }
+
+      new_resource = FHIR::DocumentReference.new(resource_with_category.source_hash)
+
+      expect(new_resource.source_hash).to have_key('_date')
+
+      allow_any_instance_of(test_class)
+        .to receive(:scratch_resources_for_patient).and_return(
+          [
+            new_resource,
+            resource_with_category_date
+          ]
+        )
+
+      params = test.search_params_with_values(test.search_param_names, patient_id)
+
+      expect(params).to_not be_empty
+      expect(params['patient']).to eq(patient_id)
+      expect(params['category']).to eq(category_code)
+      expect(params['date']).to eq(date)
+    end
   end
 
   describe '#search_param_value' do

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -838,8 +838,6 @@ RSpec.describe USCoreTestKit::SearchTest do
 
       new_resource = FHIR::DocumentReference.new(resource_with_category.source_hash)
 
-      expect(new_resource.source_hash).to have_key('_date')
-
       allow_any_instance_of(test_class)
         .to receive(:scratch_resources_for_patient).and_return(
           [


### PR DESCRIPTION
# Summary

This fixes JIRA FHIR-2687. The problem happens when search parameter targets a primitive value and the resource has an extension on the primitive, for example, instead of 

```
"date": "2024-01-01"
```

server pupulates `date` with extension:

```
"_date": {
  "extension": [ {
    "url": "http://example.com/extension",
    "valueString": "value"
  }]
}
```

When Infenro extract search values from returned resourcee, Inferno locates the primitive and tries to conver the "primitve value" into a string. When the value is actually an extension, as shown above, the `to_s` fails.

# Change Logs:
* Fix search_param_value method so that when the element is a type of Element is skip. This is based on that all search parameters target concrete data types. Data type Element is the base class and not used in any profile directly. The only usage in Inferno US Core test kit is when the navigator sees a primitive extension, it converts that into an Element with extension.
* Add two unit tests to verify that search value is retrieved when primitive has extension
* Update Dockerfile to run `gem update` before `gem install`

# Testing Guidance
* All unit tests shall pass
* Take reference server PR: https://github.com/inferno-framework/inferno-reference-server/pull/147 to load QuestionnaireResources to reference server
* Run US Core Test Suite for v6.1.0.
* QuestionnaireResponse test group shall pass

