### PR TITLE
Docs update; broken links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ for the US Core Implementation Guide
 [v7.0.0](https://hl7.org/fhir/us/core/STU7/).  This test kit
 provides testing for US Core Servers.
 
-Visit the [US Core Test Kit manual](/inferno-framework/us-core-test-kit/wiki) for more information on using this test kit.
+Visit the [US Core Test Kit Manual](https://github.com/inferno-framework/us-core-test-kit/wiki) for more information on using this test kit.
 
 ## Instructions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,4 +31,4 @@ For questions or issues with this Test Kit, please reach out to the Inferno team
 on the [#Inferno FHIR Zulip
 channel](https://chat.fhir.org/#narrow/stream/179309-inferno).
 
-Report bugs or provide suggestions in [GitHub Issues](/issues).
+Report bugs or provide suggestions in [GitHub Issues](/inferno-framework/us-core-test-kit/issues).


### PR DESCRIPTION
# Summary
Unfortunately no relative links work at all from the README.md to the wiki, so i have to use an absolute link (which makes sense as that absolute link is the singular 'home' of the manual).

I also noticed this time that the issues link didn't point to the right spot.

Sorry for the repetitive PRs, this is challenging to evaluate until it is deployed to the wiki.

