### PR TITLE
FI-2818: Revert granular scope change

### DIFF
--- a/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
@@ -5,6 +5,7 @@ module USCoreTestKit
     SMART_GRANULAR_SCOPES_GROUP1 = {
       'v610' => [
           'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis',
+          'patient/Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern',
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory',
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|social-history',
         ].map(&:freeze).freeze,
@@ -24,7 +25,6 @@ module USCoreTestKit
 
     SMART_GRANULAR_SCOPES_GROUP2 = {
       'v610' => [
-          'patient/Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern',
           'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item',
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs',
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey',

--- a/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
@@ -5,13 +5,8 @@ module USCoreTestKit
     SMART_GRANULAR_SCOPES_GROUP1 = {
       'v610' => [
           'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis',
-          'patient/Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern',
-          'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item',
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory',
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|social-history',
-          'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs',
-          'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey',
-          'patient/Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh'
         ].map(&:freeze).freeze,
       'v700_ballot' => [
           'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis',
@@ -28,6 +23,13 @@ module USCoreTestKit
     }.freeze
 
     SMART_GRANULAR_SCOPES_GROUP2 = {
+      'v610' => [
+          'patient/Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern',
+          'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item',
+          'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs',
+          'patient.Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey',
+          'patient.Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh'
+      ].map(&:freeze).freeze,
       'v700_ballot' => [
           'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item',
           'patient/DiagnosticReport.rs?category=http://loinc.org|LP7839-6',

--- a/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
@@ -27,8 +27,8 @@ module USCoreTestKit
           'patient/Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern',
           'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item',
           'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs',
-          'patient.Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey',
-          'patient.Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh'
+          'patient/Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey',
+          'patient/Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh'
       ].map(&:freeze).freeze,
       'v700_ballot' => [
           'patient/Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item',

--- a/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
@@ -1,33 +1,12 @@
 require_relative '../base_smart_granular_scopes_group'
-require_relative '../smart_scopes_constants'
-require_relative '../granted_granular_scopes_test'
 require_relative '../../generated/v6.1.0/granular_scopes1_group'
+require_relative '../../generated/v6.1.0/granular_scopes2_group'
 
 module USCoreTestKit
   module USCoreV610
-    class SmartGranularScopesGroup < Inferno::TestGroup
-      include SmartScopesConstants
-      title 'US Core SMART Granular Scopes'
+    class SmartGranularScopesGroup < BaseSmartGranularScopesGroup
       id :us_core_v610_smart_granular_scopes
-
-      description <<~DESCRIPTION
-        These tests verify that servers honor [SMART App Launch granular
-        scopes](http://hl7.org/fhir/smart-app-launch/STU2/scopes-and-launch-context.html#finer-grained-resource-constraints-using-search-parameters).
-        Support for these scopes is [required in US Core
-        7](http://hl7.org/fhir/us/core/2024Jan/scopes.html#us-core-scopes).
-
-        Prior to running these tests, first run the US Core FHIR API tests using
-        resource-level scopes. This group includes a SMART App Launch followed by
-        FHIR API tests. The app launches require that a granular scopes be
-        granted. The FHIR API tests then repeat all of the queries from the
-        original FHIR API tests that were run using resource-level scopes, and
-        verify that only resources matching the granted granular scopes are
-        returned.
-      DESCRIPTION
-
-      def self.default_group_scopes(version)
-        [DEFAULT_SCOPES, *SMART_GRANULAR_SCOPES_GROUP1[version]].join(' ')
-      end
+      title 'US Core SMART Granular Scopes'
 
       def self.scopes_string(scopes)
         scopes
@@ -36,29 +15,9 @@ module USCoreTestKit
           .join("\n")
       end
 
-      config(
-        inputs: {
-          url: {
-            locked: true
-          },
-          requested_scopes: {
-            name: :requested_scopes_group1,
-            default: default_group_scopes('v610')
-          }
-        }
-      )
-
-      group do
-        title 'SMART App Launch w/Granular Scopes'
-
-        def self.scopes_string(scopes)
-          scopes
-            .map { |scope| scope.delete_prefix 'patient/' }
-            .map { |scope| "* `#{scope}`" }
-            .join("\n")
-        end
-
-        description %(
+      groups
+        .first
+        .description %(
 These tests perform a SMART app launch to receive the following granular scopes:
 
 #{scopes_string(SMART_GRANULAR_SCOPES_GROUP1['v610'])}
@@ -68,59 +27,47 @@ are repeated to verify that the results have been filtered according to the
 above scopes.
         )
 
-        config(
-          outputs: {
-            smart_credentials: {
-              name: :granular_scopes_1_credentials
+      groups
+        .first
+        .config(
+          inputs: {
+            requested_scopes: {
+              name: :requested_scopes_group1,
+              default: groups.first.default_group_scopes('v610')
             }
           }
         )
-        group from: :us_core_smart_standalone_launch_stu2,
-              optional: true,
-              config: {
-                inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_1_credentials
-                  }
-                }
-              } do
-          groups[1].test from: :us_core_granted_granular_scopes,
-                         config: {
-                           inputs: {
-                             received_scopes: {
-                               name: :standalone_received_scopes
-                             }
-                           },
-                           options: {
-                             required_scopes: SMART_GRANULAR_SCOPES_GROUP1['v610']
-                           }
-                         }
-        end
-        group from: :us_core_smart_ehr_launch_stu2,
-              optional: true,
-              config: {
-                inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_1_credentials
-                  }
-                }
-              } do
-          groups[1].test from: :us_core_granted_granular_scopes,
-                         config: {
-                           inputs: {
-                             received_scopes: {
-                               name: :ehr_received_scopes
-                             }
-                           },
-                           options: {
-                             required_scopes: SMART_GRANULAR_SCOPES_GROUP1['v610']
-                           }
-                         }
-        end
-      end
 
-      group from: :us_core_v610_smart_granular_scopes_1,
-            title: 'US Core FHIR API w/Granular Scopes'
+      groups
+        .first
+        .group from: :us_core_v610_smart_granular_scopes_1
+
+      groups
+        .last
+        .description %(
+These tests perform a SMART app launch to receive the following granular scopes:
+
+#{scopes_string(SMART_GRANULAR_SCOPES_GROUP2['v610'])}
+
+Then all of the searches which have been performed in the US Core FHIR API tests
+are repeated to verify that the results have been filtered according to the
+above scopes.
+        )
+
+      groups
+        .last
+        .config(
+          inputs: {
+            requested_scopes: {
+              name: :requested_scopes_group2,
+              default: groups.last.default_group_scopes('v610')
+            }
+          }
+        )
+
+      groups
+        .last
+        .group  from: :us_core_v610_smart_granular_scopes_2
     end
   end
 end

--- a/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
@@ -35,6 +35,9 @@ above scopes.
               name: :requested_scopes_group1,
               default: groups.first.default_group_scopes('v610')
             }
+          },
+          options: {
+            required_scopes: SMART_GRANULAR_SCOPES_GROUP1['v610']
           }
         )
 
@@ -62,12 +65,15 @@ above scopes.
               name: :requested_scopes_group2,
               default: groups.last.default_group_scopes('v610')
             }
+          },
+          options: {
+            required_scopes: SMART_GRANULAR_SCOPES_GROUP2['v610']
           }
         )
 
       groups
         .last
-        .group  from: :us_core_v610_smart_granular_scopes_2
+        .group from: :us_core_v610_smart_granular_scopes_2
     end
   end
 end

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope1_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope1_group.rb
@@ -21,6 +21,7 @@ FHIR API tests, and verify that the resources returned are filtered
 based on the following granular scopes:
 
 * `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis`
+* `Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern`
 
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope2_group.rb
@@ -12,7 +12,7 @@ require_relative './granular_scope_tests/condition/condition_granular_scope_read
 
 module USCoreTestKit
   module USCoreV610
-    class ConditionGranularScope1Group < Inferno::TestGroup
+    class ConditionGranularScope2Group < Inferno::TestGroup
       title 'Condition Granular Scope Tests Tests'
       short_description 'Verify support for the server capabilities required by the US Core Condition Encounter Diagnosis Profile.'
       description %(
@@ -20,11 +20,12 @@ module USCoreTestKit
 FHIR API tests, and verify that the resources returned are filtered
 based on the following granular scopes:
 
-* `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis`
+* `Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern`
+* `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item`
 
       )
 
-      id :us_core_v610_condition_granular_scope_1_group
+      id :us_core_v610_condition_granular_scope_2_group
       run_as_group
 
     

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope2_group.rb
@@ -20,7 +20,6 @@ module USCoreTestKit
 FHIR API tests, and verify that the resources returned are filtered
 based on the following granular scopes:
 
-* `Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern`
 * `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item`
 
       )

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/metadata.yml
@@ -372,6 +372,6 @@
   :file_name: condition_patient_code_granular_scope_search_test.rb
 - :id: us_core_v610_Condition_granular_scope_read_test
   :file_name: condition_granular_scope_read_test.rb
-:id: us_core_v610_condition_granular_scope_1_group
-:file_name: condition_granular_scope1_group.rb
+:id: us_core_v610_condition_granular_scope_2_group
+:file_name: condition_granular_scope2_group.rb
 :delayed_references: []

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/metadata.yml
@@ -275,8 +275,8 @@
   :file_name: observation_patient_code_granular_scope_search_test.rb
 - :id: us_core_v610_Observation_granular_scope_read_test
   :file_name: observation_granular_scope_read_test.rb
-:id: us_core_v610_observation_granular_scope_1_group
-:file_name: observation_granular_scope1_group.rb
+:id: us_core_v610_observation_granular_scope_2_group
+:file_name: observation_granular_scope2_group.rb
 :delayed_references:
 - :path: specimen
   :resources:

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scopes1_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scopes1_group.rb
@@ -13,6 +13,7 @@ FHIR API tests, and verify that the resources returned are filtered
 based on the following granular scopes:
 
 * `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis`
+* `Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|social-history`
 

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scopes1_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scopes1_group.rb
@@ -13,13 +13,8 @@ FHIR API tests, and verify that the resources returned are filtered
 based on the following granular scopes:
 
 * `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis`
-* `Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern`
-* `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|social-history`
-* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs`
-* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`
-* `Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh`
 
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scopes2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scopes2_group.rb
@@ -15,8 +15,8 @@ based on the following granular scopes:
 * `Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern`
 * `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs`
-* `patient.Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`
-* `patient.Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh`
+* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`
+* `Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh`
 
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scopes2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scopes2_group.rb
@@ -1,0 +1,52 @@
+require_relative './condition_granular_scope2_group'
+require_relative './observation_granular_scope2_group'
+
+module USCoreTestKit
+  module USCoreV610
+    class SmartGranularScopes2Group < Inferno::TestGroup
+      id :us_core_v610_smart_granular_scopes_2
+      title 'US Core FHIR API w/Granular Scopes 2'
+
+      description %(
+The tests in this group repeat all of the searches from the US Core
+FHIR API tests, and verify that the resources returned are filtered
+based on the following granular scopes:
+
+* `Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern`
+* `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item`
+* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs`
+* `patient.Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`
+* `patient.Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh`
+
+      )
+
+      input :granular_scopes_2_credentials,
+            title: 'SMART Credentials for Granular Scopes 2',
+            type: :oauth_credentials,
+            locked: true
+
+      config(
+        inputs: {
+          patient_ids: {
+            locked: true
+          },
+          received_scopes: {
+            title: 'Received Scopes',
+            locked: true
+          },
+          url: {
+            locked: true
+          }
+        }
+      )
+
+      fhir_client do
+        oauth_credentials :granular_scopes_2_credentials
+        url :url
+      end
+
+      group from: :us_core_v610_condition_granular_scope_2_group
+      group from: :us_core_v610_observation_granular_scope_2_group
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scopes2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scopes2_group.rb
@@ -12,7 +12,6 @@ The tests in this group repeat all of the searches from the US Core
 FHIR API tests, and verify that the resources returned are filtered
 based on the following granular scopes:
 
