### PR TITLE
FI-2959 Add code system value to requiredBinding metadata

### DIFF
--- a/lib/us_core_test_kit/custom_groups/v6.1.0/screening_assessment_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v6.1.0/screening_assessment_group.rb
@@ -34,9 +34,30 @@ module USCoreTestKit
       test from: :us_core_screening_assessment_category do
         config(
           options: {
-            condition_screening_assessment_categories: ['sdoh'].freeze,
-            observation_screening_assessment_categories: ['sdoh', 'functional-status', 'disability-status',
-                                                          'cognitive-status'].freeze
+            condition_screening_assessment_categories: [
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'sdoh'
+              }
+            ].freeze,
+            observation_screening_assessment_categories: [
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'sdoh'
+              },
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'functional-status'
+              },
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'disability-status'
+              },
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'cognitive-status'
+              }
+            ].freeze
           }
         )
       end

--- a/lib/us_core_test_kit/custom_groups/v7.0.0/screening_assessment_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v7.0.0/screening_assessment_group.rb
@@ -37,9 +37,38 @@ module USCoreTestKit
       test from: :us_core_screening_assessment_category do
         config(
           options: {
-            condition_screening_assessment_categories: ['sdoh'].freeze,
-            observation_screening_assessment_categories: ['sdoh', 'functional-status', 'disability-status',
-                                                          'cognitive-status', 'activity', 'social-history'].freeze
+            condition_screening_assessment_categories: [
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'sdoh'
+              }
+            ].freeze,
+            observation_screening_assessment_categories: [
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'sdoh'
+              },
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'functional-status'
+              },
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'disability-status'
+              },
+              {
+                system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+                code: 'cognitive-status'
+              },
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+                code: 'activity'
+              },
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+                code: 'social-history'
+              }
+            ].freeze
           }
         )
       end

--- a/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/condition_problems_health_concerns/metadata.yml
@@ -248,8 +248,10 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - problem-list-item
-      - health-concern
+      - :system: http://terminology.hl7.org/CodeSystem/condition-category
+        :code: problem-list-item
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/condition-category
+        :code: health-concern
   - :slice_id: Condition.category:sdoh
     :slice_name: sdoh
     :path: category

--- a/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/diagnostic_report_note/metadata.yml
@@ -157,9 +157,12 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - LP29684-5
-      - LP29708-2
-      - LP7839-6
+      - :system: http://loinc.org
+        :code: LP29684-5
+      - :system: http://loinc.org
+        :code: LP29708-2
+      - :system: http://loinc.org
+        :code: LP7839-6
   :elements:
   - :path: status
   - :path: category

--- a/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/document_reference/metadata.yml
@@ -186,7 +186,8 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - clinical-note
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category
+        :code: clinical-note
   :elements:
   - :path: identifier
   - :path: status

--- a/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/medication_request/metadata.yml
@@ -151,10 +151,14 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - inpatient
-      - outpatient
-      - community
-      - discharge
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: inpatient
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: outpatient
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: community
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: discharge
   :elements:
   - :path: status
   - :path: intent

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -1207,8 +1207,10 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - problem-list-item
-        - health-concern
+        - :system: http://terminology.hl7.org/CodeSystem/condition-category
+          :code: problem-list-item
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/condition-category
+          :code: health-concern
     - :slice_id: Condition.category:sdoh
       :slice_name: sdoh
       :path: category
@@ -1615,9 +1617,12 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - LP29684-5
-        - LP29708-2
-        - LP7839-6
+        - :system: http://loinc.org
+          :code: LP29684-5
+        - :system: http://loinc.org
+          :code: LP29708-2
+        - :system: http://loinc.org
+          :code: LP7839-6
     :elements:
     - :path: status
     - :path: category
@@ -2179,7 +2184,8 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - clinical-note
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category
+          :code: clinical-note
     :elements:
     - :path: identifier
     - :path: status
@@ -3415,10 +3421,14 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - inpatient
-        - outpatient
-        - community
-        - discharge
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: inpatient
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: outpatient
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: community
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: discharge
     :elements:
     - :path: status
     - :path: intent
