### PR TITLE
FI-3367 Re-generate so that read tests are after always after search tests

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/encounter/metadata.yml
@@ -271,8 +271,6 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Encounter
 :tests:
-- :id: us_core_v311_encounter_read_test
-  :file_name: encounter_read_test.rb
 - :id: us_core_v311_encounter_patient_search_test
   :file_name: encounter_patient_search_test.rb
 - :id: us_core_v311_encounter__id_search_test
@@ -287,6 +285,8 @@
   :file_name: encounter_patient_type_search_test.rb
 - :id: us_core_v311_encounter_date_patient_search_test
   :file_name: encounter_date_patient_search_test.rb
+- :id: us_core_v311_encounter_read_test
+  :file_name: encounter_read_test.rb
 - :id: us_core_v311_encounter_provenance_revinclude_search_test
   :file_name: encounter_provenance_revinclude_search_test.rb
 - :id: us_core_v311_encounter_validation_test

--- a/lib/us_core_test_kit/generated/v3.1.1/encounter_group.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/encounter_group.rb
@@ -1,4 +1,3 @@
-require_relative 'encounter/encounter_read_test'
 require_relative 'encounter/encounter_patient_search_test'
 require_relative 'encounter/encounter_id_search_test'
 require_relative 'encounter/encounter_identifier_search_test'
@@ -6,6 +5,7 @@ require_relative 'encounter/encounter_class_patient_search_test'
 require_relative 'encounter/encounter_patient_status_search_test'
 require_relative 'encounter/encounter_patient_type_search_test'
 require_relative 'encounter/encounter_date_patient_search_test'
+require_relative 'encounter/encounter_read_test'
 require_relative 'encounter/encounter_provenance_revinclude_search_test'
 require_relative 'encounter/encounter_validation_test'
 require_relative 'encounter/encounter_must_support_test'
@@ -83,7 +83,6 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'encounter', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v311_encounter_read_test
       test from: :us_core_v311_encounter_patient_search_test
       test from: :us_core_v311_encounter__id_search_test
       test from: :us_core_v311_encounter_identifier_search_test
@@ -91,6 +90,7 @@ read succeeds.
       test from: :us_core_v311_encounter_patient_status_search_test
       test from: :us_core_v311_encounter_patient_type_search_test
       test from: :us_core_v311_encounter_date_patient_search_test
+      test from: :us_core_v311_encounter_read_test
       test from: :us_core_v311_encounter_provenance_revinclude_search_test
       test from: :us_core_v311_encounter_validation_test
       test from: :us_core_v311_encounter_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/metadata.yml
@@ -1995,8 +1995,6 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Encounter
   :tests:
-  - :id: us_core_v311_encounter_read_test
-    :file_name: encounter_read_test.rb
   - :id: us_core_v311_encounter_patient_search_test
     :file_name: encounter_patient_search_test.rb
   - :id: us_core_v311_encounter__id_search_test
@@ -2011,6 +2009,8 @@
     :file_name: encounter_patient_type_search_test.rb
   - :id: us_core_v311_encounter_date_patient_search_test
     :file_name: encounter_date_patient_search_test.rb
+  - :id: us_core_v311_encounter_read_test
+    :file_name: encounter_read_test.rb
   - :id: us_core_v311_encounter_provenance_revinclude_search_test
     :file_name: encounter_provenance_revinclude_search_test.rb
   - :id: us_core_v311_encounter_validation_test
@@ -6474,12 +6474,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Endpoint
   :tests:
-  - :id: us_core_v311_organization_read_test
-    :file_name: organization_read_test.rb
   - :id: us_core_v311_organization_name_search_test
     :file_name: organization_name_search_test.rb
   - :id: us_core_v311_organization_address_search_test
     :file_name: organization_address_search_test.rb
+  - :id: us_core_v311_organization_read_test
+    :file_name: organization_read_test.rb
   - :id: us_core_v311_organization_validation_test
     :file_name: organization_validation_test.rb
   - :id: us_core_v311_organization_must_support_test
@@ -6922,12 +6922,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Organization
   :tests:
-  - :id: us_core_v311_practitioner_read_test
-    :file_name: practitioner_read_test.rb
   - :id: us_core_v311_practitioner_name_search_test
     :file_name: practitioner_name_search_test.rb
   - :id: us_core_v311_practitioner_identifier_search_test
     :file_name: practitioner_identifier_search_test.rb
+  - :id: us_core_v311_practitioner_read_test
+    :file_name: practitioner_read_test.rb
   - :id: us_core_v311_practitioner_validation_test
     :file_name: practitioner_validation_test.rb
   - :id: us_core_v311_practitioner_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/organization/metadata.yml
@@ -116,12 +116,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Endpoint
 :tests:
-- :id: us_core_v311_organization_read_test
-  :file_name: organization_read_test.rb
 - :id: us_core_v311_organization_name_search_test
   :file_name: organization_name_search_test.rb
 - :id: us_core_v311_organization_address_search_test
   :file_name: organization_address_search_test.rb
+- :id: us_core_v311_organization_read_test
+  :file_name: organization_read_test.rb
 - :id: us_core_v311_organization_validation_test
   :file_name: organization_validation_test.rb
 - :id: us_core_v311_organization_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/organization_group.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/organization_group.rb
@@ -1,6 +1,6 @@
-require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_name_search_test'
 require_relative 'organization/organization_address_search_test'
+require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_validation_test'
 require_relative 'organization/organization_must_support_test'
 
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'organization', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v311_organization_read_test
       test from: :us_core_v311_organization_name_search_test
       test from: :us_core_v311_organization_address_search_test
+      test from: :us_core_v311_organization_read_test
       test from: :us_core_v311_organization_validation_test
       test from: :us_core_v311_organization_must_support_test
     end

--- a/lib/us_core_test_kit/generated/v3.1.1/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v3.1.1/practitioner/metadata.yml
@@ -110,12 +110,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Organization
 :tests:
-- :id: us_core_v311_practitioner_read_test
-  :file_name: practitioner_read_test.rb
 - :id: us_core_v311_practitioner_name_search_test
   :file_name: practitioner_name_search_test.rb
 - :id: us_core_v311_practitioner_identifier_search_test
   :file_name: practitioner_identifier_search_test.rb
+- :id: us_core_v311_practitioner_read_test
+  :file_name: practitioner_read_test.rb
 - :id: us_core_v311_practitioner_validation_test
   :file_name: practitioner_validation_test.rb
 - :id: us_core_v311_practitioner_must_support_test

--- a/lib/us_core_test_kit/generated/v3.1.1/practitioner_group.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/practitioner_group.rb
@@ -1,6 +1,6 @@
-require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_name_search_test'
 require_relative 'practitioner/practitioner_identifier_search_test'
