### PR TITLE
FI-2456: Verify granular scopes

### DIFF
--- a/lib/us_core_test_kit/custom_groups/base_smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/base_smart_granular_scopes_group.rb
@@ -5,6 +5,7 @@ require_relative './smart_scopes_constants'
 require_relative './smart_standalone_launch_stu2_group'
 require_relative '../granular_scope_checker'
 require_relative '../us_core_options'
+require_relative './granted_granular_scopes_test'
 
 module USCoreTestKit
   class BaseSmartGranularScopesGroup < Inferno::TestGroup
@@ -52,8 +53,7 @@ module USCoreTestKit
             smart_credentials: {
               name: :granular_scopes_1_credentials
             }
-          }
-        )
+          }        )
         group from: :us_core_smart_standalone_launch_stu2,
               optional: true,
               config: {
@@ -62,7 +62,16 @@ module USCoreTestKit
                     name: :granular_scopes_1_credentials
                   }
                 }
-              }
+              } do
+          groups[1].test from: :us_core_granted_granular_scopes,
+                         config: {
+                           inputs: {
+                             received_scopes: {
+                               name: :standalone_received_scopes
+                             }
+                           }
+                         }
+        end
         group from: :us_core_smart_ehr_launch_stu2,
               optional: true,
               config: {
@@ -71,9 +80,16 @@ module USCoreTestKit
                     name: :granular_scopes_1_credentials
                   }
                 }
-              }
-
-        # TODO: verify that all required scopes were requested and received
+              } do
+          groups[1].test from: :us_core_granted_granular_scopes,
+                         config: {
+                           inputs: {
+                             received_scopes: {
+                               name: :ehr_received_scopes
+                             }
+                           }
+                         }
+        end
       end
     end
 
@@ -103,7 +119,16 @@ module USCoreTestKit
                     name: :granular_scopes_2_credentials
                   }
                 }
-              }
+              } do
+          groups[1].test from: :us_core_granted_granular_scopes,
+                         config: {
+                           inputs: {
+                             received_scopes: {
+                               name: :standalone_received_scopes
+                             }
+                           }
+                         }
+        end
 
 
         group from: :us_core_smart_ehr_launch_stu2,
@@ -114,10 +139,16 @@ module USCoreTestKit
                     name: :granular_scopes_2_credentials
                   }
                 }
-              }
-
-
-        # TODO: verify that all required scopes were requested and received
+              } do
+          groups[1].test from: :us_core_granted_granular_scopes,
+                         config: {
+                           inputs: {
+                             received_scopes: {
+                               name: :ehr_received_scopes
+                             }
+                           }
+                         }
+        end
       end
     end
   end

--- a/lib/us_core_test_kit/custom_groups/granted_granular_scopes_test.rb
+++ b/lib/us_core_test_kit/custom_groups/granted_granular_scopes_test.rb
@@ -1,0 +1,60 @@
+module USCoreTestKit
+  class GrantedGranularScopesTest < Inferno::Test
+    id :us_core_granted_granular_scopes
+    title 'Required granular scopes were granted'
+
+    description %()
+
+    input :received_scopes
+
+    run do
+      required_granular_scopes =
+        config
+          .options[:required_scopes]
+          .map { |scope| scope[scope.index('/') + 1, scope.length] }
+
+      received_granular_scopes =
+        received_scopes
+          .split(' ')
+          .select { |scope| scope.include? '?' }
+          .map { |scope| scope[scope.index('/') + 1, scope.length] }
+
+      missing_scopes = required_granular_scopes - received_granular_scopes
+
+      wrapped_missing_scopes = missing_scopes.map { |scope| "`#{scope}`" }
+
+      assert missing_scopes.empty?,
+             "The following granular scopes were not granted: #{wrapped_missing_scopes.to_sentence}"
+
+      granular_scope_resource_types =
+        required_granular_scopes
+          .map { |scope| scope.split('.').first }
+          .uniq
+
+      received_resource_level_scopes =
+        received_scopes
+          .split(' ')
+          .reject { |scope| scope.include? '?' }
+          .map { |scope| scope[scope.index('/') + 1, scope.length] }
+          .select { |scope| granular_scope_resource_types.include? scope[0, scope.index('.')] }
+
+      wrapped_resource_scopes = received_resource_level_scopes.map { |scope| "`#{scope}`" }
+
+      assert received_resource_level_scopes.empty?,
+             'Can not verify the behavior of granular scopes because the following resource-level scopes were ' \
+             "granted: #{wrapped_resource_scopes.to_sentence}"
+
+      received_wildcard_scopes =
+        received_scopes
+          .split(' ')
+          .select { |scope| scope.match? %r{\A(user|patient|system|\*)/\*} }
+
+      wrapped_wildcard_scopes = received_wildcard_scopes.map { |scope| "`#{scope}`" }
+
+      assert received_wildcard_scopes.empty?,
+             'Can not verify the behavior of granular scopes because the following wildcard scopes were ' \
+             "granted: #{wrapped_wildcard_scopes.to_sentence}"
+
+    end
+  end
+end

--- a/lib/us_core_test_kit/custom_groups/granted_granular_scopes_test.rb
+++ b/lib/us_core_test_kit/custom_groups/granted_granular_scopes_test.rb
@@ -35,6 +35,7 @@ module USCoreTestKit
         received_scopes
           .split(' ')
           .reject { |scope| scope.include? '?' }
+          .select { |scope| scope.match? %r{\A(user|patient|system|\*)/.+\..+} }
           .map { |scope| scope[scope.index('/') + 1, scope.length] }
           .select { |scope| granular_scope_resource_types.include? scope[0, scope.index('.')] }
 