@@ -11167,14 +11177,22 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - sdoh
-        - '386053000'
-        - '410606002'
-        - '108252007'
-        - '363679005'
-        - '409063005'
-        - '409073007'
-        - '387713003'
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-tags
+          :code: sdoh
+        - :system: http://snomed.info/sct
+          :code: '386053000'
+        - :system: http://snomed.info/sct
+          :code: '410606002'
+        - :system: http://snomed.info/sct
+          :code: '108252007'
+        - :system: http://snomed.info/sct
+          :code: '363679005'
+        - :system: http://snomed.info/sct
+          :code: '409063005'
+        - :system: http://snomed.info/sct
+          :code: '409073007'
+        - :system: http://snomed.info/sct
+          :code: '387713003'
     :elements:
     - :path: status
     - :path: intent

--- a/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/service_request/metadata.yml
@@ -174,14 +174,22 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - sdoh
-      - '386053000'
-      - '410606002'
-      - '108252007'
-      - '363679005'
-      - '409063005'
-      - '409073007'
-      - '387713003'
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-tags
+        :code: sdoh
+      - :system: http://snomed.info/sct
+        :code: '386053000'
+      - :system: http://snomed.info/sct
+        :code: '410606002'
+      - :system: http://snomed.info/sct
+        :code: '108252007'
+      - :system: http://snomed.info/sct
+        :code: '363679005'
+      - :system: http://snomed.info/sct
+        :code: '409063005'
+      - :system: http://snomed.info/sct
+        :code: '409073007'
+      - :system: http://snomed.info/sct
+        :code: '387713003'
   :elements:
   - :path: status
   - :path: intent

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_problems_health_concerns/metadata.yml
@@ -255,8 +255,10 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - problem-list-item
-      - health-concern
+      - :system: http://terminology.hl7.org/CodeSystem/condition-category
+        :code: problem-list-item
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/condition-category
+        :code: health-concern
   - :slice_id: Condition.category:screening-assessment
     :slice_name: screening-assessment
     :path: category
@@ -264,10 +266,14 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - sdoh
-      - functional-status
-      - disability-status
-      - cognitive-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: sdoh
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: functional-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: disability-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: cognitive-status
   :elements:
   - :path: clinicalStatus
   - :path: verificationStatus

--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
@@ -157,9 +157,12 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - LP29684-5
-      - LP29708-2
-      - LP7839-6
+      - :system: http://loinc.org
+        :code: LP29684-5
+      - :system: http://loinc.org
+        :code: LP29708-2
+      - :system: http://loinc.org
+        :code: LP7839-6
   :elements:
   - :path: status
   - :path: category

--- a/lib/us_core_test_kit/generated/v6.1.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/document_reference/metadata.yml
@@ -186,7 +186,8 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - clinical-note
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category
+        :code: clinical-note
     :uscdi_only: true
   :elements:
   - :path: identifier

--- a/lib/us_core_test_kit/generated/v6.1.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/medication_request/metadata.yml
@@ -151,10 +151,14 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - inpatient
-      - outpatient
-      - community
-      - discharge
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: inpatient
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: outpatient
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: community
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: discharge
   :elements:
   - :path: status
   - :path: intent

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -1244,8 +1244,10 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - problem-list-item
-        - health-concern
+        - :system: http://terminology.hl7.org/CodeSystem/condition-category
+          :code: problem-list-item
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/condition-category
+          :code: health-concern
     - :slice_id: Condition.category:screening-assessment
       :slice_name: screening-assessment
       :path: category
@@ -1253,10 +1255,14 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - sdoh
-        - functional-status
-        - disability-status
-        - cognitive-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: sdoh
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: functional-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: disability-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: cognitive-status
     :elements:
     - :path: clinicalStatus
     - :path: verificationStatus
@@ -1846,9 +1852,12 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - LP29684-5
-        - LP29708-2
-        - LP7839-6
+        - :system: http://loinc.org
+          :code: LP29684-5
+        - :system: http://loinc.org
+          :code: LP29708-2
+        - :system: http://loinc.org
+          :code: LP7839-6
     :elements:
     - :path: status
     - :path: category
@@ -2409,7 +2418,8 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - clinical-note
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category
+          :code: clinical-note
       :uscdi_only: true
     :elements:
     - :path: identifier
@@ -3885,10 +3895,14 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - inpatient
-        - outpatient
-        - community
-        - discharge
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: inpatient
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: outpatient
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: community
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: discharge
     :elements:
     - :path: status
     - :path: intent
