### PR TITLE
FI-3474 Add a check if Reference.reference is empty before processing

### DIFF
--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -697,7 +697,8 @@ module USCoreTestKit
       resources.each do |resource|
         references_to_save(containing_resource_type).each do |reference_to_save|
           resolve_path(resource, reference_to_save[:path])
-            .select { |reference| reference.is_a?(FHIR::Reference) && !reference.contained? }
+            .select { |reference| reference.is_a?(FHIR::Reference) &&
+              !reference.contained? && reference.reference.present? }
             .each do |reference|
               resource_type = reference.resource_class.name.demodulize
               need_to_save = reference_to_save[:resources].include?(resource_type)

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -1379,15 +1379,6 @@ RSpec.describe USCoreTestKit::SearchTest do
         ]
       )
     end
-    let(:bundle) do
-      FHIR::Bundle.new(
-        entry: [
-          {
-            resource: diagnostic_report
-          }
-        ]
-      )
-    end
 
     before do
       allow_any_instance_of(test_class)


### PR DESCRIPTION
# Summary

This PR fixes GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/589

# Change Log
* Add a logic to check if Reference.reference is empty 
* Add a unit test

# Testing Guidance

All unit test pass

