### PR TITLE
FI 3561 US Core Documentation

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,21 @@
+name: Publish wiki
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - .github/workflows/publish-wiki.yml
+concurrency:
+  group: publish-wiki
+  cancel-in-progress: true
+permissions:
+  contents: write
+jobs:
+  publish-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Andrew-Chen-Wang/github-wiki-action@86138cbd6328b21d759e89ab6e6dd6a139b22270
+        with:
+          path: docs
+          strategy: init

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -1,0 +1,86 @@
+# US Core Test Kit Overview
+
+The US Core Test Kit provides server testing for several versions of US Core.
+Tests are designed to simulate a realistic client that would like to access all
+data described by US Core using those FHIR API read and search queries that must
+be supported.  Like real clients, the tests learn about data on the server and
+adjusts future queries based on this information.  In the process, all required
+and optional queries are checked.
+
+The US Core Test Kit serves two purposes:
+* Provide general testing to servers implementing the US Core Implementation Guide
+* Provide tests to other Test Kits that target other implementation guides, or
+certification criterion, that may reference US Core.
+
+This guide is targeting users who would like to run the US Core Test Kit without
+being the context of another Implementation Guide or certification criterion.
+
+
+# Testing Options
+
+Users of the test kit are presented with two options:
+
+* Which version of the US Core Implementation Guide to test against
+* Which version of the SMART App Launch Implementation Guide to test against
+
+Because US Core requires support of the SMART App Launch Guide, this set of
+tests also include SMART App Launch tests that may be relevant.
+
+Please note that US Core states that at least version SMART App Launch v2.0 is
+used in US Core 7; however, these tests allow testers to select SMART App Launch
+v1 for any US Core version.
+
+# Test Prerequisites
+
+Systems do not need to load a specific set of data to run these tests.  However,
+the tests do require that the system under test has a set of data that is
+representative of the data that the system will be handling.
+
+# Conformance Criteria
+
+Systems do NOT need to pass all tests within this Test Kit to be considered 'US
+Core Conformant'.  US Core allows systems to support a subset of content
+relevant to their use case.  The US Core Test Kit allows testers to choose which
+tests to run, and it is up to the tester to decide which set of tests are
+relevant to a given system.  Tests are divided in a logical way that should align
+with common boundaries associated with real-world systems; e.g. you may run
+tests relevant to a certain profile while skipping tests for other profiles.
+
+# Test Groups
+
+This test kit is organized into the following high-level test groups.  The system
+under test can choose which test groups are relevant to their system.
+
+
+## 1 SMART App Launch
+
+This group provides two tests: an EHR launch test and a standalone launch test,
+based on the SMART App Launch guide.  When used, a bearer token is stored
+that can be used in the US Core FHIR API test section.
+
+Read the description provided in each test with instructions on their use.
+
+## 2 US Core FHIR API
+
+This group contains the majority of the US Core tests that are applicable to the
+US Core Implementation Guide.  Users may either run all tests, or select a
+subset of tests based on the relevant to their system.  They are principally organized
+by US Core Profiles, and each test group includes both search and read tests
+relevant to that profile.
+
+Users may provide a single patient ID or a comma-separated list of patient IDs.
+The value of providing multiple patient IDs is that the tests can evaluate
+MUST SUPPORT elements across all resources across multiple patients.
+
+**Important**: Due to test design limitations, tests for profiles that do not
+directly reference
+a patient ID (e.g.; Organization, Practitioner) should not be run individually.
+They can only be run when the entire group US Core FHIR API group is run.
+
+## 3 US Core SMART Granular Scopes (US Core v6+, SMART App Launch v2+)
+
+This group tests the specific implementation details surrounding use of granular
+SMART App Launch scopes within US Core.
+
+
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# US Core Test Kit Manual
+
+The US Core Test Kit is an automated testing tool for servers
+implementing the US Core FHIR Implementation Guide. It contains server
+tests for v3.1.1, v4.0.0, v5.0.1, v6.1.0, and v7.0.0 of US Core.
+
+> *To update this manual, please update the associated files within the 
+`/docs/` directory of this git repository.  Manual updates to this wiki will be discarded
+by GitHub on each push to the `main` branch.*
+
+# Installation
+
+Information on downloading and running this application, including prerequisites
+and system requirements, are provided in the repository [README](../).
+
+# Using this Test Kit
+* [Test Kit Overview](Overview): An overview of the Test Kit and its tests.
+
+# Maintaining this Test Kit
+Developers contributing to this Test Kit should be familiar with authoring
+Inferno Framework test suites.  The following guides provide additional
+information about the design and implementation of this Test Kit to aid
+contributing to these tests:
+
+* [Technical Overview](Technical-Overview): An overview of the technical design of this Test Kit.
+* [Standards Update Guide](Version-Update-Guide): A step by step guide on updating this test kit to support new versions of US Core.
+
+# Support
+
+This Test Kit is supported by the Inferno team.  Ask questions to the team on [FHIR Zulip](https://chat.fhir.org).
+
+Report bugs or provide suggestions in [GitHub Issues](/issues).

--- a/docs/Technical-Overview.md
+++ b/docs/Technical-Overview.md
@@ -1,0 +1,246 @@
+# Background
+
+This guide orients developers to the technical design of this Test Kit.  While
+the Inferno Framework has documentation on how to create tests, additional
+documentation on the organization of this test kit is necessary due to the
+complexity involved in developing tests for the US Core guide.
+
+Prior to reviewing this document, the developer is expected to be familiar
+with the US Core Test Kit and building tests with the Inferno Framework.
+
+# Test Design Principals and Features
+
+Tests for this Test Kit have been designed with the following principles:
+
+* Easy testing: Users should be able to run the tests with minimal input or
+  configuration, and tests should complete in a reasonable amount of time.
+* Limit extraneous constraints: The tests should not place additional
+  constraints on the system under test.  Leverage machine-readable content: As
+  of US Core v7, the US Core developers purposefully encode many requirements in
+  machine-readable structures, and hte tests should leverage those when possible
+  to avoid mistakes.  Obey all non-machine-readable requirements and exception:
+* The tests should not ignore any requirements that are not encoded in
+  machine-readable structures.
+
+Features of this test kit reflect these principals.  For example:
+* Systems do not need to load a specific set of data for these tests, as long as
+  the data they provide are valid and demonstrate complete support for the US
+  Core Test Kit.
+* Testers supply a very limited amount of information to the
+  tests; the tests themselves learn about data provided by the system to
+  and automatically generate inputs for subsequent tests.
+* This Test Kit generates tests from machine-readable content each time US Core
+  is updated.  Additionally, the tests use the HL7 FHIR Validator to do runtime
+  validation of resources against profiles provided within US Core.
+* Occasionally, the US Core Test Kit overrides machine-readable rules in narrative;
+  for example by stating that a 'Must Support' flag may only conditionally apply
+  in certain cases.  Special cases are added throughout the tests to allow
+  certain exceptions to the machine-readable rules.
+
+The US Core Test Kit manages this complexity through standard software design
+practices and approaches, leveraging the functionality provided by the Ruby
+programming language.  And while this code is intended to be accessible to
+developers new to the Ruby language, developers are expected to learn the basics
+of Ruby development before attempting to alter these tests.  This Test Kit also
+uses RSpec to "unit test" components of these tests, and developers are expected
+to learn the basics of RSpec as well.
+
+# US Core Test Kit Project Source Code Structure:
+
+Below is a description of the source code structure for the US Core Test Kit:
+
+```
+root
++--config
+| +--presets                   Preset configurations including: server URL, patient IDs, client credentials, etc*
+| +--lib                         Functional modules for common testing functionality, such as read test, search test, validation test
+| +--us_core_test_kit
+| | +--custom_groups           Manually created Tests and Groups, such as Clinical Notes tests, or Data Absent Reason tests
+| | | +--capability_statement  Tests for CapabilityStatement
+| | | +--v3.1.1
+| | | +--v4.0.0
+| | | +-- ...
+| | +--generated               Tests generated automatically by generator
+| | | +--v3.1.1
+| | | +--v4.0.0
+| | | +-- ...
+| | +--generator               Codes for test generator
+| | | +--template              Templates used by generators
+| | +--igs                     Folder for US Core IGs
+| | | +--v3.1.1                Additional SearchParameters, ValueSets, CodeSystems for US Core v3.1.1
+| | | +--v5.0.1                Additional SearchParameters, ValueSets, CodeSystems for US Core v5.0.1
+| | | +--  ...
++--spec                        Unit tests
+```
+
+Importantly, code within the `generated` folder is generated using the
+generation script and should *not* be manually edited.  Instead, changes to the
+generator should be made in the `generator` folder.
+
+# Related Systems and Dependencies
+
+## Reference Server
+
+The Inferno Reference Server serves as a reference implementation server,
+supporting the US Core Implementation Guide, SMART App Launch, and Bulk Data
+Export. You can find the project on GitHub at
+<https://github.com/inferno-framework/inferno-reference-server>. The Inferno
+Reference Server is developed based on the HAPI FHIR Server
+(https://github.com/hapifhir/hapi-fhir).
+
+During the upgrade process, it may be necessary to update the data in the
+Inferno Reference Server to ensure it conforms to the latest Implementation
+Guide. For detailed instructions on how to load data into the server database,
+please refer to the README.md file on the GitHub repository.
+
+## SMART App Launch Test Kit
+
+The Inferno US Core Test Kit incorporates an optional test group from the SMART
+App Launch Test Kit. The purpose of the SMART App Launch Test Kit is to confirm
+a server's ability to provide authorization and/or authentication services to
+client applications that access HL7® FHIR® APIs. You can find this test kit on
+GitHub at <https://github.com/inferno-framework/smart-app-launch-test-kit>.
+
+This test kit also contains tests for specific guidance provided by US Core
+regarding the implementation of SMART App Launch.  This is typically provided
+in response to any potential ambiguity that results from the combination of
+FHIR, US Core and SMART App Launch, particularly when relevant to certification
+activities in the US.
+
+# Testing Code Changes
+
+This test kit includes comprehensive "self testing" functionality to provide
+confidence that the tests perform as expected.  It also contains a set of data
+that can be loaded into a FHIR server, such as the Inferno Reference Server,
+to demonstrate the functionality of the tests against a known correct implementation.
+Both of these should be maintained along with the tests.
+
+Prior to altering tests, developers should ensure that both RSpec tests and
+End-to-End tests pass.
+
+## RSpec Tests
+
+The test kit contains many "unit" tests within the `spec` directory.  These
+tests are written in RSpec, and can be run with the following command:
+
+```bundle exec rake spec```
+
+These tests should be run after any changes to the tests, and must pass before
+any changes to the tests are merged into the main branch.  It is not expected
+that the code base achieves 100% test coverage; instead, the team has followed a
+common sense approach to testing components that 1) are complicated or 2) are
+likely to change.
+
+## End-to-End testing
+
+Besides the unit tests provided within this Test Kit, after each update
+the tests should be validated against a complete server implementation
+that is known to be correct.  The Inferno Reference Server provides this functionality,
+and contains data that passes all of these tests.  Note that if test changes
+have been made that require data on the Reference Server to change as well,
+that data set needs to be updated.
+
+# Updating the Test Kit
+
+**To update this test kit in response to a new version of the US Core Implementation
+Guide, please see the [Version Update Guide](Version-Update-Guide).  The Version
+Update Guide provides a detailed walkthrough of the components of the Test Kit
+that are changed during this process.**
+
+While developers of this Test Kit should aim to have completely correct tests,
+issues will likely be identified by the community over time.  Because this Test Kit
+exports tests to the ONC Certification (g)(10) Test Kit, incorrect tests may delay
+certification activities for implementers, or even worse, encourage improper
+implementations just to make incorrect tests pass.  Therefore, 
+the tests should be updated to include the test fixes as soon as possible.
+
+## Updating Generating Tests
+
+The main testing logic for these tests are generated from machine-readable data
+provided by each version of the US Core Implementation Guide.  The code for
+the generator is within the `lib/us_core_test_kit/generator` directory and
+the test suites that are generated are placed within the `lib/us_core_test_kit/generated`
+directory.
+
+Never update files in teh `generated` directory manually, as they will be
+overwritten when the next time the files are regenerated.
+
+To regenerate the files, run:
+
+```bundle exec rake us\_core:generate```
+
+Each version of the implementation guide provided in the
+`lib/us_core_test_kit/igs` directory will be created.
+
+## Updating shared component tests
+
+While the generator creates code for each suite, the generated code typically
+references shared component tests. These component tests reside in the
+`lib/us_core_test_kit/` directory.  These tests are not generated, and should be
+updated manually.  Because they are reused across many test groups, updating
+them must be done with care.
+
+Tests that are version specific reside in the
+`lib/us_core_test_kit/custom_groups` directory.
+
+
+## Overriding US Core Content
+
+Occasionally, the US Core authors publish incorrect content within the
+implementation guide that affects the generation of tests, or validation of
+systems at runtime.  In these cases, the Inferno team will override the content
+with the correct content.  This is done by placing the correct content in the
+`lib/us_core_test_kit/igs/[version]/` directories.  The content in this
+directory will be used instead of the content in the implementation guide.
+
+## Overriding HL7 Validator Behavior
+
+The HL7 Validator is used to validate resources at runtime.  Occasionally, the
+HL7 Validator will report validation errors that are considered to be out of
+scope of testing, or are incorrect.  In these cases, test can choose to filter
+out these error messages.
+
+If the invalid error message applies to all versions of US Core, you can
+update the `lib/us_core_test_kit/generator/templates/suite.rb.erb` file.  If it
+only applies to a certain version of US Core, you can update the
+`lib/us_core_test_kit/generator/suite_generator.rb` file by adding a version-specific
+exception.
+
+# Unusual Implementation Details
+
+While code in this Test Kit is intended to be as simple and as easy-to-understand
+as possible, sometimes unanticipated testing requirements are introduced that
+require special handling by the US Core test kit.  The ability for Inferno
+to accommodate these requirements is a key feature of the Inferno framework.  However,
+this does add complexity to maintenance of the tests.
+
+The following is a list of unusual or unorthodox methods used in the US Core
+Test Kit that that maintainers should be aware of.  These are also opportunities
+for improvement of the Inferno Framework if this type of functionality would be
+of broad use beyond US Core.
+
+The following links are to a specific snapshot in time of the repository; this
+list should be maintained as the repository evolves.
+
+* All uses of scratch 
+
+* Add a test to a nested group -  [link](https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/custom_groups/base_smart_granular_scopes_group.rb#L144)
+
+* Replace nested groups - [link](https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/custom_groups/v7.0.0/smart_app_launch_group.rb#L9-L13) 
+
+* Extract elements from FHIR resources - [link](https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/fhir_resource_navigation.rb)
+
+* Extract FHIR resources from requests - [link](https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/granular_scope.rb#L40-L60)
+
+* Check whether a resource is valid without adding validation messages  - [link](https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/reference_resolution_test.rb#L167-L186)
+
+* Check whether a resource matches search params  - [link](
+    https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/resource_search_param_checker.rb)
+
+* Retrieve all Bundle pages  - [link](https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/search_test.rb#L549 )
+
+* Find a possible value for a search parameter from a resource  - [link](https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/search_test.rb#L601)
+
+* Save resource references to be used by later tests - [link](https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/search_test.rb#L690-L710)
+
+* Perform multiple validations without failing early. Only fail at the end if errors were received - [link](https://github.com/inferno-framework/us-core-test-kit/blob/1ecf2146596c884f02e3f5dd5793985d9f29dbb1/lib/us_core_test_kit/validation_test.rb#L18-L25 )

--- a/docs/Version-Update-Guide.md
+++ b/docs/Version-Update-Guide.md
@@ -1,0 +1,240 @@
+
+# Background
+
+This guide is intended to help developers create new tests for new versions of
+the US Core Implementation Guide.  While this Test Kit provides tools to support
+the creation of these tests, not all aspects can be 100% automated.  This
+document describes the overall process required to use the automated tools, and
+typical manual steps needed to address changes that cannot be automated. Remember that
+there are limited rules to how the US Core Implementation Guide may change, so
+even the automated portions may need to be updated to accommodate new methods
+to represent and document requirements in machine-readable formats.
+
+Prior to reviewing this document, the developer is expected to be familiar with
+using the US Core Test Kit and building test kits using the Inferno Framework.
+
+This document should be updated after each new version of the US Core
+Implementation guide is incorporated into the Test Kit.
+
+This test kit provides a test generator that can automatically extract
+requirements from StructureDefinitions to create tests. However, for
+requirements specified in the narrative sections, manual updates are necessary
+to facilitate the generation of corresponding tests.
+
+The Inferno US Core Test Kit primarily focuses on mandatory elements, "must
+support" elements, and USCDI elements within the StructureDefinitions. In the
+narrative sections, it emphasizes requirements that have a "SHALL" conformance
+level.
+
+
+# Introduction of US Core Test Kit
+
+## Testing Approach and Goals
+
+US Core Test Kit uses data returned from systems under test to make testing more
+realistic and easier to use. The goal is to have tests infer as much as possible
+from data returned instead of requiring testers to provide separate data for
+each requirement under test.
+
+
+# US Core Test Kit Project Source Code Structure:
+
+```
+root
++--config
+| +--presets                   Preset configurations including: server URL, patient IDs, client credentials, etc*
+| +--lib                         Functional modules for common testing functionality, such as read test, search test, validation test
+| +--us_core_test_kit
+| | +--custom_groups           Manually created Tests and Groups, such as Clinical Notes tests, or Data Absent Reason tests
+| | | +--capability_statement  Tests for CapabilityStatement
+| | | +--v3.1.1
+| | | +--v4.0.0
+| | | +--v5.0.1
+| | | +--v6.0.0
+| | +--generated               Tests generated automatically by generator
+| | | +--v3.1.1
+| | | +--v4.0.0
+| | | +--v5.0.1
+| | | +--v6.0.0
+| | +--generator               Codes for test generator
+| | | +--template              Templates used by generators
+| | +--igs                     Folder for US Core IGs
+| | | +--v3.1.1                Additional SearchParameters, ValueSets, CodeSystems for US Core v3.1.1
+| | | +--v5.0.1                Additional SearchParameters, ValueSets, CodeSystems for US Core v5.0.1
+| | | +--v6.0.0                Additional SearchParameters, ValueSets, CodeSystems for US Core v6.1.0
++--spec                        Unit tests
+```
+
+# Preparation Process
+
+Initiate the process by conducting a comprehensive manual review of the latest US Core Implementation Guide. This involves a detailed comparison against the requirements, especially requirements in narratives, of the previous version. As part of this comparison, identify and document all modifications, additions, revisions, or removals. This systematic approach is pivotal for grasping the updated requirements and distinguishing them from those of the former edition. Such understanding is crucial for accurately incorporating and embedding these updates into the relevant workflow or system. The result of comparison should be saved in a US Core Requirement Comparison table or chart for later reference.
+
+## Obtain the US Core Test Kit project from GitHub
+
+* Access the Inferno Framework's US Core Test Kit repository by visiting https://github.com/inferno-framework/us-core-test-kit.
+* Clone the repository to your local environment.
+
+Ensure that the directory for the cloned repository on your local machine is designated as “us-core-test-kit”.
+
+## Download the US Core Implementation Guide package
+
+* Navigate to the US Core Implementation Guide Download page at <https://hl7.org/fhir/us/core/downloads.html>.
+* Identify and select the Implementation Guide version that aligns with your project requirements.
+* Proceed to download the “Package File” (package.tgz).
+* Move the downloaded package.tgz file into the “./lib/igs” directory of the US Core Test kit repository on your local system.
+* For clarity and version control, rename package.tgz to reflect the version it represents, e.g., “us\_core\_610.tgz”.
+* It's important to note that the US Core Implementation Guide may necessitate additional artifacts from the FHIR Core Specification that are not automatically included. These must be integrated manually if required.
+
+## Integrate Additional Implementation Guide Artifacts
+
+While the Implementation Guide (IG) package is designed to be comprehensive, there are instances where certain artifacts, such as SearchParameters, ValueSets, or CodeSystems, might not be included within the package itself. An example of this is the “asserted-date” extension within the US Core v6.1.0 Condition profile.
+
+![](data:image/png;base64...)
+
+This particular extension, while not packaged within the US Core v6.1.0 Implementation Guide, can be found within the FHIR Extension Pack. Such extensions must be downloaded manually from the FHIR Extensions Pack (https://hl7.org/fhir/extensions/) and stored in the “ig” folder.
+
+Identifying these external artifacts can be challenging. The meticulous preparation outlined in Section 4 can aid in pinpointing some of these artifacts. However, others may come to light during the test suite generation and review phases.
+
+To add additional artifacts to the US Core Test Kit:
+
+* Inside the “./lib/igs” directory, generate a sub-folder that bears the same name as the downloaded tgz file; for example, if the Implementation Guide file is named “us\_core\_610.tgz,” then the corresponding folder should be labeled “us\_core\_610.”
+* Locate the additional artifacts. Extensions can be found in the FHIR Extensions Pack (<https://hl7.org/fhir/extensions/>). Profiles and Search Parameters can be found in corresponding Implementation Guide or FHIR Specification R4.0.1 (<https://hl7.org/fhir/r4/>). Value Sets and Code Systems can be found in either HL7 Terminology (THO) (<https://terminology.hl7.org/>) or VSAC (https://vsac.nlm.nih.gov/)
+* Download the additional artifacts to the folder created in the first bullet point. This step ensures that all necessary components are included for a comprehensive test environment.
+
+## Incorporate Version-Specific Custom Groups
+
+The creation of custom groups is essential for a comprehensive test suite, as not all tests can be generated directly from the StructureDefinition. The Custom Groups folder includes tests that derive from the US Core Guidance section rather than the Profile section. Examples of such tests include those for Clinical Notes and SMART scopes, which apply across all profiles. This approach ensures coverage of specific requirements not directly linked to profile validations. Here is a screen shot of what is currently included in this folder:
+
+![Text
+
+Description automatically generated](data:image/png;base64...)
+
+Tasks for Setup:
+
+### Create a Version-Specific Folder
+
+Establish a folder named after the specific version of the US Core being implemented, such as “v6.1.0”. The folder name should precisely mirror the version number of the Implementation Guide (IG) for clarity and organization.
+
+### Add the “capability\_statement\_group.rb” File
+
+This file should be duplicated from an existing version. It contains the “PROFILE” constant, which maps FHIR resource types to their corresponding US Core profiles. This mapping can range from one-to-one relationships (e.g., Patient) to one-to-many (e.g., Observation). It is crucial to update this object to reflect the nuances of the specific US Core IG version in question.
+
+### Incorporate the “smart\_granular\_scopes\_group.rb” File
+
+Like the capability\_statement\_group.rb, this file can also be copied from an existing version. The Smart Granular Scopes tests, introduced in US Core v6.1.0, require adjustments tailored to the particular US Core version being tested to ensure relevance and accuracy.
+
+### Develop Custom Tests for US Core Guidance
+
+The US Core Guidance chapter may set forth additional requirements that requests the creation of custom tests within this group. Examples include guidance on Data Absent Reason and Clinical Notes. Whenever new guidance emerges, it's important to create a specialized test or tests in this section to ensure comprehensive coverage of all US Core stipulations.
+
+## Manage Special Cases
+
+In the development of the US Core Test Suite, handling special cases is a necessity. To streamline this process, all special handling instructions are consolidated within the ",/lib/us\_core/generator/special\_cases.rb" file. Below is an overview of the key constants defined in this file and their significance:
+
+### RESOURCES\_TO\_EXCLUDE
+
+This constant lists the resource types that are excluded based on two criteria:
+
+* The resource type does not correspond to any USCDI data class or data element.
+* The resource is not referenced by a MustSupport element in any other US Core profile.
+
+If a resource type meets both conditions, it should be added to this list. The test generator will not create tests for these excluded resource types.
+
+Inclusion in this list can be version-specific, indicating that while certain versions may exclude a resource type, future versions might not. For instance, 'PractitionerRole' => ['v311', 'v400'] indicates that PractitionerRole is excluded in US Core versions 3.1.1 and 4.0.0, but included in versions 5.0.1 and 6.1.0.
+
+### PROFILES\_TO\_EXCLUDE
+
+This constant identifies "abstract" profiles, which serve as the basis for one or more "concrete" profiles. Two profiles are listed here:
+
+* US Core Vital Signs profile
+* US Core Survey profile
+
+Both profiles do not have their own test groups in the test suite. Instead, specific tests are created for each concrete implementation of these abstract profiles. It's crucial to recognize that not all parent profiles are treated as abstract; for example, both US Core Lab Result and US Core Clinical Result profiles have their test groups in version 6.1.0.
+
+### OPTIONAL\_RESOURCES and OPTIONAL\_PROFILES
+
+These constants enumerate the resource types and profiles that are optional within the US Core framework. They are either optionally mapped to a USCDI element or referenced by another US Core profile. The test suite treats these as optional test groups, and if a server supports any of these, it must pass all associated tests. Examples include the US Core PractitionerRole, US Core QuestionnaireResponse, and US Core Simple Observation profiles, each with specific conditions under which they are considered optional.
+
+### NON\_USCDI\_RESOURCES
+
+This list includes US Core resources that, while not directly aligned with a USCDI data class or element, are referenced by MustSupport elements in other US Core profiles. This differentiation is version-specific and reflects the evolving relationship between US Core and USCDI standards. For instance, the Encounter resource was not part of USCDI v1 but was included in USCDI v2.
+
+### SEARCHABLE\_DELAYED\_RESOURCES
+
+Delayed resources are those not immediately searchable due to their presence in the NON\_USCDI\_RESOURCES list or lack of a mandatory patient search parameter. The test suite gathers instances of these resources through references in other US Core resources and typically excludes them from search tests, with certain exceptions. An example is the US Core Location resource, which, in USCDI v4, becomes a searchable element despite being a delayed resource.
+
+### ALL\_VERSION\_CATEGORY\_FIRST\_PROFILES and VERSION\_SPECIFIC\_CATEGORY\_FIRST\_PROFILES
+
+Beyond the general approach of initiating test groups with patient search parameter tests, exceptions exist that start with both patient and category search parameters. This strategy is mainly applied to Observation profiles to facilitate more precise and relevant search results. The first list encompasses profiles applicable across all US Core versions, while the second list is tailored to specific version requirements, ensuring the test suite's adaptability to the evolving landscape of US Core specifications.
+
+## Implement Version-Specific MustSupport Metadata Extraction
+
+The US Core Implementation Guide (IG) delineates three categories of MustSupport components: elements, extensions, and slicing. The majority of these components, which have the attribute “mustSupport: true” within the profile’s StructureDefinition, are automatically identified and extracted by the test generator. However, there are specific scenarios that require additional manual effort:
+
+### Incorporating MustSupport for "Additional USCDI" Elements
+
+US Core Profiles are designed to align with the requirements of the U.S. Core Data for Interoperability (USCDI), particularly for the ONC Health IT Certification under criterion g(10). However, not all elements necessary for representing USCDI Data Elements are marked as Mandatory or MustSupport within the StructureDefinition, mainly because such designations may not be requisite for the broader spectrum of implementers outside of those seeking certification.
+
+From version 4.0.0 onwards, the US Core profile documentation introduced an "Additional USCDI Requirement" section, listing those components required by USCDI but not explicitly tagged as MustSupport in their StructureDefinition.
+
+By version 6.1.0, US Core IG applied the uscdi-requirement extension within StructureDefinitions covering both MustSupport components and additional USCDI requirements. This requires a calculation to differentiate the actual "additional" USCDI requirements by subtracting the MustSupport components from those tagged as USCDI requirements.
+
+With the release of US Core v7.0.0, the uscdi-requirement extension was refined to only apply to these "additional" USCDI requirements, removing it from components already identified as MustSupport.
+
+The US Core Test Generator can automatically extract both MustSupport and USCDI-Requirement information directly from the StructureDefinitions. However, certain cases, such as the representation of Patient.deceasedDateTime as a USCDI data element within the US Core Patient profile, may require manual adjustments due to technical constraints.
+
+### Addressing MustSupport Choices
+
+The "Profile Specific Implementation Guidance" provided for each US Core profile may introduce additional rules, offering server systems choices in how they support MustSupport elements. An example of this is the US Core v6.1.0 DocumentReference profile, which offers Implementation Guidance as:
+
+“The DocumentReference resources can represent the referenced content using either an address where the document can be retrieved using DocumentReference.attachment.url or the content as inline base64 encoded data using DocumentReference.attachment.data.”
+
+* Although both are marked as Must Support, the server system is not required to support an address and inline base64 encoded data, but SHALL support at least one of these elements.
+
+Handling these "Must Support Choices" requires a tailored approach, implemented through the “add\_must\_support\_choices” method. This method manually integrates the flexibility allowed by the IG, ensuring that the test suite accurately reflects the range of implementation options available to server systems.
+
+## Initiate the Generator
+
+Once all the preliminary tasks have been completed, initiate the test generation by using the following command from the root of project directory:
+
+"bundle exec rake us\_core:generate"
+
+The generated tests will be stored in the following directory: "./lib/us\_core\_test\_kit/generated/[us\_core\_version]"
+
+# Run US Core Tests
+
+## Development Environment Setup
+
+Please refer to the README file for instructions on setting up the development environment.
+
+## Preset Configuration
+
+Running the US Core test kits requires certain user inputs, such as the FHIR server endpoint and patient ID. These can be manually entered via the test kit's UI component when running the web application. Some data can also be saved as a preset to automatically populate the UI input fields. Please refer to the "./config/preset" folder for existing presets.
+
+## Executing the US Core Test
+
+Please refer to the README file for instructions on how to initiate the US Core test kit in the development environment.
+
+## Update Validation Message Filter
+
+During the test, there could be validation errors which are caused by underlying issues in the Implementation Guide, validator, or terminology services rather than the tests themselves. In this case, the error messages should be excluded. A reference to the approved FHIR JIRA ticket that notes the underlying issue should be included to indicate the reason for a message filter.
+
+After such decision has been made, the changes should be applied to VALIDATION\_MESSAGE\_FILTERS constant in the “./lib/generator/templates/suite.rb.erb” file.
+
+# Quick Checklist
+
+* Before test generation
+  + Update US Core IG Requirements comparison Chart. (section 4)
+  + Add Custom group (section 5.4)
+  + Update Special Cases (section 5.5)
+  + Update MustSupport metadata extractor (section 5.6)
+* During test generator
+  + Add missing artifacts (section 5.3)
+  + Update Special Cases (section 5.5)
+  + Update MustSupport metadata extractor (section 5.6)
+* During US Core test
+  + Add missing artifacts (section 5.3)
+  + Update Special Cases (section 5.5)
+  + Update MustSupport metadata extractor (section 5.6)
+  + Update validation message filter (section 6.4)
+


### PR DESCRIPTION
# Summary

* Adds a `docs` directory which contain markdown files and other supporting files so we can have robust Test Kit specific documentation alongside its code.
* Creates a basic organization of the documentation (user-oriented doc(s) and maintainer-oriented docs).
* Includes a basic overview of the tests for testers
* Includes a technical overview of the tests for maintainers
* Includes a guide for updating the tests in response to new versions of the standard
* Includes a GitHub workflow that copies the markdown file into the wiki for easy viewing

# Testing Guidance
Review the docs.  I don't think these have to be perfect, as I am going to update (g)(10) and SMART test kits and based on how all those turn out might shuffles these around a little bit.

I do not think there is a great way to test the GitHub workflow that copies this to the wiki.  I was able to get it working properly over in this [repo](https://github.com/arscan/docs-test-kit/blob/main/.github/workflows/publish-wiki.yml) and [wiki](https://github.com/arscan/docs-test-kit/wiki), as a demo.  I'm not sure if we want to rely on a third party workflow, and we might want to swap this out.  But I really like the functionality it proivides.
