### PR TITLE
Use default validator env var

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,3 @@
-V311_FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
-V400_FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
-V501_FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
-V610_FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
-V700_BALLOT_FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
 INFERNO_HOST=http://localhost:4567
 REDIS_URL=redis://localhost:6379/0

--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,3 @@
 REDIS_URL=redis://redis:6379/0
 INFERNO_HOST=http://localhost
-V311_FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
-V400_FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
-V501_FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
-V610_FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
-V700_BALLOT_FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
+FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     volumes:
       - ./data:/opt/inferno/data
     depends_on:
-      - validator_service
+      - hl7_validator_service
+      # - validator_service
   worker:
     build:
       context: ./

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -80,7 +80,6 @@ module USCoreTestKit
       id :us_core_v311
 
       fhir_resource_validator do
-        url ENV.fetch('V311_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
         igs 'hl7.fhir.us.core#3.1.1'
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -82,7 +82,6 @@ module USCoreTestKit
       id :us_core_v400
 
       fhir_resource_validator do
-        url ENV.fetch('V400_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
         igs 'hl7.fhir.us.core#4.0.0'
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -92,7 +92,6 @@ module USCoreTestKit
       id :us_core_v501
 
       fhir_resource_validator do
-        url ENV.fetch('V501_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
         igs 'hl7.fhir.us.core#5.0.1'
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -98,7 +98,6 @@ module USCoreTestKit
       id :us_core_v610
 
       fhir_resource_validator do
-        url ENV.fetch('V610_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
         igs 'hl7.fhir.us.core#6.1.0'
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/us_core_test_suite.rb
@@ -102,7 +102,6 @@ module USCoreTestKit
       id :us_core_v700_ballot
 
       fhir_resource_validator do
-        url ENV.fetch('V700_BALLOT_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
         igs 'hl7.fhir.us.core#7.0.0-ballot'
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 

--- a/lib/us_core_test_kit/generator/suite_generator.rb
+++ b/lib/us_core_test_kit/generator/suite_generator.rb
@@ -57,10 +57,6 @@ module USCoreTestKit
         "US Core #{ig_metadata.ig_version}"
       end
 
-      def validator_env_name
-        "#{ig_metadata.reformatted_version.upcase}_FHIR_RESOURCE_VALIDATOR_URL"
-      end
-
       def ig_identifier
         version = ig_metadata.ig_version[1..] # Remove leading 'v'
         "hl7.fhir.us.core##{version}"

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -53,7 +53,6 @@ module USCoreTestKit
       id :<%= suite_id %>
 
       fhir_resource_validator do
-        url ENV.fetch('<%= validator_env_name %>', 'http://hl7_validator_service:3500')
         igs '<%= ig_identifier %>'
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 


### PR DESCRIPTION
# Summary
Follow-on to #168 . Standardizes the environment variables used for the different test suites, now we can just use the default `FHIR_RESOURCE_VALIDATOR_URL` and remove the `url` line from the validator definition block

Also fixes the docker-compose file to allow running fully in docker, whoops.

# Testing Guidance
There should be no visible impact to the env var change - sessions should start up and work when running via ruby or via docker