### PR TITLE
FI-2497 Handle Canonical URL trailing version

### DIFF
--- a/lib/us_core_test_kit/custom_groups/capability_statement/instantiate_test.rb
+++ b/lib/us_core_test_kit/custom_groups/capability_statement/instantiate_test.rb
@@ -12,8 +12,12 @@ module USCoreTestKit
       assert_resource_type(:capability_statement)
       capability_statement = resource
 
-      assert capability_statement.instantiates.include?('http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server'),
-        "Server CapabilityStatement.instantiates does not include 'http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server'"
+      include_us_core = capability_statement.instantiates&.any? do |url|
+        url.split('|').first == 'http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server'
+      end
+
+      assert include_us_core,
+             "Server CapabilityStatement.instantiates does not include 'http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server'"
     end
   end
 end

--- a/spec/us_core/instantiate_test_spec.rb
+++ b/spec/us_core/instantiate_test_spec.rb
@@ -1,0 +1,51 @@
+require_relative '../../lib/us_core_test_kit/custom_groups/capability_statement/profile_support_test'
+
+RSpec.describe USCoreTestKit::InstantiateTest do
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name:,
+        value:,
+        type: runnable.config.input_type(name) || 'text'
+      )
+    end
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
+  end
+
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('us_core_v400') }
+  let(:test) { described_class }
+  let(:url) { 'http://example.com/fhir' }
+
+  it 'passes if instantiates does not have version' do
+    response_body =
+      FHIR::CapabilityStatement.new(
+        instantiates: [
+          'http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server'
+        ]
+      ).to_json
+    repo_create(:request, response_body:, name: 'capability_statement', test_session_id: test_session.id)
+
+    result = run(test, url:)
+
+    expect(result.result).to eq('pass')
+  end
+
+  it 'passes if instantiates has version' do
+    response_body =
+      FHIR::CapabilityStatement.new(
+        instantiates: [
+          'http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server|6.1.0'
+        ]
+      ).to_json
+    repo_create(:request, response_body:, name: 'capability_statement', test_session_id: test_session.id)
+
+    result = run(test, url:)
+
+    expect(result.result).to eq('pass')
+  end
+end

--- a/spec/us_core/profile_support_test_spec.rb
+++ b/spec/us_core/profile_support_test_spec.rb
@@ -107,6 +107,34 @@ RSpec.describe USCoreTestKit::ProfileSupportTest do
 
       expect(result.result).to eq('pass')
     end
+
+    it 'passes if supported profiles have versions' do
+      response_body =
+        FHIR::CapabilityStatement.new(
+          rest: [
+            {
+              resource: [
+                {
+                  type: 'Patient',
+                  supportedProfile: ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|6.1.0']
+                },
+                {
+                  type: 'Observation',
+                  supportedProfile:[
+                    'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0',
+                    'http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs'
+                  ]
+                }
+              ]
+            }
+          ]
+        ).to_json
+      repo_create(:request, response_body:, name: 'capability_statement', test_session_id: test_session.id)
+
+      result = run(test, url:)
+
+      expect(result.result).to eq('pass')
+    end
   end
 
   context 'with required resources' do


### PR DESCRIPTION
# Summary

This PR fixes GitHub issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/525

# Change Log:
* If CapabilityStatement's instantiate and supportedProfile elements contains canonical url with trailing version number, tests ignore the version number and use the main url part for testing.
* Add unit tests

# Testing Guidance
All unit tests pass
