### PR TITLE
FI-3445 Add media and media.link back to US Core v7 DiagnosticReport must support

### DIFF
--- a/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/diagnostic_report_note_must_support_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/diagnostic_report_note_must_support_test.rb
@@ -18,6 +18,8 @@ module USCoreTestKit
         * DiagnosticReport.effectiveDateTime
         * DiagnosticReport.encounter
         * DiagnosticReport.issued
+        * DiagnosticReport.media
+        * DiagnosticReport.media.link
         * DiagnosticReport.performer
         * DiagnosticReport.presentedForm
         * DiagnosticReport.result

--- a/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/diagnostic_report_note_reference_resolution_test.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/diagnostic_report_note_reference_resolution_test.rb
@@ -16,6 +16,7 @@ module USCoreTestKit
         Elements which may provide external references include:
 
         * DiagnosticReport.encounter
+        * DiagnosticReport.media.link
         * DiagnosticReport.performer
         * DiagnosticReport.result
         * DiagnosticReport.subject

--- a/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/diagnostic_report_note/metadata.yml
@@ -219,6 +219,10 @@
     :target_profiles:
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
     - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-result
+  - :path: media
+  - :path: media.link
+    :types:
+    - Reference
   - :path: presentedForm
 :mandatory_elements:
 - DiagnosticReport.status

--- a/lib/us_core_test_kit/generated/v7.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v7.0.0/metadata.yml
@@ -1981,6 +1981,10 @@
       :target_profiles:
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
       - http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-result
+    - :path: media
+    - :path: media.link
+      :types:
+      - Reference
     - :path: presentedForm
   :mandatory_elements:
   - DiagnosticReport.status

--- a/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
@@ -170,7 +170,7 @@ module USCoreTestKit
         )
 
         group from: :us_core_v700_capability_statement
-
+      
         group from: :us_core_v700_patient
         group from: :us_core_v700_allergy_intolerance
         group from: :us_core_v700_care_plan
@@ -231,7 +231,7 @@ module USCoreTestKit
       group from: :us_core_v700_smart_granular_scopes,
             id: :us_core_v700_smart_granular_scopes_stu2_2,
             required_suite_options: USCoreOptions::SMART_2_2_REQUIREMENT
-
+      
     end
   end
 end

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_6.rb
@@ -93,14 +93,15 @@ module USCoreTestKit
         must_supports[:elements] << { path: 'effective[x]' }
       end
 
-      # US Core v6.1.0 Patch FI-44693, Add MustSupport choice between Practitioner.address and PractitionerRole
+      # US Core v6.1.0 Patch FHIR-44693, Add MustSupport choice between Practitioner.address and PractitionerRole
+      # This is fixed formally in US Core v7
       def remove_practitioner_address
         return unless profile.type == 'Practitioner'
 
         must_supports[:elements].delete_if { |element| element[:path].start_with?('address') }
       end
 
-      # US Core v6.1.0 Patch FI-46240, Remove the Must Support on media and media.link
+      # US Core v6.1.0 Patch FHIR-46240, Remove the Must Support on media and media.link
       def remove_diagnosticreport_media
         return unless profile.id == 'us-core-diagnosticreport-note'
         must_supports[:elements].delete_if { |element| element[:path].start_with?('media') }

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_7.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_7.rb
@@ -20,7 +20,6 @@ module USCoreTestKit
         us_core_6_extractor.add_patient_uscdi_elements
         add_must_support_choices
         us_core_6_extractor.remove_practitioner_address
-        us_core_6_extractor.remove_diagnosticreport_media
       end
 
       def add_must_support_choices

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -99,7 +99,8 @@ module USCoreTestKit
       group from: :<%= smart_app_launch_id %><% if us_core_7_and_above? %>,
             required_suite_options: USCoreOptions::SMART_1_REQUIREMENT
       group from: :<%= smart_app_launch_id %>,
-            required_suite_options: USCoreOptions::SMART_2_REQUIREMENT
+            required_suite_options: USCoreOptions::SMART_2_REQUIREMENT,
+            id: :<%= smart_app_launch_id %>_stu2
       group from: :<%= smart_app_launch_id %>_stu2_2,
             required_suite_options: USCoreOptions::SMART_2_2_REQUIREMENT<% end %>
 


### PR DESCRIPTION
# Summary

US Core v6.1.0 patch [FHIR-46240](https://jira.hl7.org/browse/FHIR-46240) was incorrectly applied to US Core v7 test kit. We temporarily reversed this change till HL7 CGP WG appove this patch for US Core v7 usage.

# Testing Guidance

Run US Core v7 test kit. 
Verify that `media` and `media.link` shows in test 2.10.11 "All must support elements are provided in the DiagnosticReport resources returned"
Verify that `media.link` shows in test 2.10.12 "MustSupport references within DiagnosticReport resources are valid"

