### PR TITLE
FI3079 Combine general filter and version specific filter

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -129,7 +129,7 @@ module USCoreTestKit
         id :us_core_v311_fhir_api
 
         group from: :us_core_v311_capability_statement
-
+      
         group from: :us_core_v311_patient
         group from: :us_core_v311_allergy_intolerance
         group from: :us_core_v311_care_plan

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -57,7 +57,7 @@ module USCoreTestKit
       )
       version VERSION
 
-      VALIDATION_MESSAGE_FILTERS = [
+      GENERAL_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
@@ -71,6 +71,8 @@ module USCoreTestKit
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
 
+      VALIDATION_MESSAGE_FILTERS = GENERAL_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+
       def self.metadata
         @metadata ||= YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true)[:groups].map do |raw_metadata|
             Generator::GroupMetadata.new(raw_metadata)
@@ -81,7 +83,7 @@ module USCoreTestKit
 
       fhir_resource_validator do
         igs 'hl7.fhir.us.core#3.1.1'
-        message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+        message_filters = VALIDATION_MESSAGE_FILTERS
 
         exclude_message do |message|
 
@@ -127,7 +129,7 @@ module USCoreTestKit
         id :us_core_v311_fhir_api
 
         group from: :us_core_v311_capability_statement
-      
+
         group from: :us_core_v311_patient
         group from: :us_core_v311_allergy_intolerance
         group from: :us_core_v311_care_plan

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -59,7 +59,7 @@ module USCoreTestKit
       )
       version VERSION
 
-      VALIDATION_MESSAGE_FILTERS = [
+      GENERAL_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
@@ -73,6 +73,8 @@ module USCoreTestKit
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
 
+      VALIDATION_MESSAGE_FILTERS = GENERAL_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+
       def self.metadata
         @metadata ||= YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true)[:groups].map do |raw_metadata|
             Generator::GroupMetadata.new(raw_metadata)
@@ -83,7 +85,7 @@ module USCoreTestKit
 
       fhir_resource_validator do
         igs 'hl7.fhir.us.core#4.0.0'
-        message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+        message_filters = VALIDATION_MESSAGE_FILTERS
 
         exclude_message do |message|
 

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -69,7 +69,7 @@ module USCoreTestKit
       )
       version VERSION
 
-      VALIDATION_MESSAGE_FILTERS = [
+      GENERAL_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
@@ -83,6 +83,8 @@ module USCoreTestKit
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
 
+      VALIDATION_MESSAGE_FILTERS = GENERAL_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+
       def self.metadata
         @metadata ||= YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true)[:groups].map do |raw_metadata|
             Generator::GroupMetadata.new(raw_metadata)
@@ -93,7 +95,7 @@ module USCoreTestKit
 
       fhir_resource_validator do
         igs 'hl7.fhir.us.core#5.0.1'
-        message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+        message_filters = VALIDATION_MESSAGE_FILTERS
 
         exclude_message do |message|
 

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -158,7 +158,7 @@ module USCoreTestKit
         )
 
         group from: :us_core_v610_capability_statement
-
+      
         group from: :us_core_v610_patient
         group from: :us_core_v610_allergy_intolerance
         group from: :us_core_v610_care_plan
@@ -212,7 +212,7 @@ module USCoreTestKit
 
       group from: :us_core_v610_smart_granular_scopes,
             required_suite_options: USCoreOptions::SMART_2_REQUIREMENT
-
+      
     end
   end
 end

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -76,7 +76,7 @@ module USCoreTestKit
       )
       version VERSION
 
