### PR TITLE
FI-2790 Fix error caused by agent.who is nil

### DIFF
--- a/lib/us_core_test_kit/provenance_validator.rb
+++ b/lib/us_core_test_kit/provenance_validator.rb
@@ -19,10 +19,9 @@ module USCoreTestKit
 
       failed_provenance =
         find_a_value_at(resource, 'agent') do |agent|
-          ['Practitioner', 'Device'].any? { |resource_type| agent.who.reference&.include?(resource_type) } &&
-          agent.onBehalfOf.nil?
+          ['Practitioner', 'Device'].any? { |resource_type| agent.who&.reference&.include?(resource_type) } &&
+            agent.onBehalfOf.nil?
         end
-
 
       if failed_provenance.present?
         validation_messages << {

--- a/spec/us_core/provenance_validator_spec.rb
+++ b/spec/us_core/provenance_validator_spec.rb
@@ -1,13 +1,13 @@
 require_relative '../../lib/us_core_test_kit/provenance_validator'
 
 RSpec.describe USCoreTestKit::ProvenanceValidator do
-  let(:provenance_id){'123'}
+  let(:provenance_id) { '123' }
 
   describe '.validate' do
     it 'passes when agent.who is a Practitioner and agent.onBehalfOf exists' do
       resource = FHIR::Provenance.new(
         id: provenance_id,
-        agent:[
+        agent: [
           {
             who: {
               reference: 'Practitioner/1'
@@ -28,16 +28,16 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
     it 'passes when agent.who is a Device and agent.onBehalfOf exists' do
       resource = FHIR::Provenance.new(
         id: provenance_id,
-         agent:[
-           {
-             who: {
-               reference: 'Device/1'
-             },
-             onBehalfOf: {
-               reference: 'Organization/1'
-             }
-           }
-         ]
+        agent: [
+          {
+            who: {
+              reference: 'Device/1'
+            },
+            onBehalfOf: {
+              reference: 'Organization/1'
+            }
+          }
+        ]
       )
 
       result = described_class.validate(resource)
@@ -49,13 +49,13 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
     it 'passes when agent.who is not a Practitioner nor Device and agent.onBehalfOf does not exists' do
       resource = FHIR::Provenance.new(
         id: provenance_id,
-        agent:[
-           {
-             who: {
-               reference: 'Organization/1'
-             }
-           }
-         ]
+        agent: [
+          {
+            who: {
+              reference: 'Organization/1'
+            }
+          }
+        ]
       )
 
       result = described_class.validate(resource)
@@ -67,13 +67,13 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
     it 'fails when agent.who is a Practitioner and agent.onBehalfOf does not exists' do
       resource = FHIR::Provenance.new(
         id: provenance_id,
-        agent:[
-           {
-             who: {
-               reference: 'Practitioner/1'
-             }
-           }
-         ]
+        agent: [
+          {
+            who: {
+              reference: 'Practitioner/1'
+            }
+          }
+        ]
       )
 
       result = described_class.validate(resource)
@@ -87,13 +87,13 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
     it 'fails when agent.who is a Device and agent.onBehalfOf does not exists' do
       resource = FHIR::Provenance.new(
         id: provenance_id,
-         agent:[
-           {
-             who: {
-               reference: 'Device/1'
-             }
-           }
-         ]
+        agent: [
+          {
+            who: {
+              reference: 'Device/1'
+            }
+          }
+        ]
       )
 
       result = described_class.validate(resource)
@@ -102,6 +102,53 @@ RSpec.describe USCoreTestKit::ProvenanceValidator do
       expect(result.length).to eq(1)
       expect(result.first[:type]).to eq('error')
       expect(result.first[:message]).to start_with("Provenance/#{provenance_id}: Rule provenance-1")
+    end
+
+    it 'passes when agent.who.reference is null' do
+      resource = FHIR::Provenance.new(
+        id: provenance_id,
+        agent: [
+          {
+            who: {
+              display: 'Device/1'
+            }
+          }
+        ]
+      )
+
+      result = described_class.validate(resource)
+
+      expect(result).to be_an(Array)
+      expect(result.length).to eq(0)
+    end
+
+    it 'passes when agent.who is null' do
+      resource = FHIR::Provenance.new(
+        id: provenance_id,
+        agent: [
+          {
+            type: {
+              text: 'Author'
+            }
+          }
+        ]
+      )
+
+      result = described_class.validate(resource)
+
+      expect(result).to be_an(Array)
+      expect(result.length).to eq(0)
+    end
+
+    it 'passes when agent is null' do
+      resource = FHIR::Provenance.new(
+        id: provenance_id
+      )
+
+      result = described_class.validate(resource)
+
+      expect(result).to be_an(Array)
+      expect(result.length).to eq(0)
     end
   end
 end


### PR DESCRIPTION
# Summary
This is fix for GitHub issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/514

# Change Log
* Add & operator to agent.who
* Add unit tests to ensure when agent, agent.who, or agent.who.reference is nil, additional validation in ProvenanceValidator does not throw error

# Testing Guidance
* all unit tests pass