+require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_validation_test'
 require_relative 'practitioner/practitioner_must_support_test'
 
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'practitioner', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v311_practitioner_read_test
       test from: :us_core_v311_practitioner_name_search_test
       test from: :us_core_v311_practitioner_identifier_search_test
+      test from: :us_core_v311_practitioner_read_test
       test from: :us_core_v311_practitioner_validation_test
       test from: :us_core_v311_practitioner_must_support_test
     end

--- a/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/encounter/metadata.yml
@@ -294,8 +294,6 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Encounter
 :tests:
-- :id: us_core_v400_encounter_read_test
-  :file_name: encounter_read_test.rb
 - :id: us_core_v400_encounter_patient_search_test
   :file_name: encounter_patient_search_test.rb
 - :id: us_core_v400_encounter__id_search_test
@@ -310,6 +308,8 @@
   :file_name: encounter_class_patient_search_test.rb
 - :id: us_core_v400_encounter_patient_type_search_test
   :file_name: encounter_patient_type_search_test.rb
+- :id: us_core_v400_encounter_read_test
+  :file_name: encounter_read_test.rb
 - :id: us_core_v400_encounter_provenance_revinclude_search_test
   :file_name: encounter_provenance_revinclude_search_test.rb
 - :id: us_core_v400_encounter_validation_test

--- a/lib/us_core_test_kit/generated/v4.0.0/encounter_group.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/encounter_group.rb
@@ -1,4 +1,3 @@
-require_relative 'encounter/encounter_read_test'
 require_relative 'encounter/encounter_patient_search_test'
 require_relative 'encounter/encounter_id_search_test'
 require_relative 'encounter/encounter_identifier_search_test'
@@ -6,6 +5,7 @@ require_relative 'encounter/encounter_date_patient_search_test'
 require_relative 'encounter/encounter_patient_status_search_test'
 require_relative 'encounter/encounter_class_patient_search_test'
 require_relative 'encounter/encounter_patient_type_search_test'
+require_relative 'encounter/encounter_read_test'
 require_relative 'encounter/encounter_provenance_revinclude_search_test'
 require_relative 'encounter/encounter_validation_test'
 require_relative 'encounter/encounter_must_support_test'
@@ -83,7 +83,6 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'encounter', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v400_encounter_read_test
       test from: :us_core_v400_encounter_patient_search_test
       test from: :us_core_v400_encounter__id_search_test
       test from: :us_core_v400_encounter_identifier_search_test
@@ -91,6 +90,7 @@ read succeeds.
       test from: :us_core_v400_encounter_patient_status_search_test
       test from: :us_core_v400_encounter_class_patient_search_test
       test from: :us_core_v400_encounter_patient_type_search_test
+      test from: :us_core_v400_encounter_read_test
       test from: :us_core_v400_encounter_provenance_revinclude_search_test
       test from: :us_core_v400_encounter_validation_test
       test from: :us_core_v400_encounter_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/metadata.yml
@@ -2063,8 +2063,6 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Encounter
   :tests:
-  - :id: us_core_v400_encounter_read_test
-    :file_name: encounter_read_test.rb
   - :id: us_core_v400_encounter_patient_search_test
     :file_name: encounter_patient_search_test.rb
   - :id: us_core_v400_encounter__id_search_test
@@ -2079,6 +2077,8 @@
     :file_name: encounter_class_patient_search_test.rb
   - :id: us_core_v400_encounter_patient_type_search_test
     :file_name: encounter_patient_type_search_test.rb
+  - :id: us_core_v400_encounter_read_test
+    :file_name: encounter_read_test.rb
   - :id: us_core_v400_encounter_provenance_revinclude_search_test
     :file_name: encounter_provenance_revinclude_search_test.rb
   - :id: us_core_v400_encounter_validation_test
@@ -7098,12 +7098,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Endpoint
   :tests:
-  - :id: us_core_v400_organization_read_test
-    :file_name: organization_read_test.rb
   - :id: us_core_v400_organization_name_search_test
     :file_name: organization_name_search_test.rb
   - :id: us_core_v400_organization_address_search_test
     :file_name: organization_address_search_test.rb
+  - :id: us_core_v400_organization_read_test
+    :file_name: organization_read_test.rb
   - :id: us_core_v400_organization_validation_test
     :file_name: organization_validation_test.rb
   - :id: us_core_v400_organization_must_support_test
@@ -7557,12 +7557,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Organization
   :tests:
-  - :id: us_core_v400_practitioner_read_test
-    :file_name: practitioner_read_test.rb
   - :id: us_core_v400_practitioner_name_search_test
     :file_name: practitioner_name_search_test.rb
   - :id: us_core_v400_practitioner_identifier_search_test
     :file_name: practitioner_identifier_search_test.rb
+  - :id: us_core_v400_practitioner_read_test
+    :file_name: practitioner_read_test.rb
   - :id: us_core_v400_practitioner_validation_test
     :file_name: practitioner_validation_test.rb
   - :id: us_core_v400_practitioner_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/organization/metadata.yml
@@ -128,12 +128,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Endpoint
 :tests:
-- :id: us_core_v400_organization_read_test
-  :file_name: organization_read_test.rb
 - :id: us_core_v400_organization_name_search_test
   :file_name: organization_name_search_test.rb
 - :id: us_core_v400_organization_address_search_test
   :file_name: organization_address_search_test.rb
+- :id: us_core_v400_organization_read_test
+  :file_name: organization_read_test.rb
 - :id: us_core_v400_organization_validation_test
   :file_name: organization_validation_test.rb
 - :id: us_core_v400_organization_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/organization_group.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/organization_group.rb
@@ -1,6 +1,6 @@
-require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_name_search_test'
 require_relative 'organization/organization_address_search_test'
+require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_validation_test'
 require_relative 'organization/organization_must_support_test'
 
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'organization', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v400_organization_read_test
       test from: :us_core_v400_organization_name_search_test
       test from: :us_core_v400_organization_address_search_test
+      test from: :us_core_v400_organization_read_test
       test from: :us_core_v400_organization_validation_test
       test from: :us_core_v400_organization_must_support_test
     end

--- a/lib/us_core_test_kit/generated/v4.0.0/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v4.0.0/practitioner/metadata.yml
@@ -110,12 +110,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Organization
 :tests:
-- :id: us_core_v400_practitioner_read_test
-  :file_name: practitioner_read_test.rb
 - :id: us_core_v400_practitioner_name_search_test
   :file_name: practitioner_name_search_test.rb
 - :id: us_core_v400_practitioner_identifier_search_test
   :file_name: practitioner_identifier_search_test.rb
