### PR TITLE
FI-3060 Add MustSuport choice for Observation.effective[x]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ these tests.  This test kit requires at least 10 GB of memory are available to D
 - Run `run.sh` in this repo.
 - Navigate to `http://localhost`. The US Core test suite will be available.
 
-See the [Inferno Framework
-Documentation](https://inferno-framework.github.io/inferno-core/getting-started.html#getting-started-for-inferno-users)
+See the [Inferno Documentation](https://inferno-framework.github.io/docs/)
 for more information on running Inferno.
 
 ## License

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -7111,12 +7111,6 @@
         :path: ''
         :code: social-history
         :system: http://terminology.hl7.org/CodeSystem/observation-category
-    - :slice_id: Observation.effective[x]:effectiveDateTime
-      :slice_name: effectiveDateTime
-      :path: effective[x]
-      :discriminator:
-        :type: type
-        :code: DateTime
     :elements:
     - :path: status
     - :path: category
@@ -7128,6 +7122,7 @@
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
     - :path: valueCodeableConcept
       :original_path: value[x]
+    - :path: effective[x]
   :mandatory_elements:
   - Observation.status
   - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/metadata.yml
@@ -144,12 +144,6 @@
       :path: ''
       :code: social-history
       :system: http://terminology.hl7.org/CodeSystem/observation-category
-  - :slice_id: Observation.effective[x]:effectiveDateTime
-    :slice_name: effectiveDateTime
-    :path: effective[x]
-    :discriminator:
-      :type: type
-      :code: DateTime
   :elements:
   - :path: status
   - :path: category
@@ -161,6 +155,7 @@
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   - :path: valueCodeableConcept
     :original_path: value[x]
+  - :path: effective[x]
 :mandatory_elements:
 - Observation.status
 - Observation.category

--- a/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/smokingstatus_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/smokingstatus/smokingstatus_must_support_test.rb
@@ -15,7 +15,7 @@ module USCoreTestKit
         * Observation.category
         * Observation.category:SocialHistory
         * Observation.code
-        * Observation.effective[x]:effectiveDateTime
+        * Observation.effective[x]
         * Observation.status
         * Observation.subject
         * Observation.valueCodeableConcept

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -88,7 +88,11 @@ module USCoreTestKit
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
       ].freeze
 
-      VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
+      VERSION_SPECIFIC_MESSAGE_FILTERS = [
+        %r{Observation\.effective\.ofType\(Period\):.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus},
+        %r{Observation: Slice 'Observation\.effective\[x\]:effectiveDateTime':.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus},
+        %r{Observation\.effective\.ofType\(Period\).*This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
+      ].freeze
 
       def self.metadata
         @metadata ||= YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true)[:groups].map do |raw_metadata|

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
@@ -27,6 +27,7 @@ module USCoreTestKit
       def handle_special_cases
         add_must_support_choices
         add_patient_uscdi_elements
+        update_smoking_status_effective
       end
 
       def add_must_support_choices
@@ -79,7 +80,15 @@ module USCoreTestKit
             element[:path] = 'deceasedDateTime'
           end
         end
+      end
 
+      # US Core v6.1.0 Patch FHIR-43355, US Core Smoking Status Observation Profile may be supported
+      # either Observation.effectiveDateTime or Observation.effectivePeriod data element
+      def update_smoking_status_effective
+        return unless profile.id == 'us-core-smokingstatus'
+
+        must_supports[:slices].delete_if { |slice| slice[:slice_id] == 'Observation.effective[x]:effectiveDateTime' }
+        must_supports[:elements] << { path: 'effective[x]' }
 
       end
     end

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_7.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_7.rb
@@ -17,11 +17,13 @@ module USCoreTestKit
       end
 
       def handle_special_cases
-        us_core_6_extractor.handle_special_cases
+        us_core_6_extractor.add_patient_uscdi_elements
         add_must_support_choices
       end
 
       def add_must_support_choices
+        us_core_6_extractor.add_must_support_choices
+
         more_choices = []
 
         case profile.type

--- a/lib/us_core_test_kit/generator/suite_generator.rb
+++ b/lib/us_core_test_kit/generator/suite_generator.rb
@@ -18,7 +18,16 @@ module USCoreTestKit
       end
 
       def version_specific_message_filters
-        []
+        case ig_metadata.reformatted_version
+        when 'v610'
+          [
+            %r{Observation\.effective\.ofType\(Period\):.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus},
+            %r{Observation: Slice 'Observation\.effective\[x\]:effectiveDateTime':.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus},
+            %r{Observation\.effective\.ofType\(Period\).*This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
+          ]
+        else
+          []
+        end
       end
 
       def template

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -43,13 +43,13 @@ module USCoreTestKit
         /\A\S+: \S+: URL value '.*' does not resolve/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
       ].freeze
-
-      VERSION_SPECIFIC_MESSAGE_FILTERS = <%= if version_specific_message_filters.empty?
-        "[]"
-      else
-        "[\n" + version_specific_message_filters.map { |filter| "        %r{#{filter.source}}" }.join(",\n") + "\n      ]"
-      end %>.freeze
-
+<% if version_specific_message_filters.empty? %>
+      VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
+<% else %>
+      VERSION_SPECIFIC_MESSAGE_FILTERS = [
+        <%= version_specific_message_filters.map { |filter| "%r{#{filter.source}}" }.join(",\n        ") %>
+      ].freeze
+<% end %>
       def self.metadata
         @metadata ||= YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true)[:groups].map do |raw_metadata|
             Generator::GroupMetadata.new(raw_metadata)

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -44,7 +44,11 @@ module USCoreTestKit
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
       ].freeze
 
-      VERSION_SPECIFIC_MESSAGE_FILTERS = <%=version_specific_message_filters%>.freeze
+      VERSION_SPECIFIC_MESSAGE_FILTERS = <%= if version_specific_message_filters.empty?
+        "[]"
+      else
+        "[\n" + version_specific_message_filters.map { |filter| "        %r{#{filter.source}}" }.join(",\n") + "\n      ]"
+      end %>.freeze
 
       def self.metadata
         @metadata ||= YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true)[:groups].map do |raw_metadata|


### PR DESCRIPTION
# Summary
This PR fixed this Github issue: https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/560

# Changes:
* Remove MustSupport slice: effectiveDateTime
* Add MustSuport element: effective[x]
* Add version specific error fileter to allow effectivePeriod

# Testing Guidance
Current Inferno reference server does not have effectivePeriod for SmokingStatus. Will update server data to support this test case.
