### PR TITLE
FI-2171 Remove Practitioner from SEARCHABLE_DELAYED_RESOURCES

### DIFF
--- a/lib/us_core_test_kit/generator/group_metadata.rb
+++ b/lib/us_core_test_kit/generator/group_metadata.rb
@@ -56,7 +56,7 @@ module USCoreTestKit
       end
 
       def no_patient_searches?
-        searches.none? { |search| search[:names].include? 'patient' }
+        searches.none? { |search| search[:names].include?('patient') && search[:expectation] == 'SHALL' }
       end
 
       def non_uscdi_resource?

--- a/lib/us_core_test_kit/generator/special_cases.rb
+++ b/lib/us_core_test_kit/generator/special_cases.rb
@@ -25,16 +25,14 @@ module USCoreTestKit
         'Encounter' => ['v311', 'v400'],
         'Location' => ['v311', 'v400', 'v501', 'v610'],
         'Organization' => ['v311', 'v400', 'v501', 'v610', 'v700_ballot'],
-        'Practitioner' => ['v311', 'v400'],
+        'Practitioner' => ['v311', 'v400', 'v501', 'v610', 'v700_ballot'],
         'PractitionerRole' => ['v311', 'v400', 'v501', 'v610', 'v700_ballot'],
         'Provenance' => ['v311', 'v400', 'v501', 'v610', 'v700_ballot'],
-        'RelatedPerson' => ['v501', 'v610', 'v700_ballot'],
-        'Specimen' => ['v610', 'v700_ballot']
+        'RelatedPerson' => ['v501', 'v610', 'v700_ballot']
       }.freeze
 
       SEARCHABLE_DELAYED_RESOURCES = {
-        'Location' => ['v700_ballot'],
-        'Practitioner' => ['v501', 'v610', 'v700_ballot']
+        'Location' => ['v700_ballot']
       }.freeze
 
       ALL_VERSION_CATEGORY_FIRST_PROFILES = [


### PR DESCRIPTION
# Summary

This PR fixes GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/510

# Change Log
* Move Practitioner from `SEARCHABLE_DELAYED_RESOURCES` to `NON_USCDI_RESOURCE`
* Remove Specimen from `NON_USCDI_RESOURCE` because it is a USCDI v3 data element.
* Update group_metadata logic so that not mandatory patient searches (the one in Specimen) are counted as `no_patient_search`

# Testing Guidance
This can be only tested in (g)(10) test kit. 
* Add us-core-test-kit path to g10 test kit's gem file:
  * ```gem 'us_core_test_kit', path: '[path_to]/us-core-test-kit'```
* Run `bundle install`, `inferno service start`, `inferno start`
* Start G10 test with US Core v6.1.0.
* Verify that Practitioner test group (10.41) does not have any search tests.
* Verify that Specimen test group (10.44) does not have any search tests

