### PR TITLE
FI-2957: Optional granular searches

### DIFF
--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_abatement_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_abatement_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_abatement_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_asserted_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_asserted_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_asserted_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_category_clinical_status_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_category_clinical_status_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_category_clinical_status_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_category_encounter_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_category_encounter_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_category_encounter_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_category_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_category_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_category_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_clinical_status_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_clinical_status_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_clinical_status_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_code_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_code_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_code_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_onset_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_onset_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_onset_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_recorded_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/condition/condition_patient_recorded_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Condition_patient_recorded_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_category_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_category_date_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Observation_patient_category_date_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_category_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_category_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Observation_patient_category_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_category_status_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_category_status_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Observation_patient_category_status_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_code_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_code_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Observation_patient_code_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_code_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scope_tests/observation/observation_patient_code_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v610_Observation_patient_code_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_abatement_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_abatement_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_abatement_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_asserted_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_asserted_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_asserted_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_category_clinical_status_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_category_clinical_status_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_category_clinical_status_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_category_encounter_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_category_encounter_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_category_encounter_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_category_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_category_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_category_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_clinical_status_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_clinical_status_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_clinical_status_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_code_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_code_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_code_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_lastupdated_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_lastupdated_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient__lastUpdated_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_onset_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_onset_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_onset_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_recorded_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/condition/condition_patient_recorded_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Condition_patient_recorded_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_category_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_category_date_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Observation_patient_category_date_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_category_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_category_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Observation_patient_category_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_category_lastupdated_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_category_lastupdated_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Observation_patient_category__lastUpdated_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_category_status_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_category_status_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Observation_patient_category_status_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_code_date_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_code_date_granular_scope_search_test.rb
@@ -17,6 +17,7 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Observation_patient_code_date_granular_scope_search_test
+      optional
 
       input :patient_ids,
         title: 'Patient IDs',

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_code_granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scope_tests/observation/observation_patient_code_granular_scope_search_test.rb
@@ -17,7 +17,6 @@ filtered based on the granted granular scopes.
       )
 
       id :us_core_v700_Observation_patient_code_granular_scope_search_test
-
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'

--- a/lib/us_core_test_kit/generator/granular_scope_test_generator.rb
+++ b/lib/us_core_test_kit/generator/granular_scope_test_generator.rb
@@ -80,6 +80,10 @@ module USCoreTestKit
         group_metadata.resource
       end
 
+      def conformance_expectation
+        search_metadata[:expectation]
+      end
+
       def search_params
         @search_params ||=
           search_metadata[:names].map do |name|
@@ -109,6 +113,10 @@ module USCoreTestKit
 
       def path_for_value(path)
         path == 'class' ? 'local_class' : path
+      end
+
+      def optional?
+        conformance_expectation != 'SHALL' || !search_metadata[:must_support_or_mandatory]
       end
 
       def search_definition(name)

--- a/lib/us_core_test_kit/generator/templates/granular_scope_test.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/granular_scope_test.rb.erb
@@ -13,8 +13,9 @@ module USCoreTestKit
 <%= description %>
       )
 
-      id :<%= test_id %>
-<% if needs_patient_id? %>
+      id :<%= test_id %><% if optional? %>
+      optional
+<% end %><% if needs_patient_id? %>
       input :patient_ids,
         title: 'Patient IDs',
         description: 'Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements'


### PR DESCRIPTION
# Summary
This branch makes the granular search tests for non-required search parameter combinations optional.

Before:
![Screenshot 2024-07-26 at 10 12 58 AM](https://github.com/user-attachments/assets/0a615968-ded5-4eeb-a2e9-237dbecfcdc5)

After:
![Screenshot 2024-07-26 at 10 13 44 AM](https://github.com/user-attachments/assets/19ed4e8d-f309-4941-a3c8-38e3cc3afe66)

# Testing Guidance
In the UI, you can verify that the required/optional searches in the granular scope groups matches those in the normal FHIR API groups.