+- :id: us_core_v400_practitioner_read_test
+  :file_name: practitioner_read_test.rb
 - :id: us_core_v400_practitioner_validation_test
   :file_name: practitioner_validation_test.rb
 - :id: us_core_v400_practitioner_must_support_test

--- a/lib/us_core_test_kit/generated/v4.0.0/practitioner_group.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/practitioner_group.rb
@@ -1,6 +1,6 @@
-require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_name_search_test'
 require_relative 'practitioner/practitioner_identifier_search_test'
+require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_validation_test'
 require_relative 'practitioner/practitioner_must_support_test'
 
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'practitioner', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v400_practitioner_read_test
       test from: :us_core_v400_practitioner_name_search_test
       test from: :us_core_v400_practitioner_identifier_search_test
+      test from: :us_core_v400_practitioner_read_test
       test from: :us_core_v400_practitioner_validation_test
       test from: :us_core_v400_practitioner_must_support_test
     end

--- a/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/metadata.yml
@@ -9544,12 +9544,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Endpoint
   :tests:
-  - :id: us_core_v501_organization_read_test
-    :file_name: organization_read_test.rb
   - :id: us_core_v501_organization_name_search_test
     :file_name: organization_name_search_test.rb
   - :id: us_core_v501_organization_address_search_test
     :file_name: organization_address_search_test.rb
+  - :id: us_core_v501_organization_read_test
+    :file_name: organization_read_test.rb
   - :id: us_core_v501_organization_validation_test
     :file_name: organization_validation_test.rb
   - :id: us_core_v501_organization_must_support_test
@@ -10053,14 +10053,14 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Organization
   :tests:
-  - :id: us_core_v501_practitioner_read_test
-    :file_name: practitioner_read_test.rb
   - :id: us_core_v501_practitioner__id_search_test
     :file_name: practitioner_id_search_test.rb
   - :id: us_core_v501_practitioner_name_search_test
     :file_name: practitioner_name_search_test.rb
   - :id: us_core_v501_practitioner_identifier_search_test
     :file_name: practitioner_identifier_search_test.rb
+  - :id: us_core_v501_practitioner_read_test
+    :file_name: practitioner_read_test.rb
   - :id: us_core_v501_practitioner_validation_test
     :file_name: practitioner_validation_test.rb
   - :id: us_core_v501_practitioner_must_support_test
@@ -10201,12 +10201,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Endpoint
   :tests:
-  - :id: us_core_v501_practitioner_role_read_test
-    :file_name: practitioner_role_read_test.rb
   - :id: us_core_v501_practitioner_role_specialty_search_test
     :file_name: practitioner_role_specialty_search_test.rb
   - :id: us_core_v501_practitioner_role_practitioner_search_test
     :file_name: practitioner_role_practitioner_search_test.rb
+  - :id: us_core_v501_practitioner_role_read_test
+    :file_name: practitioner_role_read_test.rb
   - :id: us_core_v501_practitioner_role_validation_test
     :file_name: practitioner_role_validation_test.rb
   - :id: us_core_v501_practitioner_role_must_support_test
@@ -10985,12 +10985,12 @@
     :profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :tests:
-  - :id: us_core_v501_related_person_read_test
-    :file_name: related_person_read_test.rb
   - :id: us_core_v501_related_person_patient_search_test
     :file_name: related_person_patient_search_test.rb
   - :id: us_core_v501_related_person__id_search_test
     :file_name: related_person_id_search_test.rb
+  - :id: us_core_v501_related_person_read_test
+    :file_name: related_person_read_test.rb
   - :id: us_core_v501_related_person_provenance_revinclude_search_test
     :file_name: related_person_provenance_revinclude_search_test.rb
   - :id: us_core_v501_related_person_validation_test

--- a/lib/us_core_test_kit/generated/v5.0.1/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/organization/metadata.yml
@@ -128,12 +128,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Endpoint
 :tests:
-- :id: us_core_v501_organization_read_test
-  :file_name: organization_read_test.rb
 - :id: us_core_v501_organization_name_search_test
   :file_name: organization_name_search_test.rb
 - :id: us_core_v501_organization_address_search_test
   :file_name: organization_address_search_test.rb
+- :id: us_core_v501_organization_read_test
+  :file_name: organization_read_test.rb
 - :id: us_core_v501_organization_validation_test
   :file_name: organization_validation_test.rb
 - :id: us_core_v501_organization_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/organization_group.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/organization_group.rb
@@ -1,6 +1,6 @@
-require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_name_search_test'
 require_relative 'organization/organization_address_search_test'
+require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_validation_test'
 require_relative 'organization/organization_must_support_test'
 
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'organization', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v501_organization_read_test
       test from: :us_core_v501_organization_name_search_test
       test from: :us_core_v501_organization_address_search_test
+      test from: :us_core_v501_organization_read_test
       test from: :us_core_v501_organization_validation_test
       test from: :us_core_v501_organization_must_support_test
     end

--- a/lib/us_core_test_kit/generated/v5.0.1/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/practitioner/metadata.yml
@@ -150,14 +150,14 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Organization
 :tests:
-- :id: us_core_v501_practitioner_read_test
-  :file_name: practitioner_read_test.rb
 - :id: us_core_v501_practitioner__id_search_test
   :file_name: practitioner_id_search_test.rb
 - :id: us_core_v501_practitioner_name_search_test
   :file_name: practitioner_name_search_test.rb
 - :id: us_core_v501_practitioner_identifier_search_test
   :file_name: practitioner_identifier_search_test.rb
+- :id: us_core_v501_practitioner_read_test
+  :file_name: practitioner_read_test.rb
 - :id: us_core_v501_practitioner_validation_test
   :file_name: practitioner_validation_test.rb
 - :id: us_core_v501_practitioner_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/practitioner_group.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/practitioner_group.rb
@@ -1,7 +1,7 @@
-require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_id_search_test'
 require_relative 'practitioner/practitioner_name_search_test'
 require_relative 'practitioner/practitioner_identifier_search_test'
+require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_validation_test'
 require_relative 'practitioner/practitioner_must_support_test'
 
@@ -76,10 +76,10 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'practitioner', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v501_practitioner_read_test
       test from: :us_core_v501_practitioner__id_search_test
       test from: :us_core_v501_practitioner_name_search_test
       test from: :us_core_v501_practitioner_identifier_search_test
+      test from: :us_core_v501_practitioner_read_test
       test from: :us_core_v501_practitioner_validation_test
       test from: :us_core_v501_practitioner_must_support_test
     end

--- a/lib/us_core_test_kit/generated/v5.0.1/practitioner_role/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/practitioner_role/metadata.yml
@@ -132,12 +132,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Endpoint
 :tests:
