### PR TITLE
FI-3586: Migrate to authinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /data/*.db
 /data/*.db-journal
+/data/igs/*.tgz
 /data/redis/*.rdb
 /data/redis/*.aof
 /data/redis/appendonlydir

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'smart_app_launch_test_kit',
+    path: '../smart-app-launch-test-kit'
+
 group :development, :test do
   gem 'debug'
   gem 'rack-test'

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'smart_app_launch_test_kit',
-    path: '../smart-app-launch-test-kit'
-
 group :development, :test do
   gem 'debug'
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,9 @@
 PATH
-  remote: ../smart-app-launch-test-kit
-  specs:
-    smart_app_launch_test_kit (0.5.0)
-      inferno_core (>= 0.6.2)
-      json-jwt (~> 1.15.3)
-      jwt (~> 2.6)
-      tls_test_kit (~> 0.3.0)
-
-PATH
   remote: .
   specs:
     us_core_test_kit (0.10.1)
       inferno_core (>= 0.6.4)
-      smart_app_launch_test_kit (>= 0.5.0)
+      smart_app_launch_test_kit (>= 0.6.0)
       tls_test_kit (~> 0.3.0)
 
 GEM
@@ -146,7 +137,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (0.6.4)
+    inferno_core (0.6.6)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -187,14 +178,14 @@ GEM
       base64
     kramdown (2.5.1)
       rexml (>= 3.3.9)
-    logger (1.6.5)
+    logger (1.6.6)
     method_source (1.1.0)
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0107)
+    mime-types-data (3.2025.0304)
     mini_portile2 (2.8.8)
-    minitest (5.25.4)
+    minitest (5.25.5)
     multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
@@ -206,14 +197,14 @@ GEM
       mustermann (= 1.1.2)
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.2)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.2-arm64-darwin)
+    nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.2-x86_64-darwin)
+    nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.2-x86_64-linux-gnu)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
@@ -236,13 +227,13 @@ GEM
     puma (5.6.9)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.13)
     rack-test (2.2.0)
       rack (>= 1.3)
     rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
-    redis-client (0.23.2)
+    redis-client (0.24.0)
       connection_pool
     reline (0.5.9)
       io-console (~> 0.5)
@@ -251,7 +242,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.4.0)
+    rexml (3.4.1)
     rouge (4.5.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -273,6 +264,11 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
+    smart_app_launch_test_kit (0.6.0)
+      inferno_core (>= 0.6.3)
+      json-jwt (~> 1.15.3)
+      jwt (~> 2.6)
+      tls_test_kit (~> 0.3.0)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.7.3-arm64-darwin)
@@ -305,7 +301,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.7.1)
+    zeitwerk (2.7.2)
 
 PLATFORMS
   arm64-darwin-21
@@ -319,7 +315,6 @@ DEPENDENCIES
   factory_bot (~> 6.1)
   rack-test
   rspec (~> 3.10)
-  smart_app_launch_test_kit!
   us_core_test_kit!
   webmock (~> 3.11)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 PATH
+  remote: ../smart-app-launch-test-kit
+  specs:
+    smart_app_launch_test_kit (0.5.0)
+      inferno_core (>= 0.6.2)
+      json-jwt (~> 1.15.3)
+      jwt (~> 2.6)
+      tls_test_kit (~> 0.3.0)
+
+PATH
   remote: .
   specs:
     us_core_test_kit (0.10.1)
@@ -264,11 +273,6 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
-    smart_app_launch_test_kit (0.5.0)
-      inferno_core (>= 0.6.2)
-      json-jwt (~> 1.15.3)
-      jwt (~> 2.6)
-      tls_test_kit (~> 0.3.0)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.7.3-arm64-darwin)
@@ -315,6 +319,7 @@ DEPENDENCIES
   factory_bot (~> 6.1)
   rack-test
   rspec (~> 3.10)
+  smart_app_launch_test_kit!
   us_core_test_kit!
   webmock (~> 3.11)
 

--- a/config/presets/inferno_reference_server_311_preset.json
+++ b/config/presets/inferno_reference_server_311_preset.json
@@ -14,12 +14,8 @@
       "name": "smart_auth_info",
       "type": "auth_info",
       "value": {
-        "auth_request_method": "GET",
         "auth_type": "public",
         "use_discovery": "true",
-        "auth_url": "https://inferno.healthit.gov/reference-server/oauth/authorization",
-        "token_url": "https://inferno.healthit.gov/reference-server/oauth/token",
-        "requested_scopes": "launch/patient openid fhirUser offline_access patient/Patient.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Coverage.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Media.read patient/Medication.read patient/MedicationDispense.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/QuestionnaireResponse.read patient/RelatedPerson.read patient/ServiceRequest.read patient/Specimen.read",
         "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
       }
     },

--- a/config/presets/inferno_reference_server_311_preset.json
+++ b/config/presets/inferno_reference_server_311_preset.json
@@ -11,41 +11,17 @@
       "value": "https://inferno.healthit.gov/reference-server/r4"
     },
     {
-      "name": "smart_credentials",
-      "type": "oauth_credentials",
-      "title": "OAuth Credentials",
-      "optional": true,
-      "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
-    },
-    {
-      "name": "standalone_client_id",
-      "type": "text",
-      "title": "Standalone Client ID",
-      "description": "Client ID provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "standalone_client_secret",
-      "type": "text",
-      "title": "Standalone Client Secret",
-      "description": "Client Secret provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "ehr_client_id",
-      "type": "text",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "ehr_client_secret",
-      "type": "text",
-      "optional": false,
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "client_auth_type",
-      "type": "text",
-      "value": "confidential_symmetric"
+      "name": "smart_auth_info",
+      "type": "auth_info",
+      "value": {
+        "auth_request_method": "GET",
+        "auth_type": "public",
+        "use_discovery": "true",
+        "auth_url": "https://inferno.healthit.gov/reference-server/oauth/authorization",
+        "token_url": "https://inferno.healthit.gov/reference-server/oauth/token",
+        "requested_scopes": "launch/patient openid fhirUser offline_access patient/Patient.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Coverage.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Media.read patient/Medication.read patient/MedicationDispense.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/QuestionnaireResponse.read patient/RelatedPerson.read patient/ServiceRequest.read patient/Specimen.read",
+        "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
+      }
     },
     {
       "name": "patient_ids",

--- a/config/presets/inferno_reference_server_400_preset.json
+++ b/config/presets/inferno_reference_server_400_preset.json
@@ -14,12 +14,8 @@
       "name": "smart_auth_info",
       "type": "auth_info",
       "value": {
-        "auth_request_method": "GET",
         "auth_type": "public",
         "use_discovery": "true",
-        "auth_url": "https://inferno.healthit.gov/reference-server/oauth/authorization",
-        "token_url": "https://inferno.healthit.gov/reference-server/oauth/token",
-        "requested_scopes": "launch/patient openid fhirUser offline_access patient/Patient.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Coverage.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Media.read patient/Medication.read patient/MedicationDispense.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/QuestionnaireResponse.read patient/RelatedPerson.read patient/ServiceRequest.read patient/Specimen.read",
         "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
       }
     },

--- a/config/presets/inferno_reference_server_400_preset.json
+++ b/config/presets/inferno_reference_server_400_preset.json
@@ -11,41 +11,17 @@
       "value": "https://inferno.healthit.gov/reference-server/r4"
     },
     {
-      "name": "smart_credentials",
-      "type": "oauth_credentials",
-      "title": "OAuth Credentials",
-      "optional": true,
-      "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
-    },
-    {
-      "name": "standalone_client_id",
-      "type": "text",
-      "title": "Standalone Client ID",
-      "description": "Client ID provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "standalone_client_secret",
-      "type": "text",
-      "title": "Standalone Client Secret",
-      "description": "Client Secret provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "ehr_client_id",
-      "type": "text",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "ehr_client_secret",
-      "type": "text",
-      "optional": false,
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "client_auth_type",
-      "type": "text",
-      "value": "confidential_symmetric"
+      "name": "smart_auth_info",
+      "type": "auth_info",
+      "value": {
+        "auth_request_method": "GET",
+        "auth_type": "public",
+        "use_discovery": "true",
+        "auth_url": "https://inferno.healthit.gov/reference-server/oauth/authorization",
+        "token_url": "https://inferno.healthit.gov/reference-server/oauth/token",
+        "requested_scopes": "launch/patient openid fhirUser offline_access patient/Patient.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Coverage.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Media.read patient/Medication.read patient/MedicationDispense.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/QuestionnaireResponse.read patient/RelatedPerson.read patient/ServiceRequest.read patient/Specimen.read",
+        "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
+      }
     },
     {
       "name": "patient_ids",

--- a/config/presets/inferno_reference_server_501_preset.json
+++ b/config/presets/inferno_reference_server_501_preset.json
@@ -14,12 +14,8 @@
       "name": "smart_auth_info",
       "type": "auth_info",
       "value": {
-        "auth_request_method": "GET",
         "auth_type": "public",
         "use_discovery": "true",
-        "auth_url": "https://inferno.healthit.gov/reference-server/oauth/authorization",
-        "token_url": "https://inferno.healthit.gov/reference-server/oauth/token",
-        "requested_scopes": "launch/patient openid fhirUser offline_access patient/Patient.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Coverage.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Media.read patient/Medication.read patient/MedicationDispense.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/QuestionnaireResponse.read patient/RelatedPerson.read patient/ServiceRequest.read patient/Specimen.read",
         "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
       }
     },

--- a/config/presets/inferno_reference_server_501_preset.json
+++ b/config/presets/inferno_reference_server_501_preset.json
@@ -11,41 +11,17 @@
       "value": "https://inferno.healthit.gov/reference-server/r4"
     },
     {
-      "name": "smart_credentials",
-      "type": "oauth_credentials",
-      "title": "OAuth Credentials",
-      "optional": true,
-      "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
-    },
-    {
-      "name": "standalone_client_id",
-      "type": "text",
-      "title": "Standalone Client ID",
-      "description": "Client ID provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "standalone_client_secret",
-      "type": "text",
-      "title": "Standalone Client Secret",
-      "description": "Client Secret provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "ehr_client_id",
-      "type": "text",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "ehr_client_secret",
-      "type": "text",
-      "optional": false,
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "client_auth_type",
-      "type": "text",
-      "value": "confidential_symmetric"
+      "name": "smart_auth_info",
+      "type": "auth_info",
+      "value": {
+        "auth_request_method": "GET",
+        "auth_type": "public",
+        "use_discovery": "true",
+        "auth_url": "https://inferno.healthit.gov/reference-server/oauth/authorization",
+        "token_url": "https://inferno.healthit.gov/reference-server/oauth/token",
+        "requested_scopes": "launch/patient openid fhirUser offline_access patient/Patient.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Coverage.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Media.read patient/Medication.read patient/MedicationDispense.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/QuestionnaireResponse.read patient/RelatedPerson.read patient/ServiceRequest.read patient/Specimen.read",
+        "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
+      }
     },
     {
       "name": "patient_ids",

--- a/config/presets/inferno_reference_server_610_preset.json
+++ b/config/presets/inferno_reference_server_610_preset.json
@@ -11,41 +11,13 @@
       "value": "https://inferno.healthit.gov/reference-server/r4"
     },
     {
-      "name": "smart_credentials",
-      "type": "oauth_credentials",
-      "title": "OAuth Credentials",
-      "optional": true,
-      "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
-    },
-    {
-      "name": "standalone_client_id",
-      "type": "text",
-      "title": "Standalone Client ID",
-      "description": "Client ID provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "standalone_client_secret",
-      "type": "text",
-      "title": "Standalone Client Secret",
-      "description": "Client Secret provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "ehr_client_id",
-      "type": "text",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "ehr_client_secret",
-      "type": "text",
-      "optional": false,
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "client_auth_type",
-      "type": "text",
-      "value": "confidential_symmetric"
+      "name": "smart_auth_info",
+      "type": "auth_info",
+      "value": {
+        "auth_type": "public",
+        "use_discovery": "true",
+        "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
+      }
     },
     {
       "name": "patient_ids",
@@ -61,6 +33,24 @@
       "description": "Enter the code for an Implantable Device type, or multiple codes separated by commas. If blank, Inferno will validate all Device resources against the Implantable Device profile",
       "optional": true,
       "value": null
+    },
+    {
+      "name": "granular_scopes_1_auth_info",
+      "type": "auth_info",
+      "value": {
+        "auth_type": "public",
+        "use_discovery": "true",
+        "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
+      }
+    },
+    {
+      "name": "granular_scopes_2_auth_info",
+      "type": "auth_info",
+      "value": {
+        "auth_type": "public",
+        "use_discovery": "true",
+        "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
+      }
     }
   ]
 }

--- a/config/presets/inferno_reference_server_700_preset.json
+++ b/config/presets/inferno_reference_server_700_preset.json
@@ -11,41 +11,13 @@
       "value": "https://inferno.healthit.gov/reference-server/r4"
     },
     {
-      "name": "smart_credentials",
-      "type": "oauth_credentials",
-      "title": "OAuth Credentials",
-      "optional": true,
-      "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
-    },
-    {
-      "name": "standalone_client_id",
-      "type": "text",
-      "title": "Standalone Client ID",
-      "description": "Client ID provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "standalone_client_secret",
-      "type": "text",
-      "title": "Standalone Client Secret",
-      "description": "Client Secret provided during registration of Inferno as a standalone application",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "ehr_client_id",
-      "type": "text",
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
-    },
-    {
-      "name": "ehr_client_secret",
-      "type": "text",
-      "optional": false,
-      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
-    },
-    {
-      "name": "client_auth_type",
-      "type": "text",
-      "value": "confidential_symmetric"
+      "name": "smart_auth_info",
+      "type": "auth_info",
+      "value": {
+        "auth_type": "public",
+        "use_discovery": "true",
+        "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
+      }
     },
     {
       "name": "patient_ids",
@@ -61,6 +33,24 @@
       "description": "Enter the code for an Implantable Device type, or multiple codes separated by commas. If blank, Inferno will validate all Device resources against the Implantable Device profile",
       "optional": true,
       "value": null
+    },
+    {
+      "name": "granular_scopes_1_auth_info",
+      "type": "auth_info",
+      "value": {
+        "auth_type": "public",
+        "use_discovery": "true",
+        "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
+      }
+    },
+    {
+      "name": "granular_scopes_2_auth_info",
+      "type": "auth_info",
+      "value": {
+        "auth_type": "public",
+        "use_discovery": "true",
+        "client_id": "SAMPLE_PUBLIC_CLIENT_ID"
+      }
     }
   ]
 }

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -7,7 +7,7 @@ services:
       # Negative values mean sessions never expire, 0 means sessions immediately expire
       SESSION_CACHE_DURATION: -1
     volumes:
-      - ./lib/us_core_test_kit/igs:/home/igs
+      - ./data/igs:/app/igs
       # To let the service share your local FHIR package cache,
       # uncomment the below line
       # - ~/.fhir:/home/ktor/.fhir
@@ -15,7 +15,7 @@ services:
   #   image: infernocommunity/fhir-validator-service
   #   # Update this path to match your directory structure
   #   volumes:
-  #     - ./lib/us_core_test_kit/igs:/home/igs
+  #     - ./data/igs:/home/igs
   # fhir_validator_app:
   #   image: infernocommunity/fhir-validator-app
   #   depends_on:

--- a/lib/us_core_test_kit/custom_groups/base_smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/base_smart_granular_scopes_group.rb
@@ -51,8 +51,8 @@ module USCoreTestKit
 
         config(
           outputs: {
-            smart_credentials: {
-              name: :granular_scopes_1_credentials
+            smart_auth_info: {
+              name: :granular_scopes_1_auth_info
             }
           }
         )
@@ -61,8 +61,8 @@ module USCoreTestKit
               optional: true,
               config: {
                 inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_1_credentials
+                  smart_auth_info: {
+                    name: :granular_scopes_1_auth_info
                   }
                 }
               } do
@@ -80,8 +80,8 @@ module USCoreTestKit
               optional: true,
               config: {
                 inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_1_credentials
+                  smart_auth_info: {
+                    name: :granular_scopes_1_auth_info
                   }
                 }
               } do
@@ -100,8 +100,8 @@ module USCoreTestKit
               optional: true,
               config: {
                 inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_1_credentials
+                  smart_auth_info: {
+                    name: :granular_scopes_1_auth_info
                   }
                 }
               } do
@@ -119,8 +119,8 @@ module USCoreTestKit
               optional: true,
               config: {
                 inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_1_credentials
+                  smart_auth_info: {
+                    name: :granular_scopes_1_auth_info
                   }
                 }
               } do
@@ -148,8 +148,8 @@ module USCoreTestKit
 
         config(
           outputs: {
-            smart_credentials: {
-              name: :granular_scopes_2_credentials
+            smart_auth_info: {
+              name: :granular_scopes_2_auth_info
             }
           }
         )
@@ -159,8 +159,8 @@ module USCoreTestKit
               optional: true,
               config: {
                 inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_2_credentials
+                  smart_auth_info: {
+                    name: :granular_scopes_2_auth_info
                   }
                 }
               } do
@@ -178,8 +178,8 @@ module USCoreTestKit
               optional: true,
               config: {
                 inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_2_credentials
+                  smart_auth_info: {
+                    name: :granular_scopes_2_auth_info
                   }
                 }
               } do
@@ -198,8 +198,8 @@ module USCoreTestKit
               optional: true,
               config: {
                 inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_2_credentials
+                  smart_auth_info: {
+                    name: :granular_scopes_2_auth_info
                   }
                 }
               } do
@@ -217,8 +217,8 @@ module USCoreTestKit
               optional: true,
               config: {
                 inputs: {
-                  smart_credentials: {
-                    name: :granular_scopes_2_credentials
+                  smart_auth_info: {
+                    name: :granular_scopes_2_auth_info
                   }
                 }
               } do

--- a/lib/us_core_test_kit/custom_groups/smart_app_launch_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_app_launch_group.rb
@@ -12,64 +12,28 @@ module USCoreTestKit
     id :us_core_smart_app_launch
     title 'SMART App Launch'
 
-    SMART_V1_RESOURCE_LEVEL_SCOPES = 'launch/patient openid fhirUser offline_access patient/Patient.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Coverage.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Media.read patient/Medication.read patient/MedicationDispense.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/QuestionnaireResponse.read patient/RelatedPerson.read patient/ServiceRequest.read patient/Specimen.read'.freeze
-
-    SMART_V2_RESOURCE_LEVEL_SCOPES = 'launch/patient openid fhirUser offline_access patient/Patient.rs patient/AllergyIntolerance.rs patient/CarePlan.rs patient/CareTeam.rs patient/Condition.rs patient/Coverage.rs patient/Device.rs patient/DiagnosticReport.rs patient/DocumentReference.rs patient/Encounter.rs patient/Endpoint.rs patient/Goal.rs patient/Immunization.rs patient/Location.rs patient/Media.rs patient/Medication.rs patient/MedicationDispense.rs patient/MedicationRequest.rs patient/Observation.rs patient/Organization.rs patient/Practitioner.rs patient/PractitionerRole.rs patient/Procedure.rs patient/Provenance.rs patient/QuestionnaireResponse.rs patient/RelatedPerson.rs patient/ServiceRequest.rs patient/Specimen.rs'.freeze
-
-    SMART_V2_2_RESOURCE_LEVEL_SCOPES = 'launch/patient openid fhirUser offline_access patient/Patient.rs patient/AllergyIntolerance.rs patient/CarePlan.rs patient/CareTeam.rs patient/Condition.rs patient/Coverage.rs patient/Device.rs patient/DiagnosticReport.rs patient/DocumentReference.rs patient/Encounter.rs patient/Endpoint.rs patient/Goal.rs patient/Immunization.rs patient/Location.rs patient/Media.rs patient/Medication.rs patient/MedicationDispense.rs patient/MedicationRequest.rs patient/Observation.rs patient/Organization.rs patient/Practitioner.rs patient/PractitionerRole.rs patient/Procedure.rs patient/Provenance.rs patient/QuestionnaireResponse.rs patient/RelatedPerson.rs patient/ServiceRequest.rs patient/Specimen.rs'.freeze
-
     group from: :us_core_smart_standalone_launch_stu1,
           required_suite_options: USCoreOptions::SMART_1_REQUIREMENT,
-          optional: true,
-          config: {
-            inputs: {
-              requested_scopes: { default: SmartAppLaunchGroup::SMART_V1_RESOURCE_LEVEL_SCOPES }
-            }
-          }
+          optional: true
 
     group from: :us_core_smart_ehr_launch_stu1,
           required_suite_options: USCoreOptions::SMART_1_REQUIREMENT,
-          optional: true,
-          config: {
-            inputs: {
-              requested_scopes: { default: SmartAppLaunchGroup::SMART_V1_RESOURCE_LEVEL_SCOPES }
-            }
-          }
+          optional: true
 
     group from: :us_core_smart_standalone_launch_stu2,
           required_suite_options: USCoreOptions::SMART_2_REQUIREMENT,
-          optional: true,
-          config: {
-            inputs: {
-              requested_scopes: { default: SmartAppLaunchGroup::SMART_V2_RESOURCE_LEVEL_SCOPES }
-            }
-          }
+          optional: true
 
     group from: :us_core_smart_ehr_launch_stu2,
           required_suite_options: USCoreOptions::SMART_2_REQUIREMENT,
-          optional: true,
-          config: {
-            inputs: {
-              requested_scopes: { default: SmartAppLaunchGroup::SMART_V2_RESOURCE_LEVEL_SCOPES }
-            }
-          }
+          optional: true
 
     group from: :us_core_smart_standalone_launch_stu2_2,
           required_suite_options: USCoreOptions::SMART_2_2_REQUIREMENT,
-          optional: true,
-          config: {
-            inputs: {
-              requested_scopes: { default: SmartAppLaunchGroup::SMART_V2_2_RESOURCE_LEVEL_SCOPES }
-            }
-          }
+          optional: true
 
     group from: :us_core_smart_ehr_launch_stu2_2,
           required_suite_options: USCoreOptions::SMART_2_2_REQUIREMENT,
-          optional: true,
-          config: {
-            inputs: {
-              requested_scopes: { default: SmartAppLaunchGroup::SMART_V2_2_RESOURCE_LEVEL_SCOPES }
-            }
-          }
+          optional: true
   end
 end

--- a/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu1.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu1.rb
@@ -13,9 +13,14 @@ module USCoreTestKit
       inputs: {
         smart_auth_info: {
           name: :smart_auth_info,
-          default: {
-            requested_scopes: SMART_V1_RESOURCE_LEVEL_SCOPES
-          }.to_json
+          options: {
+            components: [
+              {
+                name: :requested_scopes,
+                default: SMART_V1_RESOURCE_LEVEL_SCOPES
+              }
+            ]
+          }
         },
         received_scopes: { name: :ehr_received_scopes }
       },

--- a/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu1.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu1.rb
@@ -1,9 +1,25 @@
+require_relative 'smart_scopes_constants'
+
 module USCoreTestKit
   class SmartEHRLaunchSTU1 < Inferno::TestGroup
+    include SmartScopesConstants
+
     id :us_core_smart_ehr_launch_stu1
     title 'EHR Launch'
 
     run_as_group
+
+    config(
+      inputs: {
+        smart_auth_info: {
+          name: :ehr_smart_auth_info,
+          default: {
+            requested_scopes: SMART_V1_RESOURCE_LEVEL_SCOPES
+          }.to_json
+        },
+        received_scopes: { name: :ehr_received_scopes }
+      }
+    )
 
     group from: :smart_discovery,
           run_as_group: true
@@ -16,10 +32,6 @@ module USCoreTestKit
       config(
         inputs: {
           id_token: { name: :ehr_id_token },
-          client_id: { name: :ehr_client_id },
-          requested_scopes: { name: :ehr_requested_scopes },
-          access_token: { name: :ehr_access_token },
-          smart_credentials: { name: :ehr_smart_credentials }
         }
       )
     end
@@ -27,14 +39,6 @@ module USCoreTestKit
     group from: :smart_token_refresh do
       run_as_group
       optional
-      config(
-        inputs: {
-          refresh_token: { name: :ehr_refresh_token },
-          client_id: { name: :ehr_client_id },
-          client_secret: { name: :ehr_client_secret },
-          received_scopes: { name: :ehr_received_scopes }
-        }
-      )
     end
   end
 end

--- a/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu1.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu1.rb
@@ -12,12 +12,17 @@ module USCoreTestKit
     config(
       inputs: {
         smart_auth_info: {
-          name: :ehr_smart_auth_info,
+          name: :smart_auth_info,
           default: {
             requested_scopes: SMART_V1_RESOURCE_LEVEL_SCOPES
           }.to_json
         },
         received_scopes: { name: :ehr_received_scopes }
+      },
+      outputs: {
+        smart_auth_info: {
+          name: :smart_auth_info
+        }
       }
     )
 

--- a/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2.rb
@@ -1,9 +1,25 @@
+require_relative 'smart_scopes_constants'
+
 module USCoreTestKit
   class SmartEHRLaunchSTU2 < Inferno::TestGroup
+    include SmartScopesConstants
+
     id :us_core_smart_ehr_launch_stu2
     title 'EHR Launch'
 
     run_as_group
+
+    config(
+      inputs: {
+        smart_auth_info: {
+          name: :standalone_smart_auth_info,
+          default: {
+            requested_scopes: SMART_V2_RESOURCE_LEVEL_SCOPES
+          }.to_json
+        },
+        received_scopes: { name: :ehr_received_scopes }
+      }
+    )
 
     group from: :smart_discovery_stu2,
           run_as_group: true
@@ -16,10 +32,6 @@ module USCoreTestKit
       config(
         inputs: {
           id_token: { name: :ehr_id_token },
-          client_id: { name: :ehr_client_id },
-          requested_scopes: { name: :ehr_requested_scopes },
-          access_token: { name: :ehr_access_token },
-          smart_credentials: { name: :ehr_smart_credentials }
         }
       )
     end
@@ -27,14 +39,6 @@ module USCoreTestKit
     group from: :smart_token_refresh do
       run_as_group
       optional
-      config(
-        inputs: {
-          refresh_token: { name: :ehr_refresh_token },
-          client_id: { name: :ehr_client_id },
-          client_secret: { name: :ehr_client_secret },
-          received_scopes: { name: :ehr_received_scopes }
-        }
-      )
     end
   end
 end

--- a/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2.rb
@@ -12,12 +12,17 @@ module USCoreTestKit
     config(
       inputs: {
         smart_auth_info: {
-          name: :standalone_smart_auth_info,
+          name: :smart_auth_info,
           default: {
             requested_scopes: SMART_V2_RESOURCE_LEVEL_SCOPES
           }.to_json
         },
         received_scopes: { name: :ehr_received_scopes }
+      },
+      outputs: {
+        smart_auth_info: {
+          name: :smart_auth_info
+        }
       }
     )
 

--- a/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2.rb
@@ -13,9 +13,14 @@ module USCoreTestKit
       inputs: {
         smart_auth_info: {
           name: :smart_auth_info,
-          default: {
-            requested_scopes: SMART_V2_RESOURCE_LEVEL_SCOPES
-          }.to_json
+          options: {
+            components: [
+              {
+                name: :requested_scopes,
+                default: SMART_V2_RESOURCE_LEVEL_SCOPES
+              }
+            ]
+          }
         },
         received_scopes: { name: :ehr_received_scopes }
       },

--- a/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2_2.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2_2.rb
@@ -13,9 +13,14 @@ module USCoreTestKit
       inputs: {
         smart_auth_info: {
           name: :smart_auth_info,
-          default: {
-            requested_scopes: SMART_V2_2_RESOURCE_LEVEL_SCOPES
-          }.to_json
+          options: {
+            components: [
+              {
+                name: :requested_scopes,
+                default: SMART_V2_2_RESOURCE_LEVEL_SCOPES
+              }
+            ]
+          }
         },
         received_scopes: { name: :ehr_received_scopes }
       },

--- a/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2_2.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2_2.rb
@@ -1,9 +1,25 @@
+require_relative 'smart_scopes_constants'
+
 module USCoreTestKit
   class SmartEHRLaunchSTU22 < Inferno::TestGroup
+    include SmartScopesConstants
+
     id :us_core_smart_ehr_launch_stu2_2
     title 'EHR Launch'
 
     run_as_group
+
+    config(
+      inputs: {
+        smart_auth_info: {
+          name: :standalone_smart_auth_info,
+          default: {
+            requested_scopes: SMART_V2_2_RESOURCE_LEVEL_SCOPES
+          }.to_json
+        },
+        received_scopes: { name: :ehr_received_scopes }
+      }
+    )
 
     group from: :smart_discovery_stu2_2,
           run_as_group: true
@@ -16,10 +32,6 @@ module USCoreTestKit
       config(
         inputs: {
           id_token: { name: :ehr_id_token },
-          client_id: { name: :ehr_client_id },
-          requested_scopes: { name: :ehr_requested_scopes },
-          access_token: { name: :ehr_access_token },
-          smart_credentials: { name: :ehr_smart_credentials }
         }
       )
     end
@@ -27,14 +39,6 @@ module USCoreTestKit
     group from: :smart_token_refresh_stu2 do
       run_as_group
       optional
-      config(
-        inputs: {
-          refresh_token: { name: :ehr_refresh_token },
-          client_id: { name: :ehr_client_id },
-          client_secret: { name: :ehr_client_secret },
-          received_scopes: { name: :ehr_received_scopes }
-        }
-      )
     end
   end
 end

--- a/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2_2.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_ehr_launch_stu2_2.rb
@@ -12,12 +12,17 @@ module USCoreTestKit
     config(
       inputs: {
         smart_auth_info: {
-          name: :standalone_smart_auth_info,
+          name: :smart_auth_info,
           default: {
             requested_scopes: SMART_V2_2_RESOURCE_LEVEL_SCOPES
           }.to_json
         },
         received_scopes: { name: :ehr_received_scopes }
+      },
+      outputs: {
+        smart_auth_info: {
+          name: :smart_auth_info
+        }
       }
     )
 

--- a/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_scopes_constants.rb
@@ -39,5 +39,11 @@ module USCoreTestKit
       'Observation',
       'ServiceRequest'
     ].map(&:freeze).freeze
+
+    SMART_V1_RESOURCE_LEVEL_SCOPES = 'launch/patient openid fhirUser offline_access patient/Patient.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Coverage.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Media.read patient/Medication.read patient/MedicationDispense.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/QuestionnaireResponse.read patient/RelatedPerson.read patient/ServiceRequest.read patient/Specimen.read'.freeze
+
+    SMART_V2_RESOURCE_LEVEL_SCOPES = 'launch/patient openid fhirUser offline_access patient/Patient.rs patient/AllergyIntolerance.rs patient/CarePlan.rs patient/CareTeam.rs patient/Condition.rs patient/Coverage.rs patient/Device.rs patient/DiagnosticReport.rs patient/DocumentReference.rs patient/Encounter.rs patient/Endpoint.rs patient/Goal.rs patient/Immunization.rs patient/Location.rs patient/Media.rs patient/Medication.rs patient/MedicationDispense.rs patient/MedicationRequest.rs patient/Observation.rs patient/Organization.rs patient/Practitioner.rs patient/PractitionerRole.rs patient/Procedure.rs patient/Provenance.rs patient/QuestionnaireResponse.rs patient/RelatedPerson.rs patient/ServiceRequest.rs patient/Specimen.rs'.freeze
+
+    SMART_V2_2_RESOURCE_LEVEL_SCOPES = 'launch/patient openid fhirUser offline_access patient/Patient.rs patient/AllergyIntolerance.rs patient/CarePlan.rs patient/CareTeam.rs patient/Condition.rs patient/Coverage.rs patient/Device.rs patient/DiagnosticReport.rs patient/DocumentReference.rs patient/Encounter.rs patient/Endpoint.rs patient/Goal.rs patient/Immunization.rs patient/Location.rs patient/Media.rs patient/Medication.rs patient/MedicationDispense.rs patient/MedicationRequest.rs patient/Observation.rs patient/Organization.rs patient/Practitioner.rs patient/PractitionerRole.rs patient/Procedure.rs patient/Provenance.rs patient/QuestionnaireResponse.rs patient/RelatedPerson.rs patient/ServiceRequest.rs patient/Specimen.rs'.freeze
   end
 end

--- a/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu1_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu1_group.rb
@@ -1,9 +1,25 @@
+require_relative 'smart_scopes_constants'
+
 module USCoreTestKit
   class SmartStandaloneLaunchSTU1 < Inferno::TestGroup
+    include SmartScopesConstants
+
     id :us_core_smart_standalone_launch_stu1
     title 'Standalone Launch'
 
     run_as_group
+
+    config(
+      inputs: {
+        smart_auth_info: {
+          name: :standalone_smart_auth_info,
+          default: {
+            requested_scopes: SMART_V1_RESOURCE_LEVEL_SCOPES
+          }.to_json
+        },
+        received_scopes: { name: :standalone_received_scopes }
+      }
+    )
 
     group from: :smart_discovery,
           run_as_group: true
@@ -15,11 +31,7 @@ module USCoreTestKit
       optional
       config(
         inputs: {
-          id_token: { name: :standalone_id_token },
-          client_id: { name: :standalone_client_id },
-          requested_scopes: { name: :standalone_requested_scopes },
-          access_token: { name: :standalone_access_token },
-          smart_credentials: { name: :standalone_smart_credentials }
+          id_token: { name: :standalone_id_token }
         }
       )
     end
@@ -27,14 +39,6 @@ module USCoreTestKit
     group from: :smart_token_refresh do
       run_as_group
       optional
-      config(
-        inputs: {
-          refresh_token: { name: :standalone_refresh_token },
-          client_id: { name: :standalone_client_id },
-          client_secret: { name: :standalone_client_secret },
-          received_scopes: { name: :standalone_received_scopes }
-        }
-      )
     end
   end
 end

--- a/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu1_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu1_group.rb
@@ -12,12 +12,17 @@ module USCoreTestKit
     config(
       inputs: {
         smart_auth_info: {
-          name: :standalone_smart_auth_info,
+          name: :smart_auth_info,
           default: {
             requested_scopes: SMART_V1_RESOURCE_LEVEL_SCOPES
           }.to_json
         },
         received_scopes: { name: :standalone_received_scopes }
+      },
+      outputs: {
+        smart_auth_info: {
+          name: :smart_auth_info
+        }
       }
     )
 

--- a/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu1_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu1_group.rb
@@ -13,9 +13,14 @@ module USCoreTestKit
       inputs: {
         smart_auth_info: {
           name: :smart_auth_info,
-          default: {
-            requested_scopes: SMART_V1_RESOURCE_LEVEL_SCOPES
-          }.to_json
+          options: {
+            components: [
+              {
+                name: :requested_scopes,
+                default: SMART_V1_RESOURCE_LEVEL_SCOPES
+              }
+            ]
+          }
         },
         received_scopes: { name: :standalone_received_scopes }
       },

--- a/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_2_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_2_group.rb
@@ -13,9 +13,14 @@ module USCoreTestKit
       inputs: {
         smart_auth_info: {
           name: :smart_auth_info,
-          default: {
-            requested_scopes: SMART_V2_2_RESOURCE_LEVEL_SCOPES
-          }.to_json
+          options: {
+            components: [
+              {
+                name: :requested_scopes,
+                default: SMART_V2_2_RESOURCE_LEVEL_SCOPES
+              }
+            ]
+          }
         },
         received_scopes: { name: :standalone_received_scopes }
       },

--- a/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_2_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_2_group.rb
@@ -1,9 +1,25 @@
+require_relative 'smart_scopes_constants'
+
 module USCoreTestKit
   class SmartStandaloneLaunchSTU22 < Inferno::TestGroup
+    include SmartScopesConstants
+
     id :us_core_smart_standalone_launch_stu2_2
     title 'Standalone Launch'
 
     run_as_group
+
+    config(
+      inputs: {
+        smart_auth_info: {
+          name: :standalone_smart_auth_info,
+          default: {
+            requested_scopes: SMART_V2_2_RESOURCE_LEVEL_SCOPES
+          }.to_json
+        },
+        received_scopes: { name: :standalone_received_scopes }
+      }
+    )
 
     group from: :smart_discovery_stu2_2,
           run_as_group: true
@@ -15,11 +31,7 @@ module USCoreTestKit
       optional
       config(
         inputs: {
-          id_token: { name: :standalone_id_token },
-          client_id: { name: :standalone_client_id },
-          requested_scopes: { name: :standalone_requested_scopes },
-          access_token: { name: :standalone_access_token },
-          smart_credentials: { name: :standalone_smart_credentials }
+          id_token: { name: :standalone_id_token }
         }
       )
     end
@@ -27,14 +39,6 @@ module USCoreTestKit
     group from: :smart_token_refresh_stu2 do
       run_as_group
       optional
-      config(
-        inputs: {
-          refresh_token: { name: :standalone_refresh_token },
-          client_id: { name: :standalone_client_id },
-          client_secret: { name: :standalone_client_secret },
-          received_scopes: { name: :standalone_received_scopes }
-        }
-      )
     end
   end
 end

--- a/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_2_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_2_group.rb
@@ -12,12 +12,17 @@ module USCoreTestKit
     config(
       inputs: {
         smart_auth_info: {
-          name: :standalone_smart_auth_info,
+          name: :smart_auth_info,
           default: {
             requested_scopes: SMART_V2_2_RESOURCE_LEVEL_SCOPES
           }.to_json
         },
         received_scopes: { name: :standalone_received_scopes }
+      },
+      outputs: {
+        smart_auth_info: {
+          name: :smart_auth_info
+        }
       }
     )
 

--- a/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_group.rb
@@ -13,9 +13,14 @@ module USCoreTestKit
       inputs: {
         smart_auth_info: {
           name: :smart_auth_info,
-          default: {
-            requested_scopes: SMART_V2_RESOURCE_LEVEL_SCOPES
-          }.to_json
+          options: {
+            components: [
+              {
+                name: :requested_scopes,
+                default: SMART_V2_RESOURCE_LEVEL_SCOPES
+              }
+            ]
+          }
         },
         received_scopes: { name: :standalone_received_scopes }
       },

--- a/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_group.rb
@@ -1,9 +1,25 @@
+require_relative 'smart_scopes_constants'
+
 module USCoreTestKit
   class SmartStandaloneLaunchSTU2 < Inferno::TestGroup
+    include SmartScopesConstants
+
     id :us_core_smart_standalone_launch_stu2
     title 'Standalone Launch'
 
     run_as_group
+
+    config(
+      inputs: {
+        smart_auth_info: {
+          name: :standalone_smart_auth_info,
+          default: {
+            requested_scopes: SMART_V2_RESOURCE_LEVEL_SCOPES
+          }.to_json
+        },
+        received_scopes: { name: :standalone_received_scopes }
+      }
+    )
 
     group from: :smart_discovery_stu2,
           run_as_group: true
@@ -15,11 +31,7 @@ module USCoreTestKit
       optional
       config(
         inputs: {
-          id_token: { name: :standalone_id_token },
-          client_id: { name: :standalone_client_id },
-          requested_scopes: { name: :standalone_requested_scopes },
-          access_token: { name: :standalone_access_token },
-          smart_credentials: { name: :standalone_smart_credentials }
+          id_token: { name: :standalone_id_token }
         }
       )
     end
@@ -27,14 +39,6 @@ module USCoreTestKit
     group from: :smart_token_refresh do
       run_as_group
       optional
-      config(
-        inputs: {
-          refresh_token: { name: :standalone_refresh_token },
-          client_id: { name: :standalone_client_id },
-          client_secret: { name: :standalone_client_secret },
-          received_scopes: { name: :standalone_received_scopes }
-        }
-      )
     end
   end
 end

--- a/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_group.rb
+++ b/lib/us_core_test_kit/custom_groups/smart_standalone_launch_stu2_group.rb
@@ -12,12 +12,17 @@ module USCoreTestKit
     config(
       inputs: {
         smart_auth_info: {
-          name: :standalone_smart_auth_info,
+          name: :smart_auth_info,
           default: {
             requested_scopes: SMART_V2_RESOURCE_LEVEL_SCOPES
           }.to_json
         },
         received_scopes: { name: :standalone_received_scopes }
+      },
+      outputs: {
+        smart_auth_info: {
+          name: :smart_auth_info
+        }
       }
     )
 

--- a/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
@@ -31,9 +31,11 @@ above scopes.
         .first
         .config(
           inputs: {
-            requested_scopes: {
-              name: :requested_scopes_group1,
-              default: groups.first.default_group_scopes('v610')
+            smart_auth_info: {
+              name: :granular_scopes_1_auth_info,
+              default: {
+                requested_scopes: groups.first.default_group_scopes('v610')
+              }.to_json
             }
           },
           options: {
@@ -61,9 +63,11 @@ above scopes.
         .last
         .config(
           inputs: {
-            requested_scopes: {
-              name: :requested_scopes_group2,
-              default: groups.last.default_group_scopes('v610')
+            smart_auth_info: {
+              name: :granular_scopes_2_auth_info,
+              default: {
+                requested_scopes: groups.last.default_group_scopes('v610')
+              }.to_json
             }
           },
           options: {

--- a/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
@@ -33,9 +33,14 @@ above scopes.
           inputs: {
             smart_auth_info: {
               name: :granular_scopes_1_auth_info,
-              default: {
-                requested_scopes: groups.first.default_group_scopes('v610')
-              }.to_json
+              options: {
+                components: [
+                  {
+                    name: :requested_scopes,
+                    default: groups.first.default_group_scopes('v610')
+                  }
+                ]
+              }
             }
           },
           options: {
@@ -65,9 +70,14 @@ above scopes.
           inputs: {
             smart_auth_info: {
               name: :granular_scopes_2_auth_info,
-              default: {
-                requested_scopes: groups.last.default_group_scopes('v610')
-              }.to_json
+              options: {
+                components: [
+                  {
+                    name: :requested_scopes,
+                    default: groups.last.default_group_scopes('v610')
+                  }
+                ]
+              }
             }
           },
           options: {

--- a/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v6.1.0/smart_granular_scopes_group.rb
@@ -33,6 +33,7 @@ above scopes.
           inputs: {
             smart_auth_info: {
               name: :granular_scopes_1_auth_info,
+              title: 'Granular Scopes 1 Credentials',
               options: {
                 components: [
                   {
@@ -70,6 +71,7 @@ above scopes.
           inputs: {
             smart_auth_info: {
               name: :granular_scopes_2_auth_info,
+              title: 'Granular Scopes 2 Credentials',
               options: {
                 components: [
                   {

--- a/lib/us_core_test_kit/custom_groups/v7.0.0/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v7.0.0/smart_granular_scopes_group.rb
@@ -33,9 +33,14 @@ above scopes.
           inputs: {
             smart_auth_info: {
               name: :granular_scopes_1_auth_info,
-              default: {
-                requested_scopes: groups.first.default_group_scopes('v700')
-              }.to_json
+              options: {
+                components: [
+                  {
+                    name: :requested_scopes,
+                    default: groups.first.default_group_scopes('v700')
+                  }
+                ]
+              }
             }
           },
           options: {
@@ -65,9 +70,14 @@ above scopes.
           inputs: {
             smart_auth_info: {
               name: :granular_scopes_2_auth_info,
-              default: {
-                requested_scopes: groups.last.default_group_scopes('v700')
-              }.to_json
+              options: {
+                components: [
+                  {
+                    name: :requested_scopes,
+                    default: groups.last.default_group_scopes('v700')
+                  }
+                ]
+              }
             }
           },
           options: {

--- a/lib/us_core_test_kit/custom_groups/v7.0.0/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v7.0.0/smart_granular_scopes_group.rb
@@ -31,9 +31,11 @@ above scopes.
         .first
         .config(
           inputs: {
-            requested_scopes: {
-              name: :requested_scopes_group1,
-              default: groups.first.default_group_scopes('v700')
+            smart_auth_info: {
+              name: :granular_scopes_1_auth_info,
+              default: {
+                requested_scopes: groups.first.default_group_scopes('v700')
+              }.to_json
             }
           },
           options: {
@@ -61,9 +63,11 @@ above scopes.
         .last
         .config(
           inputs: {
-            requested_scopes: {
-              name: :requested_scopes_group2,
-              default: groups.last.default_group_scopes('v700')
+            smart_auth_info: {
+              name: :granular_scopes_2_auth_info,
+              default: {
+                requested_scopes: groups.last.default_group_scopes('v700')
+              }.to_json
             }
           },
           options: {

--- a/lib/us_core_test_kit/custom_groups/v7.0.0/smart_granular_scopes_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v7.0.0/smart_granular_scopes_group.rb
@@ -33,6 +33,7 @@ above scopes.
           inputs: {
             smart_auth_info: {
               name: :granular_scopes_1_auth_info,
+              title: 'Granular Scopes 1 Credentials',
               options: {
                 components: [
                   {
@@ -70,6 +71,7 @@ above scopes.
           inputs: {
             smart_auth_info: {
               name: :granular_scopes_2_auth_info,
+              title: 'Granular Scopes 2 Credentials',
               options: {
                 components: [
                   {

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -120,14 +120,14 @@ module USCoreTestKit
       group from: :us_core_smart_app_launch
 
       group do
-        input :smart_credentials,
+        input :smart_auth_info,
           title: 'OAuth Credentials',
-          type: :oauth_credentials,
+          type: :auth_info,
           optional: true
 
         fhir_client do
           url :url
-          oauth_credentials :smart_credentials
+          auth_info :smart_auth_info
         end
 
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -122,14 +122,14 @@ module USCoreTestKit
       group from: :us_core_smart_app_launch
 
       group do
-        input :smart_credentials,
+        input :smart_auth_info,
           title: 'OAuth Credentials',
-          type: :oauth_credentials,
+          type: :auth_info,
           optional: true
 
         fhir_client do
           url :url
-          oauth_credentials :smart_credentials
+          auth_info :smart_auth_info
         end
 
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -132,14 +132,14 @@ module USCoreTestKit
       group from: :us_core_smart_app_launch
 
       group do
-        input :smart_credentials,
+        input :smart_auth_info,
           title: 'OAuth Credentials',
-          type: :oauth_credentials,
+          type: :auth_info,
           optional: true
 
         fhir_client do
           url :url
-          oauth_credentials :smart_credentials
+          auth_info :smart_auth_info
         end
 
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scopes1_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scopes1_group.rb
@@ -19,9 +19,9 @@ based on the following granular scopes:
 
       )
 
-      input :granular_scopes_1_credentials,
+      input :granular_scopes_1_auth_info,
             title: 'SMART Credentials for Granular Scopes 1',
-            type: :oauth_credentials,
+            type: :auth_info,
             locked: true
 
       config(
@@ -40,7 +40,7 @@ based on the following granular scopes:
       )
 
       fhir_client do
-        oauth_credentials :granular_scopes_1_credentials
+        auth_info :granular_scopes_1_auth_info
         url :url
       end
 

--- a/lib/us_core_test_kit/generated/v6.1.0/granular_scopes2_group.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/granular_scopes2_group.rb
@@ -19,9 +19,9 @@ based on the following granular scopes:
 
       )
 
-      input :granular_scopes_2_credentials,
+      input :granular_scopes_2_auth_info,
             title: 'SMART Credentials for Granular Scopes 2',
-            type: :oauth_credentials,
+            type: :auth_info,
             locked: true
 
       config(
@@ -40,7 +40,7 @@ based on the following granular scopes:
       )
 
       fhir_client do
-        oauth_credentials :granular_scopes_2_credentials
+        auth_info :granular_scopes_2_auth_info
         url :url
       end
 

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -143,14 +143,14 @@ module USCoreTestKit
       group from: :us_core_smart_app_launch
 
       group do
-        input :smart_credentials,
+        input :smart_auth_info,
           title: 'OAuth Credentials',
-          type: :oauth_credentials,
+          type: :auth_info,
           optional: true
 
         fhir_client do
           url :url
-          oauth_credentials :smart_credentials
+          auth_info :smart_auth_info
         end
 
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scopes1_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scopes1_group.rb
@@ -19,9 +19,9 @@ based on the following granular scopes:
 
       )
 
-      input :granular_scopes_1_credentials,
+      input :granular_scopes_1_auth_info,
             title: 'SMART Credentials for Granular Scopes 1',
-            type: :oauth_credentials,
+            type: :auth_info,
             locked: true
 
       config(
@@ -40,7 +40,7 @@ based on the following granular scopes:
       )
 
       fhir_client do
-        oauth_credentials :granular_scopes_1_credentials
+        auth_info :granular_scopes_1_auth_info
         url :url
       end
 

--- a/lib/us_core_test_kit/generated/v7.0.0/granular_scopes2_group.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/granular_scopes2_group.rb
@@ -19,9 +19,9 @@ based on the following granular scopes:
 
       )
 
-      input :granular_scopes_2_credentials,
+      input :granular_scopes_2_auth_info,
             title: 'SMART Credentials for Granular Scopes 2',
-            type: :oauth_credentials,
+            type: :auth_info,
             locked: true
 
       config(
@@ -40,7 +40,7 @@ based on the following granular scopes:
       )
 
       fhir_client do
-        oauth_credentials :granular_scopes_2_credentials
+        auth_info :granular_scopes_2_auth_info
         url :url
       end
 

--- a/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
@@ -151,14 +151,14 @@ module USCoreTestKit
             required_suite_options: USCoreOptions::SMART_2_2_REQUIREMENT
 
       group do
-        input :smart_credentials,
+        input :smart_auth_info,
           title: 'OAuth Credentials',
-          type: :oauth_credentials,
+          type: :auth_info,
           optional: true
 
         fhir_client do
           url :url
-          oauth_credentials :smart_credentials
+          auth_info :smart_auth_info
         end
 
         title 'US Core FHIR API'

--- a/lib/us_core_test_kit/generator/templates/granular_scope_group.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/granular_scope_group.rb.erb
@@ -10,9 +10,9 @@ module USCoreTestKit
 <%= description %>
       )
 
-      input :granular_scopes_<%= group_number %>_credentials,
+      input :granular_scopes_<%= group_number %>_auth_info,
             title: 'SMART Credentials for Granular Scopes <%= group_number %>',
-            type: :oauth_credentials,
+            type: :auth_info,
             locked: true
 
       config(
@@ -31,7 +31,7 @@ module USCoreTestKit
       )
 
       fhir_client do
-        oauth_credentials :granular_scopes_<%= group_number %>_credentials
+        auth_info :granular_scopes_<%= group_number %>_auth_info
         url :url
       end
 <% group_id_list.each do |group_id| %>

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -106,14 +106,14 @@ module USCoreTestKit
             required_suite_options: USCoreOptions::SMART_2_2_REQUIREMENT<% end %>
 
       group do
-        input :smart_credentials,
+        input :smart_auth_info,
           title: 'OAuth Credentials',
-          type: :oauth_credentials,
+          type: :auth_info,
           optional: true
 
         fhir_client do
           url :url
-          oauth_credentials :smart_credentials
+          auth_info :smart_auth_info
         end
 
         title 'US Core FHIR API'

--- a/us_core_test_kit.gemspec
+++ b/us_core_test_kit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inferno-framework/us-core-test-kit'
   spec.license       = 'Apache-2.0'
   spec.add_runtime_dependency 'inferno_core', '>= 0.6.4'
-  spec.add_runtime_dependency 'smart_app_launch_test_kit', '>= 0.5.0'
+  spec.add_runtime_dependency 'smart_app_launch_test_kit', '>= 0.6.0'
   spec.add_runtime_dependency 'tls_test_kit', '~> 0.3.0'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'


### PR DESCRIPTION
# Summary
This branch updates the US Core Test Kit to use the updated SMART App Launch Test Kit with AuthInfo instead of OAuthCredentials.

# Testing Guidance
All tests and presets should work as normal.