### PR TITLE
FI-3133 Test name typo for granular scope tests.

### DIFF
--- a/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope1_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope1_group.rb
@@ -13,7 +13,7 @@ require_relative './granular_scope_tests/condition/condition_granular_scope_read
 module USCoreTestKit
   module USCoreV610
     class ConditionGranularScope1Group < Inferno::TestGroup
-      title 'Condition Granular Scope Tests Tests'
+      title 'Condition Granular Scope Tests'
       short_description 'Verify support for the server capabilities required by the US Core Condition Encounter Diagnosis Profile.'
       description %(
   The tests in this group repeat all of the searches from the US Core

--- a/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/condition_granular_scope2_group.rb
@@ -13,7 +13,7 @@ require_relative './granular_scope_tests/condition/condition_granular_scope_read
 module USCoreTestKit
   module USCoreV610
     class ConditionGranularScope2Group < Inferno::TestGroup
-      title 'Condition Granular Scope Tests Tests'
+      title 'Condition Granular Scope Tests'
       short_description 'Verify support for the server capabilities required by the US Core Condition Encounter Diagnosis Profile.'
       description %(
   The tests in this group repeat all of the searches from the US Core

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope1_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope1_group.rb
@@ -8,7 +8,7 @@ require_relative './granular_scope_tests/observation/observation_granular_scope_
 module USCoreTestKit
   module USCoreV610
     class ObservationGranularScope1Group < Inferno::TestGroup
-      title 'Observation Granular Scope Tests Tests'
+      title 'Observation Granular Scope Tests'
       short_description 'Verify support for the server capabilities required by the US Core Laboratory Result Observation Profile.'
       description %(
   The tests in this group repeat all of the searches from the US Core

--- a/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/observation_granular_scope2_group.rb
@@ -8,7 +8,7 @@ require_relative './granular_scope_tests/observation/observation_granular_scope_
 module USCoreTestKit
   module USCoreV610
     class ObservationGranularScope2Group < Inferno::TestGroup
-      title 'Observation Granular Scope Tests Tests'
+      title 'Observation Granular Scope Tests'
       short_description 'Verify support for the server capabilities required by the US Core Laboratory Result Observation Profile.'
       description %(
   The tests in this group repeat all of the searches from the US Core

--- a/lib/us_core_test_kit/generated/v7.0.0/condition_granular_scope1_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/condition_granular_scope1_group.rb
@@ -14,7 +14,7 @@ require_relative './granular_scope_tests/condition/condition_granular_scope_read
 module USCoreTestKit
   module USCoreV700
     class ConditionGranularScope1Group < Inferno::TestGroup
-      title 'Condition Granular Scope Tests Tests'
+      title 'Condition Granular Scope Tests'
       short_description 'Verify support for the server capabilities required by the US Core Condition Encounter Diagnosis Profile.'
       description %(
   The tests in this group repeat all of the searches from the US Core

--- a/lib/us_core_test_kit/generated/v7.0.0/condition_granular_scope2_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/condition_granular_scope2_group.rb
@@ -14,7 +14,7 @@ require_relative './granular_scope_tests/condition/condition_granular_scope_read
 module USCoreTestKit
   module USCoreV700
     class ConditionGranularScope2Group < Inferno::TestGroup
-      title 'Condition Granular Scope Tests Tests'
+      title 'Condition Granular Scope Tests'
       short_description 'Verify support for the server capabilities required by the US Core Condition Encounter Diagnosis Profile.'
       description %(
   The tests in this group repeat all of the searches from the US Core

--- a/lib/us_core_test_kit/generated/v7.0.0/observation_granular_scope1_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/observation_granular_scope1_group.rb
@@ -9,7 +9,7 @@ require_relative './granular_scope_tests/observation/observation_granular_scope_
 module USCoreTestKit
   module USCoreV700
     class ObservationGranularScope1Group < Inferno::TestGroup
-      title 'Observation Granular Scope Tests Tests'
+      title 'Observation Granular Scope Tests'
       short_description 'Verify support for the server capabilities required by the US Core Laboratory Result Observation Profile.'
       description %(
   The tests in this group repeat all of the searches from the US Core

--- a/lib/us_core_test_kit/generated/v7.0.0/observation_granular_scope2_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/observation_granular_scope2_group.rb
@@ -9,7 +9,7 @@ require_relative './granular_scope_tests/observation/observation_granular_scope_
 module USCoreTestKit
   module USCoreV700
     class ObservationGranularScope2Group < Inferno::TestGroup
-      title 'Observation Granular Scope Tests Tests'
+      title 'Observation Granular Scope Tests'
       short_description 'Verify support for the server capabilities required by the US Core Laboratory Result Observation Profile.'
       description %(
   The tests in this group repeat all of the searches from the US Core

--- a/lib/us_core_test_kit/generator/granular_scope_resource_type_group_generator.rb
+++ b/lib/us_core_test_kit/generator/granular_scope_resource_type_group_generator.rb
@@ -58,7 +58,7 @@ module USCoreTestKit
       end
 
       def title
-        "#{resource_type} Granular Scope Tests"
+        "#{resource_type} Granular Scope"
       end
 
       def short_description


### PR DESCRIPTION
# Summary
This PR fixes FI-3133 Test name typo for granular scope tests.
The root is that both the granular scope class and granular scope template have trailing term "Tests".

This PR can be reviewed after SVAP 2024.

# Code change
* Remove the trailing "Tests" from title property
* Add misisng id into generator template.

# Testing Guidance
Verify 9.14.2.2 and 9.14.2.3 test does not have "Tests Tests" in their test title.

