### PR TITLE
FI-2859 Fix issue where v7 capability test added to old uscore version

### DIFF
--- a/lib/us_core_test_kit/custom_groups/v7.0.0/smart_app_launch_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v7.0.0/smart_app_launch_group.rb
@@ -1,0 +1,16 @@
+require_relative '../smart_app_launch_group'
+require_relative './smart_discovery_stu2_group'
+
+module USCoreTestKit
+  module USCoreV700
+    class SmartAppLaunchGroup < USCoreTestKit::SmartAppLaunchGroup
+      id :us_core_v700_smart_app_launch
+
+      groups[2].group from: :us_core_v700_smart_discovery_stu2
+      groups[2].children[0] = groups[2].children.pop
+
+      groups.last.group from: :us_core_v700_smart_discovery_stu2
+      groups.last.children[0] = groups.last.children.pop
+    end
+  end
+end

--- a/lib/us_core_test_kit/custom_groups/v7.0.0/smart_discovery_stu2_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v7.0.0/smart_discovery_stu2_group.rb
@@ -1,0 +1,11 @@
+require_relative '../smart_well_known_capabilities_test'
+
+module USCoreTestKit
+  module USCoreV700
+    class USCoreDiscoverySTU2Group < SMARTAppLaunch::DiscoverySTU2Group
+      id :us_core_v700_smart_discovery_stu2
+
+      test from: :us_core_smart_well_known_capabilities
+    end
+  end
+end

--- a/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
@@ -8,6 +8,7 @@ require_relative '../../custom_groups/v7.0.0/smart_granular_scopes_group'
 require_relative '../../custom_groups/v7.0.0/screening_assessment_group'
 require_relative '../../provenance_validator'
 require_relative '../../us_core_options'
+require_relative '../../custom_groups/v7.0.0/smart_app_launch_group'
 
 require_relative 'patient_group'
 require_relative 'allergy_intolerance_group'
@@ -133,7 +134,7 @@ module USCoreTestKit
           }
         ]
 
-      group from: :us_core_smart_app_launch
+      group from: :us_core_v700_smart_app_launch
 
       group do
         input :smart_credentials,

--- a/lib/us_core_test_kit/generator/suite_generator.rb
+++ b/lib/us_core_test_kit/generator/suite_generator.rb
@@ -70,6 +70,10 @@ module USCoreTestKit
         ig_metadata.ig_version[1].to_i > 5
       end
 
+      def us_core_7_and_above?
+        ig_metadata.ig_version[1].to_i > 6
+      end
+
       def generate
         File.open(output_file_name, 'w') { |f| f.write(output) }
       end
@@ -127,6 +131,18 @@ module USCoreTestKit
 
       def screening_assessment_id
         "us_core_#{ig_metadata.reformatted_version}_screening_assessment"
+      end
+
+      def smart_app_launch_file_name
+        "../../custom_groups/#{ig_metadata.ig_version}/smart_app_launch_group"
+      end
+
+      def smart_app_launch_id
+        if us_core_7_and_above?
+          "us_core_#{ig_metadata.reformatted_version}_smart_app_launch"
+        else
+          'us_core_smart_app_launch'
+        end
       end
     end
   end

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -7,7 +7,8 @@ require_relative '../../custom_groups/smart_app_launch_group'<% if us_core_6_and
 require_relative '<%= granular_scopes_file_name %>'
 require_relative '<%= screening_assessment_file_name %>'<% end %>
 require_relative '../../provenance_validator'
-require_relative '../../us_core_options'
+require_relative '../../us_core_options'<% if us_core_7_and_above? %>
+require_relative '<%= smart_app_launch_file_name %>'<% end %>
 
 <% group_file_list.each do |file_name| %>require_relative '<%= file_name %>'
 <% end %>
@@ -84,7 +85,7 @@ module USCoreTestKit
           }
         ]
 
-      group from: :us_core_smart_app_launch
+      group from: :<%= smart_app_launch_id %>
 
       group do
         input :smart_credentials,


### PR DESCRIPTION
# Summary

This ticket fixed FI-2859.

# Change Log
* Add US Core v7 specific test group for smart_app_launch and smart_discovery_stu2
* Update suite_generator and suite_template to add smart_app_lauch group based on US Core version.

# Testing Guidance
* Run US Core Test Kit
* Start US Core v7 + SMART v2
* Verify that "Well-known configuration declares support for Additional US Core Required capabilities" is shown in SMART on FHIR Discovery test group for both stand along launch and EHR launch (1.3.1 and 1.4.1)
* Start US Core v6 + SMART v2
* Verify that "Well-known configuration declares support for Additional US Core Required capabilities" is shown in test group 1.3.1 and 1.4.1

