### PR TITLE
FI-3042 Don't Include OperationOutcomes when Checking Granular Scope Search Results

### DIFF
--- a/lib/us_core_test_kit/granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/granular_scope_search_test.rb
@@ -28,7 +28,7 @@ module USCoreTestKit
           if request.status != 200
             []
           else
-            fetch_all_bundled_resources
+            fetch_all_bundled_resources.select { |resource| resource.resourceType == resource_type }
           end
 
         mismatched_ids = mismatched_resource_ids(found_resources)
@@ -78,6 +78,7 @@ module USCoreTestKit
 
     def expected_resource_ids(resources)
       resources
+        .select { |resource| resource.resourceType == resource_type }
         .select do |resource|
           granular_scope_search_params.any? do |param|
             resource_matches_param?(resource, param[:name], param[:value])
@@ -88,6 +89,7 @@ module USCoreTestKit
 
     def mismatched_resource_ids(resources)
       resources
+        .select { |resource| resource.resourceType == resource_type }
         .reject do |resource|
           granular_scope_search_params.any? do |param|
             resource_matches_param?(resource, param[:name], param[:value])

--- a/spec/us_core/granular_scope_search_spec.rb
+++ b/spec/us_core/granular_scope_search_spec.rb
@@ -236,6 +236,24 @@ RSpec.describe USCoreTestKit::GranularScopeSearchTest do
         expect(result.result).to eq('pass')
       end
 
+      it 'passes if an OperationOutcome is included among matching resources' do
+        response_body =
+          FHIR::Bundle.new(
+            entry: [
+              { resource: matching_resource.to_hash },
+              { resource: matching_resource2.to_hash },
+              { resource: FHIR::OperationOutcome.new(id: "temp") }
+            ]
+          ).to_json
+        stub_request(request.verb.to_sym, request.url.split('?').first)
+          .with(query: request.query_parameters)
+          .to_return(body: response_body)
+
+        result = run(granular_scope_test, url:, patient_ids:, received_scopes:)
+
+        expect(result.result).to eq('pass')
+      end
+
       context 'with POST requests' do
         let!(:post_request) do
           repo_create(

--- a/spec/us_core/granular_scope_search_spec.rb
+++ b/spec/us_core/granular_scope_search_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe USCoreTestKit::GranularScopeSearchTest do
             entry: [
               { resource: matching_resource.to_hash },
               { resource: matching_resource2.to_hash },
-              { resource: FHIR::OperationOutcome.new(id: "temp") }
+              { resource: FHIR::OperationOutcome.new(id: "OperationOutcomeID") }
             ]
           ).to_json
         stub_request(request.verb.to_sym, request.url.split('?').first)
@@ -250,7 +250,6 @@ RSpec.describe USCoreTestKit::GranularScopeSearchTest do
           .to_return(body: response_body)
 
         result = run(granular_scope_test, url:, patient_ids:, received_scopes:)
-
         expect(result.result).to eq('pass')
       end
 


### PR DESCRIPTION
# Summary
Add guards against other returned resources within granular searches, such as OperationOutcome.