@@ -5576,19 +5590,32 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - sdoh
-        - functional-status
-        - disability-status
-        - cognitive-status
-        - social-history
-        - vital-signs
-        - imaging
-        - laboratory
-        - procedure
-        - survey
-        - exam
-        - therapy
-        - activity
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: sdoh
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: functional-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: disability-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: cognitive-status
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: social-history
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: vital-signs
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: imaging
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: laboratory
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: procedure
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: survey
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: exam
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: therapy
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: activity
     :elements:
     - :path: status
     - :path: category
@@ -8467,10 +8494,14 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - sdoh
-        - functional-status
-        - disability-status
-        - cognitive-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: sdoh
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: functional-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: disability-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: cognitive-status
     :elements:
     - :path: status
     - :path: category
@@ -9078,13 +9109,20 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - laboratory
-        - exam
-        - therapy
-        - imaging
-        - procedure
-        - vital-signs
-        - activity
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: laboratory
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: exam
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: therapy
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: imaging
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: procedure
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: vital-signs
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: activity
     :elements:
     - :path: status
     - :path: category
@@ -11861,17 +11899,28 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - sdoh
-        - functional-status
-        - disability-status
-        - cognitive-status
-        - '386053000'
-        - '410606002'
-        - '108252007'
-        - '363679005'
-        - '409063005'
-        - '409073007'
-        - '387713003'
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: sdoh
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: functional-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: disability-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: cognitive-status
+        - :system: http://snomed.info/sct
+          :code: '386053000'
+        - :system: http://snomed.info/sct
+          :code: '410606002'
+        - :system: http://snomed.info/sct
+          :code: '108252007'
+        - :system: http://snomed.info/sct
+          :code: '363679005'
+        - :system: http://snomed.info/sct
+          :code: '409063005'
+        - :system: http://snomed.info/sct
+          :code: '409073007'
+        - :system: http://snomed.info/sct
+          :code: '387713003'
     :elements:
     - :path: status
     - :path: intent

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_clinical_result/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_clinical_result/metadata.yml
@@ -154,13 +154,20 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - laboratory
-      - exam
-      - therapy
-      - imaging
-      - procedure
-      - vital-signs
-      - activity
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: laboratory
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: exam
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: therapy
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: imaging
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: procedure
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: vital-signs
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: activity
   :elements:
   - :path: status
   - :path: category

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_screening_assessment/metadata.yml
@@ -156,10 +156,14 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - sdoh
-      - functional-status
-      - disability-status
-      - cognitive-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: sdoh
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: functional-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: disability-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: cognitive-status
   :elements:
   - :path: status
   - :path: category

--- a/lib/us_core_test_kit/generated/v6.1.0/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/service_request/metadata.yml
@@ -177,17 +177,28 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - sdoh
-      - functional-status
-      - disability-status
-      - cognitive-status
-      - '386053000'
-      - '410606002'
-      - '108252007'
-      - '363679005'
-      - '409063005'
-      - '409073007'
-      - '387713003'
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: sdoh
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: functional-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: disability-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: cognitive-status
+      - :system: http://snomed.info/sct
+        :code: '386053000'
+      - :system: http://snomed.info/sct
+        :code: '410606002'
+      - :system: http://snomed.info/sct
+        :code: '108252007'
+      - :system: http://snomed.info/sct
+        :code: '363679005'
+      - :system: http://snomed.info/sct
+        :code: '409063005'
+      - :system: http://snomed.info/sct
+        :code: '409073007'
+      - :system: http://snomed.info/sct
+        :code: '387713003'
   :elements:
   - :path: status
   - :path: intent

--- a/lib/us_core_test_kit/generated/v6.1.0/simple_observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/simple_observation/metadata.yml
@@ -160,19 +160,32 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - sdoh
-      - functional-status
-      - disability-status
-      - cognitive-status
-      - social-history
-      - vital-signs
-      - imaging
-      - laboratory
-      - procedure
-      - survey
-      - exam
-      - therapy
-      - activity
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: sdoh
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: functional-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: disability-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: cognitive-status
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: social-history
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: vital-signs
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: imaging
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: laboratory
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: procedure
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: survey
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: exam
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: therapy
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: activity
   :elements:
   - :path: status
   - :path: category

