### PR TITLE
Fix link in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ for the US Core Implementation Guide
 [v7.0.0](https://hl7.org/fhir/us/core/STU7/).  This test kit
 provides testing for US Core Servers.
 
-Visit the [US Core Test Kit manual](wiki) for more information on using this test kit.
+Visit the [US Core Test Kit manual](/inferno-framework/us-core-test-kit/wiki) for more information on using this test kit.
 
 ## Instructions
 


### PR DESCRIPTION
# Summary
The relative link to the wiki didn't work in the README.  Fixes that.  Other links throughout seem ok.