-- :id: us_core_v501_practitioner_role_read_test
-  :file_name: practitioner_role_read_test.rb
 - :id: us_core_v501_practitioner_role_specialty_search_test
   :file_name: practitioner_role_specialty_search_test.rb
 - :id: us_core_v501_practitioner_role_practitioner_search_test
   :file_name: practitioner_role_practitioner_search_test.rb
+- :id: us_core_v501_practitioner_role_read_test
+  :file_name: practitioner_role_read_test.rb
 - :id: us_core_v501_practitioner_role_validation_test
   :file_name: practitioner_role_validation_test.rb
 - :id: us_core_v501_practitioner_role_must_support_test

--- a/lib/us_core_test_kit/generated/v5.0.1/practitioner_role_group.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/practitioner_role_group.rb
@@ -1,6 +1,6 @@
-require_relative 'practitioner_role/practitioner_role_read_test'
 require_relative 'practitioner_role/practitioner_role_specialty_search_test'
 require_relative 'practitioner_role/practitioner_role_practitioner_search_test'
+require_relative 'practitioner_role/practitioner_role_read_test'
 require_relative 'practitioner_role/practitioner_role_validation_test'
 require_relative 'practitioner_role/practitioner_role_must_support_test'
 require_relative 'practitioner_role/practitioner_role_reference_resolution_test'
@@ -78,9 +78,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'practitioner_role', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v501_practitioner_role_read_test
       test from: :us_core_v501_practitioner_role_specialty_search_test
       test from: :us_core_v501_practitioner_role_practitioner_search_test
+      test from: :us_core_v501_practitioner_role_read_test
       test from: :us_core_v501_practitioner_role_validation_test
       test from: :us_core_v501_practitioner_role_must_support_test
       test from: :us_core_v501_practitioner_role_reference_resolution_test

--- a/lib/us_core_test_kit/generated/v5.0.1/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v5.0.1/related_person/metadata.yml
@@ -95,12 +95,12 @@
   :profiles:
   - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :tests:
-- :id: us_core_v501_related_person_read_test
-  :file_name: related_person_read_test.rb
 - :id: us_core_v501_related_person_patient_search_test
   :file_name: related_person_patient_search_test.rb
 - :id: us_core_v501_related_person__id_search_test
   :file_name: related_person_id_search_test.rb
+- :id: us_core_v501_related_person_read_test
+  :file_name: related_person_read_test.rb
 - :id: us_core_v501_related_person_provenance_revinclude_search_test
   :file_name: related_person_provenance_revinclude_search_test.rb
 - :id: us_core_v501_related_person_validation_test

--- a/lib/us_core_test_kit/generated/v5.0.1/related_person_group.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/related_person_group.rb
@@ -1,6 +1,6 @@
-require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_patient_search_test'
 require_relative 'related_person/related_person_id_search_test'
+require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_provenance_revinclude_search_test'
 require_relative 'related_person/related_person_validation_test'
 require_relative 'related_person/related_person_must_support_test'
@@ -76,9 +76,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'related_person', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v501_related_person_read_test
       test from: :us_core_v501_related_person_patient_search_test
       test from: :us_core_v501_related_person__id_search_test
+      test from: :us_core_v501_related_person_read_test
       test from: :us_core_v501_related_person_provenance_revinclude_search_test
       test from: :us_core_v501_related_person_validation_test
       test from: :us_core_v501_related_person_must_support_test

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -10221,12 +10221,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Endpoint
   :tests:
-  - :id: us_core_v610_organization_read_test
-    :file_name: organization_read_test.rb
   - :id: us_core_v610_organization_name_search_test
     :file_name: organization_name_search_test.rb
   - :id: us_core_v610_organization_address_search_test
     :file_name: organization_address_search_test.rb
+  - :id: us_core_v610_organization_read_test
+    :file_name: organization_read_test.rb
   - :id: us_core_v610_organization_validation_test
     :file_name: organization_validation_test.rb
   - :id: us_core_v610_organization_must_support_test
@@ -10771,14 +10771,14 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Organization
   :tests:
-  - :id: us_core_v610_practitioner_read_test
-    :file_name: practitioner_read_test.rb
   - :id: us_core_v610_practitioner__id_search_test
     :file_name: practitioner_id_search_test.rb
   - :id: us_core_v610_practitioner_name_search_test
     :file_name: practitioner_name_search_test.rb
   - :id: us_core_v610_practitioner_identifier_search_test
     :file_name: practitioner_identifier_search_test.rb
+  - :id: us_core_v610_practitioner_read_test
+    :file_name: practitioner_read_test.rb
   - :id: us_core_v610_practitioner_validation_test
     :file_name: practitioner_validation_test.rb
   - :id: us_core_v610_practitioner_must_support_test
@@ -10921,12 +10921,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Endpoint
   :tests:
-  - :id: us_core_v610_practitioner_role_read_test
-    :file_name: practitioner_role_read_test.rb
   - :id: us_core_v610_practitioner_role_specialty_search_test
     :file_name: practitioner_role_specialty_search_test.rb
   - :id: us_core_v610_practitioner_role_practitioner_search_test
     :file_name: practitioner_role_practitioner_search_test.rb
+  - :id: us_core_v610_practitioner_role_read_test
+    :file_name: practitioner_role_read_test.rb
   - :id: us_core_v610_practitioner_role_validation_test
     :file_name: practitioner_role_validation_test.rb
   - :id: us_core_v610_practitioner_role_must_support_test
@@ -11691,8 +11691,6 @@
     :profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :tests:
-  - :id: us_core_v610_related_person_read_test
-    :file_name: related_person_read_test.rb
   - :id: us_core_v610_related_person_patient_search_test
     :file_name: related_person_patient_search_test.rb
   - :id: us_core_v610_related_person__id_search_test
@@ -11701,6 +11699,8 @@
     :file_name: related_person_name_search_test.rb
   - :id: us_core_v610_related_person_patient_name_search_test
     :file_name: related_person_patient_name_search_test.rb
+  - :id: us_core_v610_related_person_read_test
+    :file_name: related_person_read_test.rb
   - :id: us_core_v610_related_person_provenance_revinclude_search_test
     :file_name: related_person_provenance_revinclude_search_test.rb
   - :id: us_core_v610_related_person_validation_test
@@ -12149,12 +12149,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Substance
   :tests:
-  - :id: us_core_v610_specimen_read_test
-    :file_name: specimen_read_test.rb
   - :id: us_core_v610_specimen_patient_search_test
     :file_name: specimen_patient_search_test.rb
   - :id: us_core_v610_specimen__id_search_test
     :file_name: specimen_id_search_test.rb
+  - :id: us_core_v610_specimen_read_test
+    :file_name: specimen_read_test.rb
   - :id: us_core_v610_specimen_validation_test
     :file_name: specimen_validation_test.rb
   - :id: us_core_v610_specimen_must_support_test

