### PR TITLE
FI-3754 Default suites to use smart v2.0.0 in new metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     us_core_test_kit (0.10.0)
-      inferno_core (>= 0.6.1)
+      inferno_core (>= 0.6.4)
       smart_app_launch_test_kit (>= 0.5.0)
       tls_test_kit (~> 0.3.0)
 
@@ -137,7 +137,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (0.6.2)
+    inferno_core (0.6.4)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -100,6 +100,7 @@ module USCoreTestKit
 
       suite_option :smart_app_launch_version,
         title: 'SMART App Launch Version',
+        default: USCoreOptions::SMART_2,
         list_options: [
           {
             label: 'SMART App Launch 1.0.0',
@@ -108,7 +109,6 @@ module USCoreTestKit
           {
             label: 'SMART App Launch 2.0.0',
             value: USCoreOptions::SMART_2,
-            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -107,7 +107,8 @@ module USCoreTestKit
           },
           {
             label: 'SMART App Launch 2.0.0',
-            value: USCoreOptions::SMART_2
+            value: USCoreOptions::SMART_2,
+            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -102,6 +102,7 @@ module USCoreTestKit
 
       suite_option :smart_app_launch_version,
         title: 'SMART App Launch Version',
+        default: USCoreOptions::SMART_2,
         list_options: [
           {
             label: 'SMART App Launch 1.0.0',
@@ -110,7 +111,6 @@ module USCoreTestKit
           {
             label: 'SMART App Launch 2.0.0',
             value: USCoreOptions::SMART_2,
-            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -109,7 +109,8 @@ module USCoreTestKit
           },
           {
             label: 'SMART App Launch 2.0.0',
-            value: USCoreOptions::SMART_2
+            value: USCoreOptions::SMART_2,
+            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -112,6 +112,7 @@ module USCoreTestKit
 
       suite_option :smart_app_launch_version,
         title: 'SMART App Launch Version',
+        default: USCoreOptions::SMART_2,
         list_options: [
           {
             label: 'SMART App Launch 1.0.0',
@@ -120,7 +121,6 @@ module USCoreTestKit
           {
             label: 'SMART App Launch 2.0.0',
             value: USCoreOptions::SMART_2,
-            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -119,7 +119,8 @@ module USCoreTestKit
           },
           {
             label: 'SMART App Launch 2.0.0',
-            value: USCoreOptions::SMART_2
+            value: USCoreOptions::SMART_2,
+            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -130,7 +130,8 @@ module USCoreTestKit
           },
           {
             label: 'SMART App Launch 2.0.0',
-            value: USCoreOptions::SMART_2
+            value: USCoreOptions::SMART_2,
+            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -123,6 +123,7 @@ module USCoreTestKit
 
       suite_option :smart_app_launch_version,
         title: 'SMART App Launch Version',
+        default: USCoreOptions::SMART_2,
         list_options: [
           {
             label: 'SMART App Launch 1.0.0',
@@ -131,7 +132,6 @@ module USCoreTestKit
           {
             label: 'SMART App Launch 2.0.0',
             value: USCoreOptions::SMART_2,
-            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
@@ -132,7 +132,8 @@ module USCoreTestKit
           },
           {
             label: 'SMART App Launch 2.0.0',
-            value: USCoreOptions::SMART_2
+            value: USCoreOptions::SMART_2,
+            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
@@ -125,6 +125,7 @@ module USCoreTestKit
 
       suite_option :smart_app_launch_version,
         title: 'SMART App Launch Version',
+        default: USCoreOptions::SMART_2,
         list_options: [
           {
             label: 'SMART App Launch 1.0.0',
@@ -133,7 +134,6 @@ module USCoreTestKit
           {
             label: 'SMART App Launch 2.0.0',
             value: USCoreOptions::SMART_2,
-            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -87,7 +87,8 @@ module USCoreTestKit
           },
           {
             label: 'SMART App Launch 2.0.0',
-            value: USCoreOptions::SMART_2
+            value: USCoreOptions::SMART_2,
+            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -80,6 +80,7 @@ module USCoreTestKit
 
       suite_option :smart_app_launch_version,
         title: 'SMART App Launch Version',
+        default: USCoreOptions::SMART_2,
         list_options: [
           {
             label: 'SMART App Launch 1.0.0',
@@ -88,7 +89,6 @@ module USCoreTestKit
           {
             label: 'SMART App Launch 2.0.0',
             value: USCoreOptions::SMART_2,
-            default: true
           },
           {
             label: 'SMART App Launch 2.2.0',

--- a/us_core_test_kit.gemspec
+++ b/us_core_test_kit.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'US Core Inferno tests'
   spec.homepage      = 'https://github.com/inferno-framework/us-core-test-kit'
   spec.license       = 'Apache-2.0'
-  spec.add_runtime_dependency 'inferno_core', '>= 0.6.1'
+  spec.add_runtime_dependency 'inferno_core', '>= 0.6.4'
   spec.add_runtime_dependency 'smart_app_launch_test_kit', '>= 0.5.0'
   spec.add_runtime_dependency 'tls_test_kit', '~> 0.3.0'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'


### PR DESCRIPTION
inferno.healthit.gov defaults to smart v2 for all suites in US Core.  See https://inferno.healthit.gov/test-kits/us-core/

This updates our suite options to be consistent with that so there is no behavior change when we migrate over to the new method of leveraging test kit metadata on platform apps.

This operates under the assumption that we want to use this version of smart as the default, but it seems reasonable to me.  Feel free to disagree though -- we don't have to merge this.

This includes functionality provided by the new v0.6.4 inferno core release, which is why the gemspec reflects that as a minimum version.

The only way to test right now is to launch the app and check the API responses that come back; SMART App Launch 2 should be the default for all US Core suites.  A later upgrade to inferno core will update the standalone app UI, but in the meantime we'll be updating platforms to read that so as to not loose existing functionality on inferno.healthit.gov in moving towards test kit metadata usage on the test kit pages.

<img width="1426" alt="Screenshot 2025-02-14 at 2 25 56 PM" src="https://github.com/user-attachments/assets/be1a6a50-723a-4b55-89da-0bdc71f48e85" />



