### PR TITLE
FI-3486 Add validation message filter for US Core 6 Observation Smoking Status effectivePeriod.start

### DIFF
--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -91,7 +91,7 @@ module USCoreTestKit
       VERSION_SPECIFIC_MESSAGE_FILTERS = [
         %r{Observation\.effective\.ofType\(Period\):.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0},
         %r{Observation: Slice 'Observation\.effective\[x\]:effectiveDateTime':.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0},
-        %r{Observation\.effective\.ofType\(Period\)\.end: This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
+        %r{Observation\.effective\.ofType\(Period\)\.(start|end): This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
       ].freeze
 
       VALIDATION_MESSAGE_FILTERS = GENERAL_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS

--- a/lib/us_core_test_kit/generator/suite_generator.rb
+++ b/lib/us_core_test_kit/generator/suite_generator.rb
@@ -23,7 +23,7 @@ module USCoreTestKit
           [
             %r{Observation\.effective\.ofType\(Period\):.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0},
             %r{Observation: Slice 'Observation\.effective\[x\]:effectiveDateTime':.*http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0},
-            %r{Observation\.effective\.ofType\(Period\)\.end: This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
+            %r{Observation\.effective\.ofType\(Period\)\.(start|end): This element is not allowed by the profile http://hl7.org/fhir/StructureDefinition/dateTime}
           ]
         else
           []


### PR DESCRIPTION
# Summary

This updates GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/573. The previous solution does not hand effectivePeriod.start. This adds that subelement into the regex.

# Testing Guidance

