### PR TITLE
FI-3421 Remove media and media.link from DiagnosticReport's MustSupport list

### DIFF
--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/diagnostic_report_note_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/diagnostic_report_note_must_support_test.rb
@@ -18,8 +18,6 @@ module USCoreTestKit
         * DiagnosticReport.effectiveDateTime
         * DiagnosticReport.encounter
         * DiagnosticReport.issued
-        * DiagnosticReport.media
-        * DiagnosticReport.media.link
         * DiagnosticReport.performer
         * DiagnosticReport.presentedForm
         * DiagnosticReport.result

--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/diagnostic_report_note_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/diagnostic_report_note_reference_resolution_test.rb
@@ -16,7 +16,6 @@ module USCoreTestKit
         Elements which may provide external references include:
 
         * DiagnosticReport.encounter
-        * DiagnosticReport.media.link
         * DiagnosticReport.performer
         * DiagnosticReport.result
         * DiagnosticReport.subject

--- a/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/diagnostic_report_note/metadata.yml
@@ -192,10 +192,6 @@
     :target_profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-result
-  - :path: media
-  - :path: media.link
-    :types:
-    - Reference
   - :path: presentedForm
 :mandatory_elements:
 - DiagnosticReport.status

--- a/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v6.1.0/metadata.yml
@@ -1887,10 +1887,6 @@
       :target_profiles:
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-result
-    - :path: media
-    - :path: media.link
-      :types:
-      - Reference
     - :path: presentedForm
   :mandatory_elements:
   - DiagnosticReport.status

--- a/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/diagnostic_report_note_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/diagnostic_report_note_must_support_test.rb
@@ -18,8 +18,6 @@ module USCoreTestKit
         * DiagnosticReport.effectiveDateTime
         * DiagnosticReport.encounter
         * DiagnosticReport.issued
-        * DiagnosticReport.media
-        * DiagnosticReport.media.link
         * DiagnosticReport.performer
         * DiagnosticReport.presentedForm
         * DiagnosticReport.result

--- a/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/diagnostic_report_note_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/diagnostic_report_note_reference_resolution_test.rb
@@ -16,7 +16,6 @@ module USCoreTestKit
         Elements which may provide external references include:
 
         * DiagnosticReport.encounter
-        * DiagnosticReport.media.link
         * DiagnosticReport.performer
         * DiagnosticReport.result
         * DiagnosticReport.subject

--- a/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/metadata.yml
@@ -219,10 +219,6 @@
     :target_profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-result
-  - :path: media
-  - :path: media.link
-    :types:
-    - Reference
   - :path: presentedForm
 :mandatory_elements:
 - DiagnosticReport.status

--- a/lib/us_core_test_kit/generated/v7.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/metadata.yml
@@ -1981,10 +1981,6 @@
       :target_profiles:
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-result
-    - :path: media
-    - :path: media.link
-      :types:
-      - Reference
     - :path: presentedForm
   :mandatory_elements:
   - DiagnosticReport.status

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
@@ -93,12 +93,14 @@ module USCoreTestKit
         must_supports[:elements] << { path: 'effective[x]' }
       end
 
+      # US Core v6.1.0 Patch FI-44693, Add MustSupport choice between Practitioner.address and PractitionerRole
       def remove_practitioner_address
         return unless profile.type == 'Practitioner'
 
         must_supports[:elements].delete_if { |element| element[:path].start_with?('address') }
       end
 
+      # US Core v6.1.0 Patch FI-46240, Remove the Must Support on media and media.link
       def remove_diagnosticreport_media
         return unless profile.id == 'us-core-diagnosticreport-note'
         must_supports[:elements].delete_if { |element| element[:path].start_with?('media') }

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
@@ -29,6 +29,7 @@ module USCoreTestKit
         add_patient_uscdi_elements
         update_smoking_status_effective
         remove_practitioner_address
+        remove_diagnosticreport_media
       end
 
       def add_must_support_choices
@@ -96,6 +97,11 @@ module USCoreTestKit
         return unless profile.type == 'Practitioner'
 
         must_supports[:elements].delete_if { |element| element[:path].start_with?('address') }
+      end
+
+      def remove_diagnosticreport_media
+        return unless profile.id == 'us-core-diagnosticreport-note'
+        must_supports[:elements].delete_if { |element| element[:path].start_with?('media') }
       end
     end
   end

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_7.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_7.rb
@@ -20,6 +20,7 @@ module USCoreTestKit
         us_core_6_extractor.add_patient_uscdi_elements
         add_must_support_choices
         us_core_6_extractor.remove_practitioner_address
+        us_core_6_extractor.remove_diagnosticreport_media
       end
 
       def add_must_support_choices


### PR DESCRIPTION
# Summary

This PR fixes JIRA ticket FI-3421 Remove media and media.link from DiagnosticReport's MustSupport list

# Testing Guidance

Start US Core Test Kit for v6.1.0:
Expand Test: 2.10.10 "All must support elements are provided in the DiagnosticReport resources returned"
Go to About page
Verify that `DiagnosticReport.media` and `DiagnosticReport.media.link` are not in the list

Expand Test 2.10.11 "MustSupport references within DiagnosticReport resources are valid"
Go to About page
Verify that `DiagnosticReport.media.link` is not in the list

Start US Core Test Kit for v7.0.0
Do the same verification as US Core v6.1.0