--- a/lib/us_core_test_kit/generated/v6.1.0/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/organization/metadata.yml
@@ -128,12 +128,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Endpoint
 :tests:
-- :id: us_core_v610_organization_read_test
-  :file_name: organization_read_test.rb
 - :id: us_core_v610_organization_name_search_test
   :file_name: organization_name_search_test.rb
 - :id: us_core_v610_organization_address_search_test
   :file_name: organization_address_search_test.rb
+- :id: us_core_v610_organization_read_test
+  :file_name: organization_read_test.rb
 - :id: us_core_v610_organization_validation_test
   :file_name: organization_validation_test.rb
 - :id: us_core_v610_organization_must_support_test

--- a/lib/us_core_test_kit/generated/v6.1.0/organization_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/organization_group.rb
@@ -1,6 +1,6 @@
-require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_name_search_test'
 require_relative 'organization/organization_address_search_test'
+require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_validation_test'
 require_relative 'organization/organization_must_support_test'
 
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'organization', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v610_organization_read_test
       test from: :us_core_v610_organization_name_search_test
       test from: :us_core_v610_organization_address_search_test
+      test from: :us_core_v610_organization_read_test
       test from: :us_core_v610_organization_validation_test
       test from: :us_core_v610_organization_must_support_test
     end

--- a/lib/us_core_test_kit/generated/v6.1.0/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/practitioner/metadata.yml
@@ -144,14 +144,14 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Organization
 :tests:
-- :id: us_core_v610_practitioner_read_test
-  :file_name: practitioner_read_test.rb
 - :id: us_core_v610_practitioner__id_search_test
   :file_name: practitioner_id_search_test.rb
 - :id: us_core_v610_practitioner_name_search_test
   :file_name: practitioner_name_search_test.rb
 - :id: us_core_v610_practitioner_identifier_search_test
   :file_name: practitioner_identifier_search_test.rb
+- :id: us_core_v610_practitioner_read_test
+  :file_name: practitioner_read_test.rb
 - :id: us_core_v610_practitioner_validation_test
   :file_name: practitioner_validation_test.rb
 - :id: us_core_v610_practitioner_must_support_test

--- a/lib/us_core_test_kit/generated/v6.1.0/practitioner_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/practitioner_group.rb
@@ -1,7 +1,7 @@
-require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_id_search_test'
 require_relative 'practitioner/practitioner_name_search_test'
 require_relative 'practitioner/practitioner_identifier_search_test'
+require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_validation_test'
 require_relative 'practitioner/practitioner_must_support_test'
 require_relative 'practitioner/practitioner_address_test'
@@ -77,10 +77,10 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'practitioner', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v610_practitioner_read_test
       test from: :us_core_v610_practitioner__id_search_test
       test from: :us_core_v610_practitioner_name_search_test
       test from: :us_core_v610_practitioner_identifier_search_test
+      test from: :us_core_v610_practitioner_read_test
       test from: :us_core_v610_practitioner_validation_test
       test from: :us_core_v610_practitioner_must_support_test
       test from: :us_core_v610_practitioner_address_test

--- a/lib/us_core_test_kit/generated/v6.1.0/practitioner_role/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/practitioner_role/metadata.yml
@@ -132,12 +132,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Endpoint
 :tests:
-- :id: us_core_v610_practitioner_role_read_test
-  :file_name: practitioner_role_read_test.rb
 - :id: us_core_v610_practitioner_role_specialty_search_test
   :file_name: practitioner_role_specialty_search_test.rb
 - :id: us_core_v610_practitioner_role_practitioner_search_test
   :file_name: practitioner_role_practitioner_search_test.rb
+- :id: us_core_v610_practitioner_role_read_test
+  :file_name: practitioner_role_read_test.rb
 - :id: us_core_v610_practitioner_role_validation_test
   :file_name: practitioner_role_validation_test.rb
 - :id: us_core_v610_practitioner_role_must_support_test

--- a/lib/us_core_test_kit/generated/v6.1.0/practitioner_role_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/practitioner_role_group.rb
@@ -1,6 +1,6 @@
-require_relative 'practitioner_role/practitioner_role_read_test'
 require_relative 'practitioner_role/practitioner_role_specialty_search_test'
 require_relative 'practitioner_role/practitioner_role_practitioner_search_test'
+require_relative 'practitioner_role/practitioner_role_read_test'
 require_relative 'practitioner_role/practitioner_role_validation_test'
 require_relative 'practitioner_role/practitioner_role_must_support_test'
 require_relative 'practitioner_role/practitioner_role_reference_resolution_test'
@@ -78,9 +78,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'practitioner_role', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v610_practitioner_role_read_test
       test from: :us_core_v610_practitioner_role_specialty_search_test
       test from: :us_core_v610_practitioner_role_practitioner_search_test
+      test from: :us_core_v610_practitioner_role_read_test
       test from: :us_core_v610_practitioner_role_validation_test
       test from: :us_core_v610_practitioner_role_must_support_test
       test from: :us_core_v610_practitioner_role_reference_resolution_test

--- a/lib/us_core_test_kit/generated/v6.1.0/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/related_person/metadata.yml
@@ -116,8 +116,6 @@
   :profiles:
   - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :tests:
-- :id: us_core_v610_related_person_read_test
-  :file_name: related_person_read_test.rb
 - :id: us_core_v610_related_person_patient_search_test
   :file_name: related_person_patient_search_test.rb
 - :id: us_core_v610_related_person__id_search_test
@@ -126,6 +124,8 @@
   :file_name: related_person_name_search_test.rb
 - :id: us_core_v610_related_person_patient_name_search_test
   :file_name: related_person_patient_name_search_test.rb
+- :id: us_core_v610_related_person_read_test
+  :file_name: related_person_read_test.rb
 - :id: us_core_v610_related_person_provenance_revinclude_search_test
   :file_name: related_person_provenance_revinclude_search_test.rb
 - :id: us_core_v610_related_person_validation_test

--- a/lib/us_core_test_kit/generated/v6.1.0/related_person_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/related_person_group.rb
@@ -1,8 +1,8 @@
-require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_patient_search_test'
 require_relative 'related_person/related_person_id_search_test'
 require_relative 'related_person/related_person_name_search_test'
 require_relative 'related_person/related_person_patient_name_search_test'
+require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_provenance_revinclude_search_test'
 require_relative 'related_person/related_person_validation_test'
 require_relative 'related_person/related_person_must_support_test'
@@ -78,11 +78,11 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'related_person', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v610_related_person_read_test
       test from: :us_core_v610_related_person_patient_search_test
       test from: :us_core_v610_related_person__id_search_test
       test from: :us_core_v610_related_person_name_search_test
       test from: :us_core_v610_related_person_patient_name_search_test