--- a/lib/us_core_test_kit/generated/v7.0.0/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/condition_problems_health_concerns/metadata.yml
@@ -280,8 +280,10 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - problem-list-item
-      - health-concern
+      - :system: http://terminology.hl7.org/CodeSystem/condition-category
+        :code: problem-list-item
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/condition-category
+        :code: health-concern
   - :slice_id: Condition.category:screening-assessment
     :slice_name: screening-assessment
     :path: category
@@ -289,12 +291,18 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - sdoh
-      - functional-status
-      - disability-status
-      - cognitive-status
-      - treatment-intervention-preference
-      - care-experience-preference
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: sdoh
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: functional-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: disability-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: cognitive-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: treatment-intervention-preference
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: care-experience-preference
   :elements:
   - :path: meta
   - :path: meta.lastUpdated

--- a/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/metadata.yml
@@ -184,9 +184,12 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - LP29684-5
-      - LP29708-2
-      - LP7839-6
+      - :system: http://loinc.org
+        :code: LP29684-5
+      - :system: http://loinc.org
+        :code: LP29708-2
+      - :system: http://loinc.org
+        :code: LP7839-6
   :elements:
   - :path: status
   - :path: category

--- a/lib/us_core_test_kit/generated/v7.0.0/document_reference/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/document_reference/metadata.yml
@@ -186,7 +186,8 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - clinical-note
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category
+        :code: clinical-note
     :uscdi_only: true
   :elements:
   - :path: identifier

--- a/lib/us_core_test_kit/generated/v7.0.0/medication_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/medication_request/metadata.yml
@@ -155,10 +155,14 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - inpatient
-      - outpatient
-      - community
-      - discharge
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: inpatient
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: outpatient
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: community
+      - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+        :code: discharge
   :elements:
   - :path: status
   - :path: intent

--- a/lib/us_core_test_kit/generated/v7.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/metadata.yml
@@ -1302,8 +1302,10 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - problem-list-item
-        - health-concern
+        - :system: http://terminology.hl7.org/CodeSystem/condition-category
+          :code: problem-list-item
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/condition-category
+          :code: health-concern
     - :slice_id: Condition.category:screening-assessment
       :slice_name: screening-assessment
       :path: category
@@ -1311,12 +1313,18 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - sdoh
-        - functional-status
-        - disability-status
-        - cognitive-status
-        - treatment-intervention-preference
-        - care-experience-preference
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: sdoh
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: functional-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: disability-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: cognitive-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: treatment-intervention-preference
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: care-experience-preference
     :elements:
     - :path: meta
     - :path: meta.lastUpdated
@@ -1938,9 +1946,12 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - LP29684-5
-        - LP29708-2
-        - LP7839-6
+        - :system: http://loinc.org
+          :code: LP29684-5
+        - :system: http://loinc.org
+          :code: LP29708-2
+        - :system: http://loinc.org
+          :code: LP7839-6
     :elements:
     - :path: status
     - :path: category
@@ -2550,7 +2561,8 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - clinical-note
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category
+          :code: clinical-note
       :uscdi_only: true
     :elements:
     - :path: identifier
@@ -4112,10 +4124,14 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - inpatient
-        - outpatient
-        - community
-        - discharge
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: inpatient
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: outpatient
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: community
+        - :system: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+          :code: discharge
     :elements:
     - :path: status
     - :path: intent
@@ -6008,21 +6024,36 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - sdoh
-        - functional-status
-        - disability-status
-        - cognitive-status
-        - treatment-intervention-preference
-        - care-experience-preference
-        - social-history
-        - vital-signs
-        - imaging
-        - laboratory
-        - procedure
-        - survey
-        - exam
-        - therapy
-        - activity
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: sdoh
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: functional-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: disability-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: cognitive-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: treatment-intervention-preference
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: care-experience-preference
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: social-history
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: vital-signs
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: imaging
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: laboratory
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: procedure
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: survey
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: exam
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: therapy
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: activity
     :elements:
     - :path: status
     - :path: category
@@ -9773,12 +9804,18 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - sdoh
-        - functional-status
-        - disability-status
-        - cognitive-status
-        - treatment-intervention-preference
-        - care-experience-preference
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: sdoh
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: functional-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: disability-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: cognitive-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: treatment-intervention-preference
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: care-experience-preference
     :elements:
     - :path: status
     - :path: category
