### PR TITLE
FI-3642 Update docs publishing workflow to US Core test kit

### DIFF
--- a/.github/workflows/publish-docs-wiki.yml
+++ b/.github/workflows/publish-docs-wiki.yml
@@ -1,20 +1,20 @@
-name: Publish wiki
+name: Publish Docs Wiki
 on:
   push:
     branches: [main]
     paths:
       - docs/**
-      - .github/workflows/publish-wiki.yml
+  workflow_dispatch:
 concurrency:
-  group: publish-wiki
+  group: publish-docs-wiki
   cancel-in-progress: true
 permissions:
   contents: write
 jobs:
-  publish-wiki:
+  publish-docs-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Andrew-Chen-Wang/github-wiki-action@86138cbd6328b21d759e89ab6e6dd6a139b22270
         with:
           path: docs


### PR DESCRIPTION
# Summary

This applies the improved docs publishing workflow that we have already incorporated into the g10 test kit.  It makes it easier to preview updates to the documentation that get published to the wiki.  I'd like to get this in here before i add one final PR for a last round of US Core Test Kit documentation updates.

# Testing Guidance
I do not believe testing is necessary as this was tested in the g10 repo.