--- a/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
@@ -10,8 +10,8 @@ module USCoreTestKit
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory',
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|social-history',
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs',
-          'patient.Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey',
-          'patient.Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh'
+          'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey',
+          'patient/Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh'
         ].map(&:freeze).freeze,
       'v700_ballot' => [
           'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis',

--- a/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
@@ -1,5 +1,6 @@
 require_relative '../base_smart_granular_scopes_group'
 require_relative '../smart_scopes_constants'
+require_relative '../granted_granular_scopes_test'
 require_relative '../../generated/v6.1.0/granular_scopes1_group'
 
 module USCoreTestKit
@@ -82,7 +83,19 @@ above scopes.
                     name: :granular_scopes_1_credentials
                   }
                 }
-              }
+              } do
+          groups[1].test from: :us_core_granted_granular_scopes,
+                         config: {
+                           inputs: {
+                             received_scopes: {
+                               name: :standalone_received_scopes
+                             }
+                           },
+                           options: {
+                             required_scopes: SMART_GRANULAR_SCOPES_GROUP1['v610']
+                           }
+                         }
+        end
         group from: :us_core_smart_ehr_launch_stu2,
               optional: true,
               config: {
@@ -91,9 +104,19 @@ above scopes.
                     name: :granular_scopes_1_credentials
                   }
                 }
-              }
-
-        # TODO: verify that all required scopes were requested and received
+              } do
+          groups[1].test from: :us_core_granted_granular_scopes,
+                         config: {
+                           inputs: {
+                             received_scopes: {
+                               name: :ehr_received_scopes
+                             }
+                           },
+                           options: {
+                             required_scopes: SMART_GRANULAR_SCOPES_GROUP1['v610']
+                           }
+                         }
+        end
       end
 
       group from: :us_core_v610_smart_granular_scopes_1,

--- a/lib/us_core_test_kit/custom_groups/v7.0.0-ballot/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v7.0.0-ballot/smart_granular_scopes_group.rb
@@ -43,6 +43,9 @@ above scopes.
               name: :requested_scopes_group1,
               default: groups.first.default_group_scopes('v700_ballot')
             }
+          },
+          options: {
+            required_scopes: SMART_GRANULAR_SCOPES_GROUP1['v700_ballot']
           }
         )
 
@@ -70,6 +73,9 @@ above scopes.
               name: :requested_scopes_group2,
               default: groups.last.default_group_scopes('v700_ballot')
             }
+          },
+          options: {
+            required_scopes: SMART_GRANULAR_SCOPES_GROUP2['v700_ballot']
           }
         )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scopes1_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scopes1_group.rb
@@ -18,8 +18,8 @@ based on the following granular scopes:
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|social-history`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs`
-* `patient.Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`
-* `patient.Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh`
+* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`
+* `Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh`
 
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope1_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope1_group.rb
@@ -17,6 +17,8 @@ based on the following granular scopes:
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|social-history`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs`
+* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`
+* `Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh`
 
       )
 

--- a/spec/us_core/granted_granular_scopes_test_spec.rb
+++ b/spec/us_core/granted_granular_scopes_test_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe USCoreTestKit::GrantedGranularScopesTest do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('us_core_v400') }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:required_scopes) { USCoreTestKit::SmartScopesConstants::SMART_GRANULAR_SCOPES_GROUP1['v610'] }
+  let(:test) do
+    described_class.config(options: { required_scopes: })
+    described_class
+  end
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name: name,
+        value: value,
+        type: runnable.config.input_type(name)
+      )
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  it 'passes if all required scopes were received' do
+    received_scopes = required_scopes.map { |scope| scope.gsub('patient/', 'user/') }.join(' ')
+
+    result = run(test, received_scopes:)
+
+    expect(result.result).to eq('pass')
+  end
+
+  it 'fails if not all required scopes were received' do
+    received_scopes = required_scopes.dup
+    missing_scope = received_scopes.pop.delete_prefix('patient/')
+
+    result = run(test, received_scopes: received_scopes.join(' '))
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to include(missing_scope)
+  end
+
+  it 'fails if resource-level scopes are granted' do
+    resource_level_scopes = ['patient/Condition.rs', 'patient/Patient.rs']
+    received_scopes = required_scopes + resource_level_scopes
+
+    result = run(test, received_scopes: received_scopes.join(' '))
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to include(resource_level_scopes.first.delete_prefix('patient/') )
+    expect(result.result_message).to_not include(resource_level_scopes.last.delete_prefix('patient/') )
+  end
+
+  it 'fails if wildcard scopes are granted' do
+    wildcard_scopes = ['patient/*.rs', '*/*.*']
+    received_scopes = required_scopes + wildcard_scopes
+
+    result = run(test, received_scopes: received_scopes.join(' '))
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to include(wildcard_scopes.first )
+    expect(result.result_message).to include(wildcard_scopes.last )
+  end
+end

--- a/spec/us_core/granted_granular_scopes_test_spec.rb
+++ b/spec/us_core/granted_granular_scopes_test_spec.rb
@@ -23,7 +23,11 @@ RSpec.describe USCoreTestKit::GrantedGranularScopesTest do
   end
 
   it 'passes if all required scopes were received' do
-    received_scopes = required_scopes.map { |scope| scope.gsub('patient/', 'user/') }.join(' ')
+    received_scopes =
+      required_scopes
+        .map { |scope| scope.gsub('patient/', 'user/') }
+        .join(' ')
+        .concat(' launch/patient openid')
 
     result = run(test, received_scopes:)
 


### PR DESCRIPTION
# Summary
This branch adds tests to verify that the required granular scopes were granted.

# Testing Guidance
Run one of the granular scope launches against the reference server. When the reference server allows you to select which scopes to grant, deselect some of the granular scopes, and test will fail.