### PR TITLE
FI-2762 Add PrimitiveType class

### DIFF
--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -68,14 +68,14 @@ module USCoreTestKit
         slice
       else
         value = element.send(property)
-        primitive_value = get_primitive_value(element, property, value)
+        primitive_value = get_primitive_type_value(element, property, value)
         primitive_value.present? ? primitive_value : value
       end
     rescue NoMethodError
       nil
     end
 
-    def get_primitive_value(element, property, value)
+    def get_primitive_type_value(element, property, value)
       source_value = element.source_hash["_#{property}"]
 
       return nil unless source_value.present?

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -115,12 +115,13 @@ module USCoreTestKit
               .map { |ex| ex[:url] }
 
             value_found = find_a_value_at(resource, path) do |value|
-              if value.respond_to?(:extension) && ms_extension_urls.present?
-                urls = value.extension.map(&:url)
+              if value.instance_of?(USCoreTestKit::PrimitiveType) && ms_extension_urls.present?
+                urls = value.extension&.map(&:url)
                 has_ms_extension = (urls & ms_extension_urls).present?
               end
 
               unless has_ms_extension
+                value = value.value if value.instance_of?(USCoreTestKit::PrimitiveType)
                 value_without_extensions =
                   value.respond_to?(:to_hash) ? value.to_hash.reject { |key, _| key == 'extension' } : value
               end

--- a/lib/us_core_test_kit/primitive_type.rb
+++ b/lib/us_core_test_kit/primitive_type.rb
@@ -1,0 +1,5 @@
+module USCoreTestKit
+  class PrimitiveType < FHIR::Element
+    attr_accessor :value
+  end
+end

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -629,6 +629,8 @@ module USCoreTestKit
             element.family || element.given&.first || element.text
           when FHIR::Address
             element.text || element.city || element.state || element.postalCode || element.country
+          when USCoreTestKit::PrimitiveType
+            element.value
           else
             if metadata.version != 'v3.1.1' &&
                metadata.search_definitions[name.to_sym][:type] == 'date' &&
@@ -676,8 +678,8 @@ module USCoreTestKit
         (element.family || element.given&.first || element.text).present?
       when FHIR::Address
         (element.text || element.city || element.state || element.postalCode || element.country).present?
-      when FHIR::Element
-        false
+      when USCoreTestKit::PrimitiveType
+        element.value.present?
       else
         true
       end

--- a/spec/fixtures/QuestionnaireResponse.json
+++ b/spec/fixtures/QuestionnaireResponse.json
@@ -5,6 +5,7 @@
       "value": "identifier"
     }
   ],
+  "questionnaire": "http://example.com/questionnaire-1",
   "_questionnaire" : {
     "extension" : [
       {

--- a/spec/us_core/must_support_test_spec.rb
+++ b/spec/us_core/must_support_test_spec.rb
@@ -505,7 +505,6 @@ RSpec.describe USCoreTestKit::MustSupportTest do
               }
             )
 
-
           result = run(test_class)
           expect(result.result).to eq('pass')
         end
@@ -835,6 +834,25 @@ RSpec.describe USCoreTestKit::MustSupportTest do
       expect(result.result).to eq('skip')
       expect(result.result_message).to include('QuestionnaireResponse.questionnaire.extension:questionnaireDisplay')
       expect(result.result_message).to include('QuestionnaireResponse.questionnaire.extension:url')
+    end
+
+    it 'skips if both MS extensions and MS element in a primitive are not provided' do
+      qr.source_hash['_questionnaire']['extension'][0]['url'] = 'http://example.com/extension'
+      qr.source_hash['_questionnaire']['extension'][1]['url'] = 'http://example.com/extension'
+      new_qr = FHIR::QuestionnaireResponse.new(qr.source_hash)
+      new_qr.questionnaire = nil
+
+      allow_any_instance_of(test_class)
+        .to receive(:scratch_resources).and_return(
+          {
+            all: [new_qr]
+          }
+        )
+
+      result = run(test_class)
+      expect(result.result).to eq('skip')
+      expect(result.result_message).to include('QuestionnaireResponse.questionnaire.extension:questionnaireDisplay')
+      expect(result.result_message).to include('QuestionnaireResponse.questionnaire.extension:url')
       expect(result.result_message).to include(' questionnaire')
     end
 
@@ -852,8 +870,8 @@ RSpec.describe USCoreTestKit::MustSupportTest do
       result = run(test_class)
       expect(result.result).to eq('skip')
       expect(result.result_message).to include('QuestionnaireResponse.questionnaire.extension:questionnaireDisplay')
-      expect(result.result_message).not_to include('QuestionnaireResponse.questionnaire.extension:url')
-      expect(result.result_message).not_to include(' questionnaire')
+      expect(result.result_message).to_not include('QuestionnaireResponse.questionnaire.extension:url')
+      expect(result.result_message).to_not include(' questionnaire')
     end
 
     it 'skips if MS primitive value is missing' do

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -797,7 +797,7 @@ RSpec.describe USCoreTestKit::SearchTest do
       expect(params['date']).to be_nil
     end
 
-    it 'skips primitive with extensions' do
+    it 'skips primitive with only extensions' do
       resource_with_category.source_hash['_date'] = {
         'extension' => [
           {
@@ -824,6 +824,34 @@ RSpec.describe USCoreTestKit::SearchTest do
       expect(params['patient']).to eq(patient_id)
       expect(params['category']).to eq(new_resource.category.first.coding.first.code)
       expect(params['date']).to be_nil
+    end
+
+    it 'return primitive having both value and extensions' do
+      resource_with_category.source_hash['_date'] = {
+        'extension' => [
+          {
+            'url' => 'http://example.com/extension',
+            'valueString' => 'value'
+          }
+        ]
+      }
+
+      new_resource = FHIR::DocumentReference.new(resource_with_category.source_hash)
+      new_resource.date = '2024-01-01'
+
+      allow_any_instance_of(test_class)
+        .to receive(:scratch_resources_for_patient).and_return(
+          [
+            new_resource
+          ]
+        )
+
+      params = test.search_params_with_values(test.search_param_names, patient_id)
+
+      expect(params).to_not be_empty
+      expect(params['patient']).to eq(patient_id)
+      expect(params['category']).to eq(new_resource.category.first.coding.first.code)
+      expect(params['date']).to eq(new_resource.date)
     end
 
     it 'skips primitive with extensions and returns value from another resource' do


### PR DESCRIPTION
# Summary
This PR fixes a new issue reported on GitHub issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/411

Previous solution had an assumption that an primitive element has either value or extension but not both. This has been proved wrong.

This PR handles primitive element with either value, or extensions, or both.

# Change Log
* Add PrimitiveType inherited from FHIR::Element
* Update logic in several components to handle primitive element with both value and extension
* Update unit tests

# Testing Guidance
All unit tests shall pass
All integration tests with reference server shall pass