+      test from: :us_core_v610_related_person_read_test
       test from: :us_core_v610_related_person_provenance_revinclude_search_test
       test from: :us_core_v610_related_person_validation_test
       test from: :us_core_v610_related_person_must_support_test

--- a/lib/us_core_test_kit/generated/v6.1.0/specimen/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/specimen/metadata.yml
@@ -101,12 +101,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Substance
 :tests:
-- :id: us_core_v610_specimen_read_test
-  :file_name: specimen_read_test.rb
 - :id: us_core_v610_specimen_patient_search_test
   :file_name: specimen_patient_search_test.rb
 - :id: us_core_v610_specimen__id_search_test
   :file_name: specimen_id_search_test.rb
+- :id: us_core_v610_specimen_read_test
+  :file_name: specimen_read_test.rb
 - :id: us_core_v610_specimen_validation_test
   :file_name: specimen_validation_test.rb
 - :id: us_core_v610_specimen_must_support_test

--- a/lib/us_core_test_kit/generated/v6.1.0/specimen_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/specimen_group.rb
@@ -1,6 +1,6 @@
-require_relative 'specimen/specimen_read_test'
 require_relative 'specimen/specimen_patient_search_test'
 require_relative 'specimen/specimen_id_search_test'
+require_relative 'specimen/specimen_read_test'
 require_relative 'specimen/specimen_validation_test'
 require_relative 'specimen/specimen_must_support_test'
 require_relative 'specimen/specimen_reference_resolution_test'
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'specimen', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v610_specimen_read_test
       test from: :us_core_v610_specimen_patient_search_test
       test from: :us_core_v610_specimen__id_search_test
+      test from: :us_core_v610_specimen_read_test
       test from: :us_core_v610_specimen_validation_test
       test from: :us_core_v610_specimen_must_support_test
       test from: :us_core_v610_specimen_reference_resolution_test

--- a/lib/us_core_test_kit/generated/v7.0.0/location/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/location/metadata.yml
@@ -168,8 +168,6 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Endpoint
 :tests:
-- :id: us_core_v700_location_read_test
-  :file_name: location_read_test.rb
 - :id: us_core_v700_location_address_search_test
   :file_name: location_address_search_test.rb
 - :id: us_core_v700_location_address_city_search_test
@@ -180,6 +178,8 @@
   :file_name: location_address_state_search_test.rb
 - :id: us_core_v700_location_name_search_test
   :file_name: location_name_search_test.rb
+- :id: us_core_v700_location_read_test
+  :file_name: location_read_test.rb
 - :id: us_core_v700_location_validation_test
   :file_name: location_validation_test.rb
 - :id: us_core_v700_location_must_support_test

--- a/lib/us_core_test_kit/generated/v7.0.0/location_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/location_group.rb
@@ -1,9 +1,9 @@
-require_relative 'location/location_read_test'
 require_relative 'location/location_address_search_test'
 require_relative 'location/location_address_city_search_test'
 require_relative 'location/location_address_postalcode_search_test'
 require_relative 'location/location_address_state_search_test'
 require_relative 'location/location_name_search_test'
+require_relative 'location/location_read_test'
 require_relative 'location/location_validation_test'
 require_relative 'location/location_must_support_test'
 require_relative 'location/location_reference_resolution_test'
@@ -79,12 +79,12 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'location', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v700_location_read_test
       test from: :us_core_v700_location_address_search_test
       test from: :us_core_v700_location_address_city_search_test
       test from: :us_core_v700_location_address_postalcode_search_test
       test from: :us_core_v700_location_address_state_search_test
       test from: :us_core_v700_location_name_search_test
+      test from: :us_core_v700_location_read_test
       test from: :us_core_v700_location_validation_test
       test from: :us_core_v700_location_must_support_test
       test from: :us_core_v700_location_reference_resolution_test

--- a/lib/us_core_test_kit/generated/v7.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/metadata.yml
@@ -3649,8 +3649,6 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Endpoint
   :tests:
-  - :id: us_core_v700_location_read_test
-    :file_name: location_read_test.rb
   - :id: us_core_v700_location_address_search_test
     :file_name: location_address_search_test.rb
   - :id: us_core_v700_location_address_city_search_test
@@ -3661,6 +3659,8 @@
     :file_name: location_address_state_search_test.rb
   - :id: us_core_v700_location_name_search_test
     :file_name: location_name_search_test.rb
+  - :id: us_core_v700_location_read_test
+    :file_name: location_read_test.rb
   - :id: us_core_v700_location_validation_test
     :file_name: location_validation_test.rb
   - :id: us_core_v700_location_must_support_test
@@ -12027,12 +12027,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Endpoint
   :tests:
-  - :id: us_core_v700_organization_read_test
-    :file_name: organization_read_test.rb
   - :id: us_core_v700_organization_address_search_test
     :file_name: organization_address_search_test.rb
   - :id: us_core_v700_organization_name_search_test
     :file_name: organization_name_search_test.rb
+  - :id: us_core_v700_organization_read_test
+    :file_name: organization_read_test.rb
   - :id: us_core_v700_organization_validation_test
     :file_name: organization_validation_test.rb
   - :id: us_core_v700_organization_must_support_test
@@ -12577,14 +12577,14 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Organization
   :tests:
-  - :id: us_core_v700_practitioner_read_test
-    :file_name: practitioner_read_test.rb
   - :id: us_core_v700_practitioner__id_search_test
     :file_name: practitioner_id_search_test.rb
   - :id: us_core_v700_practitioner_identifier_search_test
     :file_name: practitioner_identifier_search_test.rb
   - :id: us_core_v700_practitioner_name_search_test
     :file_name: practitioner_name_search_test.rb
+  - :id: us_core_v700_practitioner_read_test
+    :file_name: practitioner_read_test.rb
   - :id: us_core_v700_practitioner_validation_test
     :file_name: practitioner_validation_test.rb
   - :id: us_core_v700_practitioner_must_support_test
@@ -12729,12 +12729,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Endpoint
   :tests:
-  - :id: us_core_v700_practitioner_role_read_test
-    :file_name: practitioner_role_read_test.rb
   - :id: us_core_v700_practitioner_role_practitioner_search_test
     :file_name: practitioner_role_practitioner_search_test.rb
   - :id: us_core_v700_practitioner_role_specialty_search_test
     :file_name: practitioner_role_specialty_search_test.rb
+  - :id: us_core_v700_practitioner_role_read_test
+    :file_name: practitioner_role_read_test.rb
   - :id: us_core_v700_practitioner_role_validation_test
     :file_name: practitioner_role_validation_test.rb
   - :id: us_core_v700_practitioner_role_must_support_test
