### PR TITLE
FI-2955: Include code system when checking for resources to read

### DIFF
--- a/lib/us_core_test_kit/granular_scope_read_test.rb
+++ b/lib/us_core_test_kit/granular_scope_read_test.rb
@@ -25,8 +25,8 @@ module USCoreTestKit
       resource_specific_granular_scope_search_params.each do |scope| 
         current_scope = granular_scopes.find {|granular| granular.include?(scope[:name]) && granular.include?(scope[:value])}
 
-        resource_matching_scope = previous_resources_for_reads.find do |prev_resource| 
-          resource_matches_param?(prev_resource, scope[:name], scope[:value])
+        resource_matching_scope = previous_resources_for_reads.find do |prev_resource|
+          resource_matches_param?(prev_resource, scope[:name], current_scope.split('=').last)
         end
         skip_if resource_matching_scope.nil?, "Unable to find any resources to match scope #{current_scope}"
 

--- a/spec/us_core/granular_scope_read_spec.rb
+++ b/spec/us_core/granular_scope_read_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe USCoreTestKit::GranularScopeReadTest do
           category: {
             coding: [
               {
-                system: 'http://terminology.hl7.org/CodeSystem/condition-category',
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/condition-category',
                 code: 'health-concern'
               }
             ]


### PR DESCRIPTION
# Summary
When finding a resource which should be able to be read using the currently granted granular scopes, currently only the code of the granular scope is used for matching. It needs to match based on both the code and system of the granular scope.

# Testing Guidance
After fixing this bug, it was necessary to update some unit test data to match this more stringent requirement.