@@ -10773,13 +10810,20 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - laboratory
-        - exam
-        - therapy
-        - imaging
-        - procedure
-        - vital-signs
-        - activity
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: laboratory
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: exam
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: therapy
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: imaging
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: procedure
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: vital-signs
+        - :system: http://terminology.hl7.org/CodeSystem/observation-category
+          :code: activity
     :elements:
     - :path: status
     - :path: category
@@ -13681,19 +13725,32 @@
         :type: requiredBinding
         :path: ''
         :values:
-        - sdoh
-        - functional-status
-        - disability-status
-        - cognitive-status
-        - treatment-intervention-preference
-        - care-experience-preference
-        - '386053000'
-        - '410606002'
-        - '108252007'
-        - '363679005'
-        - '409063005'
-        - '409073007'
-        - '387713003'
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: sdoh
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: functional-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: disability-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: cognitive-status
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: treatment-intervention-preference
+        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+          :code: care-experience-preference
+        - :system: http://snomed.info/sct
+          :code: '386053000'
+        - :system: http://snomed.info/sct
+          :code: '410606002'
+        - :system: http://snomed.info/sct
+          :code: '108252007'
+        - :system: http://snomed.info/sct
+          :code: '363679005'
+        - :system: http://snomed.info/sct
+          :code: '409063005'
+        - :system: http://snomed.info/sct
+          :code: '409073007'
+        - :system: http://snomed.info/sct
+          :code: '387713003'
     :elements:
     - :path: status
     - :path: intent

--- a/lib/us_core_test_kit/generated/v7.0.0/observation_clinical_result/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/observation_clinical_result/metadata.yml
@@ -181,13 +181,20 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - laboratory
-      - exam
-      - therapy
-      - imaging
-      - procedure
-      - vital-signs
-      - activity
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: laboratory
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: exam
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: therapy
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: imaging
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: procedure
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: vital-signs
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: activity
   :elements:
   - :path: status
   - :path: category

--- a/lib/us_core_test_kit/generated/v7.0.0/observation_screening_assessment/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/observation_screening_assessment/metadata.yml
@@ -183,12 +183,18 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - sdoh
-      - functional-status
-      - disability-status
-      - cognitive-status
-      - treatment-intervention-preference
-      - care-experience-preference
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: sdoh
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: functional-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: disability-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: cognitive-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: treatment-intervention-preference
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: care-experience-preference
   :elements:
   - :path: status
   - :path: category

--- a/lib/us_core_test_kit/generated/v7.0.0/service_request/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/service_request/metadata.yml
@@ -179,19 +179,32 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - sdoh
-      - functional-status
-      - disability-status
-      - cognitive-status
-      - treatment-intervention-preference
-      - care-experience-preference
-      - '386053000'
-      - '410606002'
-      - '108252007'
-      - '363679005'
-      - '409063005'
-      - '409073007'
-      - '387713003'
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: sdoh
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: functional-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: disability-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: cognitive-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: treatment-intervention-preference
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: care-experience-preference
+      - :system: http://snomed.info/sct
+        :code: '386053000'
+      - :system: http://snomed.info/sct
+        :code: '410606002'
+      - :system: http://snomed.info/sct
+        :code: '108252007'
+      - :system: http://snomed.info/sct
+        :code: '363679005'
+      - :system: http://snomed.info/sct
+        :code: '409063005'
+      - :system: http://snomed.info/sct
+        :code: '409073007'
+      - :system: http://snomed.info/sct
+        :code: '387713003'
   :elements:
   - :path: status
   - :path: intent

--- a/lib/us_core_test_kit/generated/v7.0.0/simple_observation/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/simple_observation/metadata.yml
@@ -189,21 +189,36 @@
       :type: requiredBinding
       :path: ''
       :values:
-      - sdoh
-      - functional-status
-      - disability-status
-      - cognitive-status
-      - treatment-intervention-preference
-      - care-experience-preference
-      - social-history
-      - vital-signs
-      - imaging
-      - laboratory
-      - procedure
-      - survey
-      - exam
-      - therapy
-      - activity
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: sdoh
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: functional-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: disability-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: cognitive-status
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: treatment-intervention-preference
+      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
+        :code: care-experience-preference
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: social-history
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: vital-signs
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: imaging
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: laboratory
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: procedure
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: survey
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: exam
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: therapy
+      - :system: http://terminology.hl7.org/CodeSystem/observation-category
+        :code: activity
   :elements:
   - :path: status
   - :path: category

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -118,7 +118,7 @@ module USCoreTestKit
 
                 value_extractor = ValueExactor.new(ig_resources, resource, profile_elements)
 