@@ -13520,8 +13520,6 @@
     :profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
   :tests:
-  - :id: us_core_v700_related_person_read_test
-    :file_name: related_person_read_test.rb
   - :id: us_core_v700_related_person_patient_search_test
     :file_name: related_person_patient_search_test.rb
   - :id: us_core_v700_related_person__id_search_test
@@ -13530,6 +13528,8 @@
     :file_name: related_person_name_search_test.rb
   - :id: us_core_v700_related_person_patient_name_search_test
     :file_name: related_person_patient_name_search_test.rb
+  - :id: us_core_v700_related_person_read_test
+    :file_name: related_person_read_test.rb
   - :id: us_core_v700_related_person_provenance_revinclude_search_test
     :file_name: related_person_provenance_revinclude_search_test.rb
   - :id: us_core_v700_related_person_validation_test
@@ -14007,12 +14007,12 @@
     :profiles:
     - http://hl7.org/fhir/StructureDefinition/Substance
   :tests:
-  - :id: us_core_v700_specimen_read_test
-    :file_name: specimen_read_test.rb
   - :id: us_core_v700_specimen_patient_search_test
     :file_name: specimen_patient_search_test.rb
   - :id: us_core_v700_specimen__id_search_test
     :file_name: specimen_id_search_test.rb
+  - :id: us_core_v700_specimen_read_test
+    :file_name: specimen_read_test.rb
   - :id: us_core_v700_specimen_validation_test
     :file_name: specimen_validation_test.rb
   - :id: us_core_v700_specimen_must_support_test

--- a/lib/us_core_test_kit/generated/v7.0.0/organization/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/organization/metadata.yml
@@ -128,12 +128,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Endpoint
 :tests:
-- :id: us_core_v700_organization_read_test
-  :file_name: organization_read_test.rb
 - :id: us_core_v700_organization_address_search_test
   :file_name: organization_address_search_test.rb
 - :id: us_core_v700_organization_name_search_test
   :file_name: organization_name_search_test.rb
+- :id: us_core_v700_organization_read_test
+  :file_name: organization_read_test.rb
 - :id: us_core_v700_organization_validation_test
   :file_name: organization_validation_test.rb
 - :id: us_core_v700_organization_must_support_test

--- a/lib/us_core_test_kit/generated/v7.0.0/organization_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/organization_group.rb
@@ -1,6 +1,6 @@
-require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_address_search_test'
 require_relative 'organization/organization_name_search_test'
+require_relative 'organization/organization_read_test'
 require_relative 'organization/organization_validation_test'
 require_relative 'organization/organization_must_support_test'
 
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'organization', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v700_organization_read_test
       test from: :us_core_v700_organization_address_search_test
       test from: :us_core_v700_organization_name_search_test
+      test from: :us_core_v700_organization_read_test
       test from: :us_core_v700_organization_validation_test
       test from: :us_core_v700_organization_must_support_test
     end

--- a/lib/us_core_test_kit/generated/v7.0.0/practitioner/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/practitioner/metadata.yml
@@ -144,14 +144,14 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Organization
 :tests:
-- :id: us_core_v700_practitioner_read_test
-  :file_name: practitioner_read_test.rb
 - :id: us_core_v700_practitioner__id_search_test
   :file_name: practitioner_id_search_test.rb
 - :id: us_core_v700_practitioner_identifier_search_test
   :file_name: practitioner_identifier_search_test.rb
 - :id: us_core_v700_practitioner_name_search_test
   :file_name: practitioner_name_search_test.rb
+- :id: us_core_v700_practitioner_read_test
+  :file_name: practitioner_read_test.rb
 - :id: us_core_v700_practitioner_validation_test
   :file_name: practitioner_validation_test.rb
 - :id: us_core_v700_practitioner_must_support_test

--- a/lib/us_core_test_kit/generated/v7.0.0/practitioner_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/practitioner_group.rb
@@ -1,7 +1,7 @@
-require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_id_search_test'
 require_relative 'practitioner/practitioner_identifier_search_test'
 require_relative 'practitioner/practitioner_name_search_test'
+require_relative 'practitioner/practitioner_read_test'
 require_relative 'practitioner/practitioner_validation_test'
 require_relative 'practitioner/practitioner_must_support_test'
 require_relative 'practitioner/practitioner_address_test'
@@ -77,10 +77,10 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'practitioner', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v700_practitioner_read_test
       test from: :us_core_v700_practitioner__id_search_test
       test from: :us_core_v700_practitioner_identifier_search_test
       test from: :us_core_v700_practitioner_name_search_test
+      test from: :us_core_v700_practitioner_read_test
       test from: :us_core_v700_practitioner_validation_test
       test from: :us_core_v700_practitioner_must_support_test
       test from: :us_core_v700_practitioner_address_test

--- a/lib/us_core_test_kit/generated/v7.0.0/practitioner_role/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/practitioner_role/metadata.yml
@@ -134,12 +134,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Endpoint
 :tests:
-- :id: us_core_v700_practitioner_role_read_test
-  :file_name: practitioner_role_read_test.rb
 - :id: us_core_v700_practitioner_role_practitioner_search_test
   :file_name: practitioner_role_practitioner_search_test.rb
 - :id: us_core_v700_practitioner_role_specialty_search_test
   :file_name: practitioner_role_specialty_search_test.rb
+- :id: us_core_v700_practitioner_role_read_test
+  :file_name: practitioner_role_read_test.rb
 - :id: us_core_v700_practitioner_role_validation_test
   :file_name: practitioner_role_validation_test.rb
 - :id: us_core_v700_practitioner_role_must_support_test

--- a/lib/us_core_test_kit/generated/v7.0.0/practitioner_role_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/practitioner_role_group.rb
@@ -1,6 +1,6 @@
-require_relative 'practitioner_role/practitioner_role_read_test'
 require_relative 'practitioner_role/practitioner_role_practitioner_search_test'
 require_relative 'practitioner_role/practitioner_role_specialty_search_test'
+require_relative 'practitioner_role/practitioner_role_read_test'
 require_relative 'practitioner_role/practitioner_role_validation_test'
 require_relative 'practitioner_role/practitioner_role_must_support_test'
 require_relative 'practitioner_role/practitioner_role_reference_resolution_test'
@@ -78,9 +78,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'practitioner_role', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v700_practitioner_role_read_test
       test from: :us_core_v700_practitioner_role_practitioner_search_test
       test from: :us_core_v700_practitioner_role_specialty_search_test
+      test from: :us_core_v700_practitioner_role_read_test
       test from: :us_core_v700_practitioner_role_validation_test
       test from: :us_core_v700_practitioner_role_must_support_test
       test from: :us_core_v700_practitioner_role_reference_resolution_test