-* `Condition.rs?category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern`
 * `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs`
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -12128,9 +12128,15 @@
   Condition:
   - :id: us_core_v610_condition_granular_scope_1_group
     :file_name: condition_granular_scope1_group.rb
+  - :id: us_core_v610_condition_granular_scope_2_group
+    :file_name: condition_granular_scope2_group.rb
   Observation:
   - :id: us_core_v610_observation_granular_scope_1_group
     :file_name: observation_granular_scope1_group.rb
+  - :id: us_core_v610_observation_granular_scope_2_group
+    :file_name: observation_granular_scope2_group.rb
 :granular_scope_groups:
 - :id: us_core_v610_smart_granular_scopes_1
   :file_name: granular_scopes1_group.rb
+- :id: us_core_v610_smart_granular_scopes_2
+  :file_name: granular_scopes2_group.rb

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope2_group.rb
@@ -7,7 +7,7 @@ require_relative './granular_scope_tests/observation/observation_granular_scope_
 
 module USCoreTestKit
   module USCoreV610
-    class ObservationGranularScope1Group < Inferno::TestGroup
+    class ObservationGranularScope2Group < Inferno::TestGroup
       title 'Observation Granular Scope Tests Tests'
       short_description 'Verify support for the server capabilities required by the US Core Laboratory Result Observation Profile.'
       description %(
@@ -15,12 +15,11 @@ module USCoreTestKit
 FHIR API tests, and verify that the resources returned are filtered
 based on the following granular scopes:
 
-* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory`
-* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|social-history`
+* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs`
 
       )
 
-      id :us_core_v610_observation_granular_scope_1_group
+      id :us_core_v610_observation_granular_scope_2_group
       run_as_group
 
     

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope2_group.rb
@@ -16,6 +16,8 @@ FHIR API tests, and verify that the resources returned are filtered
 based on the following granular scopes:
 
 * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs`
+* `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`
+* `Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh`
 
       )
 

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -62,7 +62,7 @@ module USCoreTestKit
       title 'US Core v6.1.0'
       description %(
         The US Core Test Kit tests systems for their conformance to the [US Core
-        Implementation Guide](http://hl7.org/fhir/us/core/STU6).
+        Implementation Guide]().
 
         HL7® FHIR® resources are validated with the Java validator using
         `tx.fhir.org` as the terminology server. Users should note that the
@@ -204,7 +204,7 @@ module USCoreTestKit
         group from: :us_core_311_data_absent_reason
       end
 
-      group from: :'us_core_v610_smart_granular_scopes',
+      group from: :us_core_v610_smart_granular_scopes,
             required_suite_options: USCoreOptions::SMART_2_REQUIREMENT
       
     end

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -62,7 +62,7 @@ module USCoreTestKit
       title 'US Core v6.1.0'
       description %(
         The US Core Test Kit tests systems for their conformance to the [US Core
-        Implementation Guide]().
+        Implementation Guide](http://hl7.org/fhir/us/core/STU6).
 
         HL7® FHIR® resources are validated with the Java validator using
         `tx.fhir.org` as the terminology server. Users should note that the

--- a/lib/us_core_test_kit/generated/v7.0.0-ballot/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0-ballot/us_core_test_suite.rb
@@ -212,7 +212,7 @@ module USCoreTestKit
         group from: :us_core_311_data_absent_reason
       end
 
-      group from: :'us_core_v700_ballot_smart_granular_scopes',
+      group from: :us_core_v700_ballot_smart_granular_scopes,
             required_suite_options: USCoreOptions::SMART_2_REQUIREMENT
       
     end

--- a/lib/us_core_test_kit/generator/granular_scope_group_generator.rb
+++ b/lib/us_core_test_kit/generator/granular_scope_group_generator.rb
@@ -4,18 +4,11 @@ require_relative '../custom_groups/smart_scopes_constants'
 module USCoreTestKit
   class Generator
     class GranularScopeGroupGenerator
-      include SmartScopesConstants
-
       class << self
         def generate(ig_metadata, base_output_dir)
           return unless ['6', '7'].include? ig_metadata.ig_version[1]
 
           [1, 2].each do |group_number|
-            scopes =
-              SmartScopesConstants
-                .const_get("SMART_GRANULAR_SCOPES_GROUP#{group_number}")[ig_metadata.reformatted_version]
-            next if scopes.blank?
-
             new(ig_metadata, base_output_dir, group_number).generate
           end
         end

--- a/lib/us_core_test_kit/generator/granular_scope_resource_type_group_generator.rb
+++ b/lib/us_core_test_kit/generator/granular_scope_resource_type_group_generator.rb
@@ -16,7 +16,7 @@ module USCoreTestKit
                 .const_get("SMART_GRANULAR_SCOPES_GROUP#{group_number}")[ig_metadata.reformatted_version]
 
             groups.each do |group_metadata|
-              next if scopes.blank? || scopes.none? { |scope| scope.start_with? "patient/#{group_metadata.resource}" }
+              next if scopes.none? { |scope| scope.start_with? "patient/#{group_metadata.resource}" }
 
               new(GroupMetadata.new(group_metadata.to_hash), ig_metadata, base_output_dir, group_number).generate
             end

--- a/lib/us_core_test_kit/generator/granular_scope_test_generator.rb
+++ b/lib/us_core_test_kit/generator/granular_scope_test_generator.rb
@@ -11,12 +11,12 @@ module USCoreTestKit
 
           scopes =
             SmartScopesConstants::SMART_GRANULAR_SCOPES_GROUP1[ig_metadata.reformatted_version] +
-            (SmartScopesConstants::SMART_GRANULAR_SCOPES_GROUP2[ig_metadata.reformatted_version] || [])
+            SmartScopesConstants::SMART_GRANULAR_SCOPES_GROUP2[ig_metadata.reformatted_version]
 
           SmartScopesConstants::SMART_GRANULAR_SCOPE_RESOURCES.each do |resource_type|
             group = ig_metadata.groups.find { |group| group.resource == resource_type }
 
-            next if scopes.blank? || scopes.none? { |scope| scope.start_with? "patient/#{group.resource}" }
+            next if scopes.none? { |scope| scope.start_with? "patient/#{group.resource}" }
 
             group.searches
               .each { |search| new(group, search, base_output_dir).generate }

--- a/lib/us_core_test_kit/generator/suite_generator.rb
+++ b/lib/us_core_test_kit/generator/suite_generator.rb
@@ -64,8 +64,6 @@ module USCoreTestKit
 
       def ig_link
         case ig_metadata.ig_version
-        when 'v6.1.0'
-          'http://hl7.org/fhir/us/core/STU6'
         when 'v5.0.1'
           'http://hl7.org/fhir/us/core/STU5.0.1'
         when 'v4.0.0'

--- a/lib/us_core_test_kit/generator/suite_generator.rb
+++ b/lib/us_core_test_kit/generator/suite_generator.rb
@@ -64,6 +64,8 @@ module USCoreTestKit
 
       def ig_link
         case ig_metadata.ig_version
+        when 'v6.1.0'
+          'http://hl7.org/fhir/us/core/STU6'
         when 'v5.0.1'
           'http://hl7.org/fhir/us/core/STU5.0.1'
         when 'v4.0.0'

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -114,7 +114,7 @@ module USCoreTestKit
         group from: :us_core_311_data_absent_reason
       end<% if us_core_6_and_above? %>
 
-      group from: :'<%= granular_scopes_id %>',
+      group from: :<%= granular_scopes_id %>,
             required_suite_options: USCoreOptions::SMART_2_REQUIREMENT
       <% end %>
     end


### PR DESCRIPTION
# Summary
This branch reverts #169, so granular scopes in US Core 6.1.0 will again be tested using two groups with the scopes split between the groups rather than testing support for all granular scopes within a single group.

# Testing Guidance
If you run US Core 6.1.0 with SMART App Launch 2, you should see the two granular scope groups using distinct sets of scopes.