-                values = value_extractor.values_from_value_set_binding(pattern_element).presence ||
+                values = value_extractor.codings_from_value_set_binding(pattern_element).presence ||
                          value_extractor.values_from_resource_metadata([metadata[:path]]).presence || []
 
                 {

--- a/lib/us_core_test_kit/generator/search_definition_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/search_definition_metadata_extractor.rb
@@ -169,11 +169,10 @@ module USCoreTestKit
 
       def values
         values_from_must_supports(profile_element).presence ||
-        value_extractor.values_from_fixed_codes(profile_element, type).presence ||
-        #value_extractor.values_from_required_binding(profile_element).presence ||
-        value_extractor.values_from_value_set_binding(profile_element).presence ||
-        values_from_resource_metadata(paths).presence ||
-        []
+          value_extractor.values_from_fixed_codes(profile_element, type).presence ||
+          value_extractor.codes_from_value_set_binding(profile_element).presence ||
+          values_from_resource_metadata(paths).presence ||
+          []
       end
 
       def values_from_must_supports(profile_element)
@@ -198,7 +197,7 @@ module USCoreTestKit
             when 'patternCoding', 'patternCodeableConcept'
               slice[:discriminator][:code]
             when 'requiredBinding'
-              slice[:discriminator][:values]
+              value_extractor.codes_from_system_code_pair(slice[:discriminator][:values])
             when 'value'
               slice[:discriminator][:values]
                 .select { |value| value[:path] == 'coding.code' }
@@ -216,7 +215,7 @@ module USCoreTestKit
 
       def values_from_resource_metadata(paths)
         if multiple_or_expectation == 'SHALL' || paths.any? { |path| path.downcase.include?('status') }
-          value_extractor.values_from_resource_metadata(paths)
+          value_extractor.codes_from_system_code_pair(value_extractor.values_from_resource_metadata(paths))
         else
           []
         end

--- a/lib/us_core_test_kit/generator/value_extractor.rb
+++ b/lib/us_core_test_kit/generator/value_extractor.rb
@@ -9,46 +9,34 @@ module USCoreTestKit
         self.profile_elements = profile_elements
       end
 
-
-      def values_from_required_binding(profile_element)
-        return [] unless profile_element&.max == '*'
-
-        profile_elements
-          .select do |element|
-            element.path == profile_element.path && element.binding&.strength == 'required'
-          end
-          .map { |element| values_from_value_set_binding(element) }
-          .flatten.compact
-      end
-
       def values_from_fixed_codes(profile_element, type)
         return [] unless type == 'CodeableConcept'
 
-        profile_elements
-          .select do
-            |element| element.path == "#{profile_element.path}.coding.code" && element.fixedCode.present?
-          end
-          .map { |element| element.fixedCode }
+        elements = profile_elements.select do |element|
+          element.path == "#{profile_element.path}.coding.code" && element.fixedCode.present?
+        end
+
+        elements.map(&:fixedCode)
       end
 
       def values_from_pattern_coding(profile_element, type)
         return [] unless type == 'CodeableConcept'
 
-        profile_elements
-          .select do |element|
-            element.path == "#{profile_element.path}.coding" && element.patternCoding.present?
-          end
-          .map { |element| element.patternCoding.code }
+        elements = profile_elements.select do |element|
+          element.path == "#{profile_element.path}.coding" && element.patternCoding.present?
+        end
+
+        elements.map { |element| element.patternCoding.code }
       end
 
       def values_from_pattern_codeable_concept(profile_element, type)
         return [] unless type == 'CodeableConcept'
 
-        profile_elements
-          .select do |element|
-            element.path == profile_element.path && element.patternCodeableConcept.present? && element.min > 0
-          end
-          .map { |element| element.patternCodeableConcept.coding.first.code }
+        elements = profile_elements.select do |element|
+          element.path == profile_element.path && element.patternCodeableConcept.present? && element.min.positive?
+        end
+
+        elements.map { |element| element.patternCodeableConcept.coding.first.code }
       end
 
       def value_set_binding(the_element)
@@ -64,34 +52,56 @@ module USCoreTestKit
       end
 
       def bound_systems_from_valueset(value_set)
-        systems = value_set&.compose&.include&.map do |include|
-          if include.concept.present?
-            include
-          elsif include.system.present? && include.filter&.empty? # Cannot process intensional value set with filters
-            ig_resources.code_system_by_url(include.system)
-          elsif include.valueSet.present?
-            include.valueSet.map do |vs|
+        value_set&.compose&.include&.map do |include_element|
+          if include_element.concept.present?
+            include_element
+          elsif include_element.system.present? && include_element.filter&.empty?
+            # Cannot process intensional value set with filters
+            ig_resources.code_system_by_url(include_element.system)
+          elsif include_element.valueSet.present?
+            include_element.valueSet.map do |vs|
               a_value_set = ig_resources.value_set_by_url(vs)
               bound_systems_from_valueset(a_value_set)
             end
           end
         end&.flatten&.compact
-
-        systems
       end
 
-      def values_from_value_set_binding(the_element)
+      def codes_from_value_set_binding(the_element)
+        codes_from_system_code_pair(codings_from_value_set_binding(the_element))
+      end
+
+      def codes_from_system_code_pair(codings)
+        codings.present? ? codings.map { |coding| coding[:code] }.compact.uniq : []
+      end
+
+      def codings_from_value_set_binding(the_element)
         return [] if the_element.nil?
 
         bound_systems = bound_systems(the_element)
 
-        return bound_systems.flat_map { |system| system.concept.map(&:code) }.uniq if bound_systems.present?
+        return codings_from_bound_systems(bound_systems) if bound_systems.present?
 
         expansion_contains = value_set_expansion_contains(the_element)
 
         return [] if expansion_contains.blank?
 
-        expansion_contains.map(&:code).compact.uniq
+        expansion_contains.map { |contains| { system: contains.system, code: contains.code } }.compact.uniq
+      end
+
+      def codings_from_bound_systems(bound_systems)
+        return [] unless bound_systems.present?
+
+        bound_systems.flat_map do |bound_system|
+          case bound_system
+          when FHIR::ValueSet::Compose::Include
+            bound_system.concept.map { |concept| { system: bound_system.system, code: concept.code } }
+          when FHIR::CodeSystem
+            bound_system.concept.map { |concept| { system: bound_system.url, code: concept.code } }
+          else
+            []
+          end
+        end.uniq
       end
 
       def value_set_expansion_contains(element)
@@ -108,8 +118,10 @@ module USCoreTestKit
         paths.each do |current_path|
           current_metadata = fhir_metadata(current_path)
 
-          if current_metadata&.dig('valid_codes').present?
-            values = values + current_metadata['valid_codes'].values.flatten
+          next unless current_metadata&.dig('valid_codes').present?
+
+          values += current_metadata['valid_codes'].flat_map do |system, codes|
+            codes.map { |code| { system:, code: } }
           end
         end
 

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -193,7 +193,10 @@ module USCoreTestKit
           end
         when 'requiredBinding'
           coding_path = discriminator[:path].present? ? "#{discriminator[:path]}.coding" : 'coding'
-          find_a_value_at(element, coding_path) {|coding| discriminator[:values].include?(coding.code) }
+
+          find_a_value_at(element, coding_path) do |coding|
+            discriminator[:values].any? { |value| value[:system] == coding.system && value[:code] == coding.code }
+          end
         end
       end
     end

--- a/spec/us_core/screening_assessment_category_test_spec.rb
+++ b/spec/us_core/screening_assessment_category_test_spec.rb
@@ -21,8 +21,34 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
 
   let(:url) { 'http://example.com/fhir' }
   let(:patient_id) { '85' }
-  let(:observation_categories) { ['sdoh', 'functional-status', 'disability-status', 'cognitive-status'] }
-  let(:condition_categories) { ['sdoh'] }
+  let(:observation_categories) do
+    [
+      {
+        system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+        code: 'sdoh'
+      },
+      {
+        system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+        code: 'functional-status'
+      },
+      {
+        system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+        code: 'disability-status'
+      },
+      {
+        system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+        code: 'cognitive-status'
+      }
+    ]
+  end
+  let(:condition_categories) do
+    [
+      {
+        system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category',
+        code: 'sdoh'
+      }
+    ]
+  end
 
   let(:test_class) do
     obs_categories = observation_categories
@@ -45,8 +71,8 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
     FHIR::Observation.new(
       id: 'sdoh',
       category: [
-        { coding: [{ code: 'survey' }] },
-        { coding: [{ code: 'sdoh' }] }
+        { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'survey' }] },
+        { coding: [{ system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category', code: 'sdoh' }] }
       ]
     )
   end
@@ -54,8 +80,8 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
     FHIR::Observation.new(
       id: 'functional-status',
       category: [
-        { coding: [{ code: 'survey' }] },
-        { coding: [{ code: 'functional-status' }] }
+        { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'survey' }] },
+        { coding: [{ system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category', code: 'functional-status' }] }
       ]
     )
   end
@@ -63,8 +89,8 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
     FHIR::Observation.new(
       id: 'disability-status',
       category: [
-        { coding: [{ code: 'survey' }] },
-        { coding: [{ code: 'disability-status' }] }
+        { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'survey' }] },
+        { coding: [{ system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category', code: 'disability-status' }] }
       ]
     )
   end
@@ -72,8 +98,8 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
     FHIR::Observation.new(
       id: 'cognitive-status',
       category: [
-        { coding: [{ code: 'survey' }] },
-        { coding: [{ code: 'cognitive-status' }] }
+        { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'survey' }] },
+        { coding: [{ system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category', code: 'cognitive-status' }] }
       ]
     )
   end
@@ -81,7 +107,7 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
     FHIR::Observation.new(
       id: 'cognitive-status',
       category: [
-        { coding: [{ code: 'survey' }] }
+        { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'survey' }] }
       ]
     )
   end
@@ -89,8 +115,8 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
     FHIR::Condition.new(
       id: 'sdoh',
       category: [
-        { coding: [{ code: 'health-concern' }] },
-        { coding: [{ code: 'sdoh' }] }
+        { coding: [{ system: 'http://hl7.org/fhir/us/core/CodeSystem/condition-category', code: 'health-concern' }] },
+        { coding: [{ system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-category', code: 'sdoh' }] }
       ]
     )
   end
@@ -98,7 +124,7 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
     FHIR::Condition.new(
       id: 'non_sdoh',
       category: [
-        { coding: [{ code: 'health-concern' }] }
+        { coding: [{ system: 'http://hl7.org/fhir/us/core/CodeSystem/condition-category', code: 'health-concern' }] }
       ]
     )
   end
@@ -151,7 +177,7 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
       result = run(test_class, patient_ids: patient_id)
 
       expect(result.result).to eq('skip')
-      expect(result.result_message).to include('Observation categories: functional-status')
+      expect(result.result_message).to include('Observation categories: http://hl7.org/fhir/us/core/CodeSystem/us-core-category|functional-status')
     end
 
     it 'skips when a Condition category is missing' do
@@ -163,7 +189,7 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
       result = run(test_class, patient_ids: patient_id)
 
       expect(result.result).to eq('skip')
-      expect(result.result_message).to include('Condition categories: sdoh')
+      expect(result.result_message).to include('Condition categories: http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh')
     end
 
     it 'skips when Observation and Condition categories are missing' do
@@ -179,9 +205,11 @@ RSpec.describe USCoreTestKit::ScreeningAssessmentCategoryTest do
       result = run(test_class, patient_ids: patient_id)
 
       expect(result.result).to eq('skip')
-      expect(result.result_message).to include(
-        'Observation categories: functional-status, disability-status and Condition categories: sdoh'
-      )
+      expect(result.result_message).to include('Observation categories')
+      expect(result.result_message).to include('functional-status')
+      expect(result.result_message).to include('disability-status')
+      expect(result.result_message).to include('Condition categories')
+      expect(result.result_message).to include('sdoh')
     end
   end
 end


### PR DESCRIPTION
# Summary

This PR fixes GitHub Issue: https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/536

# ChangeLog
* Update value extractor to read both system and code values from ValueSet resources
* Update must_support generator to generate both system and code values for requiredBinding slice in metadata
* Update search_test generator to correct map system/code pairs to code list
* Update must support test and screen and assessment test to verify both system and code values

# Testing Guidance
* All unit tests shall pass
* Run integration test using Inferno reference server, test 2.49 shall report failure. There is a separated ticket to fix reference server.