--- a/lib/us_core_test_kit/generated/v7.0.0/related_person/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/related_person/metadata.yml
@@ -116,8 +116,6 @@
   :profiles:
   - http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
 :tests:
-- :id: us_core_v700_related_person_read_test
-  :file_name: related_person_read_test.rb
 - :id: us_core_v700_related_person_patient_search_test
   :file_name: related_person_patient_search_test.rb
 - :id: us_core_v700_related_person__id_search_test
@@ -126,6 +124,8 @@
   :file_name: related_person_name_search_test.rb
 - :id: us_core_v700_related_person_patient_name_search_test
   :file_name: related_person_patient_name_search_test.rb
+- :id: us_core_v700_related_person_read_test
+  :file_name: related_person_read_test.rb
 - :id: us_core_v700_related_person_provenance_revinclude_search_test
   :file_name: related_person_provenance_revinclude_search_test.rb
 - :id: us_core_v700_related_person_validation_test

--- a/lib/us_core_test_kit/generated/v7.0.0/related_person_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/related_person_group.rb
@@ -1,8 +1,8 @@
-require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_patient_search_test'
 require_relative 'related_person/related_person_id_search_test'
 require_relative 'related_person/related_person_name_search_test'
 require_relative 'related_person/related_person_patient_name_search_test'
+require_relative 'related_person/related_person_read_test'
 require_relative 'related_person/related_person_provenance_revinclude_search_test'
 require_relative 'related_person/related_person_validation_test'
 require_relative 'related_person/related_person_must_support_test'
@@ -78,11 +78,11 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'related_person', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v700_related_person_read_test
       test from: :us_core_v700_related_person_patient_search_test
       test from: :us_core_v700_related_person__id_search_test
       test from: :us_core_v700_related_person_name_search_test
       test from: :us_core_v700_related_person_patient_name_search_test
+      test from: :us_core_v700_related_person_read_test
       test from: :us_core_v700_related_person_provenance_revinclude_search_test
       test from: :us_core_v700_related_person_validation_test
       test from: :us_core_v700_related_person_must_support_test

--- a/lib/us_core_test_kit/generated/v7.0.0/specimen/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/specimen/metadata.yml
@@ -113,12 +113,12 @@
   :profiles:
   - http://hl7.org/fhir/StructureDefinition/Substance
 :tests:
-- :id: us_core_v700_specimen_read_test
-  :file_name: specimen_read_test.rb
 - :id: us_core_v700_specimen_patient_search_test
   :file_name: specimen_patient_search_test.rb
 - :id: us_core_v700_specimen__id_search_test
   :file_name: specimen_id_search_test.rb
+- :id: us_core_v700_specimen_read_test
+  :file_name: specimen_read_test.rb
 - :id: us_core_v700_specimen_validation_test
   :file_name: specimen_validation_test.rb
 - :id: us_core_v700_specimen_must_support_test

--- a/lib/us_core_test_kit/generated/v7.0.0/specimen_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/specimen_group.rb
@@ -1,6 +1,6 @@
-require_relative 'specimen/specimen_read_test'
 require_relative 'specimen/specimen_patient_search_test'
 require_relative 'specimen/specimen_id_search_test'
+require_relative 'specimen/specimen_read_test'
 require_relative 'specimen/specimen_validation_test'
 require_relative 'specimen/specimen_must_support_test'
 require_relative 'specimen/specimen_reference_resolution_test'
@@ -75,9 +75,9 @@ read succeeds.
         @metadata ||= Generator::GroupMetadata.new(YAML.load_file(File.join(__dir__, 'specimen', 'metadata.yml'), aliases: true))
       end
   
-      test from: :us_core_v700_specimen_read_test
       test from: :us_core_v700_specimen_patient_search_test
       test from: :us_core_v700_specimen__id_search_test
+      test from: :us_core_v700_specimen_read_test
       test from: :us_core_v700_specimen_validation_test
       test from: :us_core_v700_specimen_must_support_test
       test from: :us_core_v700_specimen_reference_resolution_test

--- a/lib/us_core_test_kit/generator/group_metadata.rb
+++ b/lib/us_core_test_kit/generator/group_metadata.rb
@@ -42,7 +42,7 @@ module USCoreTestKit
           instance_variable_set(:"@#{key}", value)
         end
       end
-=begin
+
       def delayed?
         @is_delayed ||= if resource == 'Patient'
                           false
@@ -66,14 +66,14 @@ module USCoreTestKit
       def searchable_delayed_resource?
         SpecialCases::SEARCHABLE_DELAYED_RESOURCES.key?(resource) && SpecialCases::SEARCHABLE_DELAYED_RESOURCES[resource].include?(reformatted_version)
       end
-=end
+
       def add_test(id:, file_name:)
         self.tests ||= []
 
-        # test_metadata = {
-        #   id: id,
-        #   file_name: file_name
-        # }
+        test_metadata = {
+          id: id,
+          file_name: file_name
+        }
 
         # if delayed? && id.include?('read')
         #   self.tests.unshift(test_metadata)

--- a/lib/us_core_test_kit/generator/group_metadata.rb
+++ b/lib/us_core_test_kit/generator/group_metadata.rb
@@ -42,7 +42,7 @@ module USCoreTestKit
           instance_variable_set(:"@#{key}", value)
         end
       end
-
+=begin
       def delayed?
         @is_delayed ||= if resource == 'Patient'
                           false
@@ -66,20 +66,22 @@ module USCoreTestKit
       def searchable_delayed_resource?
         SpecialCases::SEARCHABLE_DELAYED_RESOURCES.key?(resource) && SpecialCases::SEARCHABLE_DELAYED_RESOURCES[resource].include?(reformatted_version)
       end
-
+=end
       def add_test(id:, file_name:)
         self.tests ||= []
 
-        test_metadata = {
-          id: id,
-          file_name: file_name
-        }
+        # test_metadata = {
+        #   id: id,
+        #   file_name: file_name
+        # }
 
-        if delayed? && id.include?('read')
-          self.tests.unshift(test_metadata)
-        else
-          self.tests << test_metadata
-        end
+        # if delayed? && id.include?('read')
+        #   self.tests.unshift(test_metadata)
+        # else
+        #   self.tests << test_metadata
+        # end
+
+        self.tests << test_metadata
       end
 
       def add_granular_scope_test(id:, file_name:)


### PR DESCRIPTION
# Summary

Putting this up as a draft PR if anyone wants to investigate test kit behavior with this setup. I'm not expecting this to be merged to main. I'll close this PR once the bug preventing Encounter group to pass on its own is fixed (FI-3367).

# Testing Guidance

