### PR TITLE
Rename US Core v3.1.1 profile support test to resource support test

### DIFF
--- a/lib/us_core_test_kit/custom_groups/v3.1.1/capability_statement_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v3.1.1/capability_statement_group.rb
@@ -2,7 +2,7 @@ require 'tls_test_kit'
 require_relative '../capability_statement/conformance_support_test'
 require_relative '../capability_statement/fhir_version_test'
 require_relative '../capability_statement/json_support_test'
-require_relative './profile_support_test'
+require_relative './resource_support_test'
 
 module USCoreTestKit
   module USCoreV311
@@ -100,7 +100,7 @@ module USCoreTestKit
       test from: :us_core_fhir_version
       test from: :us_core_json_support
 
-      test from: :us_core_profile_support do
+      test from: :us_core_v311_resource_support do
         config(
           options: { us_core_resources: PROFILES.keys }
         )

--- a/lib/us_core_test_kit/custom_groups/v3.1.1/resource_support_test.rb
+++ b/lib/us_core_test_kit/custom_groups/v3.1.1/resource_support_test.rb
@@ -1,7 +1,7 @@
 module USCoreTestKit
   module USCoreV311
     class ProfileSupportTest < Inferno::Test
-      id :us_core_profile_support
+      id :us_core_v311_resource_support
       title 'Capability Statement lists support for required US Core Resoruce Types'
       description %(
         The US Core Implementation Guide states:

--- a/spec/us_core/us_core_v311_resource_support_test_spec.rb
+++ b/spec/us_core/us_core_v311_resource_support_test_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/us_core_test_kit/custom_groups/v3.1.1/profile_support_test'
+require_relative '../../lib/us_core_test_kit/custom_groups/v3.1.1/resource_support_test'
 
 RSpec.describe USCoreTestKit::USCoreV311::ProfileSupportTest do
   def run(runnable, inputs = {})


### PR DESCRIPTION
# Summary

US Core v3.1.1 has a special CapabilityStatement resource support test which verifies that server suports at least Patient + 1 resources. For US Core v4.0.0, this requirement is changed to server supports US Core Patient + 1 US Core profiles. The orginal resource support test for US Core v311 test suite accidentally had the same id as the one in US Core v4+ test suite.

# Change Log:
* Rename v3.1.1's profile_support_test.rb to resource_support_test.rb
* Change the test id for resource_support_test to match version and purpose

# Testing Guidance
* All unit test shall pass
* Running US Core 3.1.1 test suite using default reference server. CapabilityStatement test group (test group 2.1) shall pass