-      VALIDATION_MESSAGE_FILTERS = [
+      GENERAL_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
@@ -89,10 +89,12 @@ module USCoreTestKit
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [
-        %r{Observation\.effective\.ofType\(Period\):.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus},
-        %r{Observation: Slice 'Observation\.effective\[x\]:effectiveDateTime':.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus},
-        %r{Observation\.effective\.ofType\(Period\).*This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
+        %r{Observation\.effective\.ofType\(Period\):.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0},
+        %r{Observation: Slice 'Observation\.effective\[x\]:effectiveDateTime':.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0},
+        %r{Observation\.effective\.ofType\(Period\)\.end: This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
       ].freeze
+
+      VALIDATION_MESSAGE_FILTERS = GENERAL_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 
       def self.metadata
         @metadata ||= YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true)[:groups].map do |raw_metadata|
@@ -104,7 +106,7 @@ module USCoreTestKit
 
       fhir_resource_validator do
         igs 'hl7.fhir.us.core#6.1.0'
-        message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+        message_filters = VALIDATION_MESSAGE_FILTERS
 
         exclude_message do |message|
 
@@ -156,7 +158,7 @@ module USCoreTestKit
         )
 
         group from: :us_core_v610_capability_statement
-      
+
         group from: :us_core_v610_patient
         group from: :us_core_v610_allergy_intolerance
         group from: :us_core_v610_care_plan
@@ -210,7 +212,7 @@ module USCoreTestKit
 
       group from: :us_core_v610_smart_granular_scopes,
             required_suite_options: USCoreOptions::SMART_2_REQUIREMENT
-      
+
     end
   end
 end

--- a/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
@@ -81,7 +81,7 @@ module USCoreTestKit
       )
       version VERSION
 
-      VALIDATION_MESSAGE_FILTERS = [
+      GENERAL_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
@@ -95,6 +95,8 @@ module USCoreTestKit
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
 
+      VALIDATION_MESSAGE_FILTERS = GENERAL_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+
       def self.metadata
         @metadata ||= YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true)[:groups].map do |raw_metadata|
             Generator::GroupMetadata.new(raw_metadata)
@@ -105,7 +107,7 @@ module USCoreTestKit
 
       fhir_resource_validator do
         igs 'hl7.fhir.us.core#7.0.0'
-        message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+        message_filters = VALIDATION_MESSAGE_FILTERS
 
         exclude_message do |message|
 

--- a/lib/us_core_test_kit/generator/suite_generator.rb
+++ b/lib/us_core_test_kit/generator/suite_generator.rb
@@ -21,9 +21,9 @@ module USCoreTestKit
         case ig_metadata.reformatted_version
         when 'v610'
           [
-            %r{Observation\.effective\.ofType\(Period\):.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus},
-            %r{Observation: Slice 'Observation\.effective\[x\]:effectiveDateTime':.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus},
-            %r{Observation\.effective\.ofType\(Period\).*This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
+            %r{Observation\.effective\.ofType\(Period\):.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0},
+            %r{Observation: Slice 'Observation\.effective\[x\]:effectiveDateTime':.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0},
+            %r{Observation\.effective\.ofType\(Period\)\.end: This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
           ]
         else
           []

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -32,7 +32,7 @@ module USCoreTestKit
       )
       version VERSION
 
-      VALIDATION_MESSAGE_FILTERS = [
+      GENERAL_MESSAGE_FILTERS = [
         %r{Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         %r{Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris},
         /Observation\.effective\.ofType\(Period\): .*vs-1:/, # Invalid invariant in FHIR v4.0.1
@@ -50,6 +50,8 @@ module USCoreTestKit
         <%= version_specific_message_filters.map { |filter| "%r{#{filter.source}}" }.join(",\n        ") %>
       ].freeze
 <% end %>
+      VALIDATION_MESSAGE_FILTERS = GENERAL_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+
       def self.metadata
         @metadata ||= YAML.load_file(File.join(__dir__, 'metadata.yml'), aliases: true)[:groups].map do |raw_metadata|
             Generator::GroupMetadata.new(raw_metadata)
@@ -60,7 +62,7 @@ module USCoreTestKit
 
       fhir_resource_validator do
         igs '<%= ig_identifier %>'
-        message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
+        message_filters = VALIDATION_MESSAGE_FILTERS
 
         exclude_message do |message|
 


### PR DESCRIPTION
# Summary

This PR fixes GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/573. The issue is casued by that US Core has two fileters: `VALIDATION_MESSAGE_FILTERS` and `VERSION_SPECIFIC_MESSAGE_FILTERS`. (g)(10) test kit uses `VALIDATION_MESSAGE_FILTERS` only.

## Resolution:
Combine `VALIDATION_MESSAGE_FILTERS` and `VERSION_SPECIFIC_MESSAGE_FILTERS` so there's no code change required in (g)(10) test kit.


# Testing Guidance
* Running US Core Test Kit v3.1.1 - 6.1.0 using reference server. 

