### PR TITLE
FI-3752: Observation BMI dataAbsentReason Validation Filter

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -66,7 +66,7 @@ module USCoreTestKit
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
-        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
+        %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -65,7 +65,8 @@ module USCoreTestKit
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
-        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
+        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -68,7 +68,7 @@ module USCoreTestKit
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
-        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
+        %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -67,7 +67,8 @@ module USCoreTestKit
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
-        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
+        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -78,7 +78,7 @@ module USCoreTestKit
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
-        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
+        %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -77,7 +77,8 @@ module USCoreTestKit
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
-        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
+        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -85,7 +85,7 @@ module USCoreTestKit
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
-        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
+        %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -84,7 +84,8 @@ module USCoreTestKit
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
-        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
+        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [

--- a/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
@@ -91,7 +91,7 @@ module USCoreTestKit
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
-        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
+        %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
@@ -90,7 +90,8 @@ module USCoreTestKit
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
-        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
+        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
       ].freeze
 
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -42,7 +42,7 @@ module USCoreTestKit
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
-        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
+        %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze
 <% if version_specific_message_filters.empty? %>
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -41,7 +41,8 @@ module USCoreTestKit
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
-        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'} # Known issue with the Pulse Oximetry Profile
+        %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
+        %r{Slice 'Observation.value\[x\]:valueQuantity': a matching slice is required, but not found \(from \[http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1\|http://hl7\.org/fhir/StructureDefinition/bmi%7C4\.0\.1\]\)}
       ].freeze
 <% if version_specific_message_filters.empty? %>
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze


### PR DESCRIPTION
# Summary
This is linked to GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/620

Previously, when the server sends an Observation BMI resource with dataAbsentReason, the validator would throw a validation error:

Observation: Slice 'Observation.value[x]:valueQuantity': a matching slice is required, but not found (from [http://hl7.org/fhir/StructureDefinition/bmi|4.0.1|http://hl7.org/fhir/StructureDefinition/bmi%7C4.0.1]).

The reason is that all resources have to be valid not only to its declared profiles but also to corresponding FHIR resource type and FHIR core profiles. When the validator validates a US Core BMI observation resource, it validates it using both US Core BMI profile and FHIR BMI profile. US Core BMI profile inherits from FHIR vital-signs profile which allows the choice between value[x] and dataAbsentReason. FHIR BMI profile also inherits from FHIR vital-signs profiles but restricts the choice to mandate value[x] to be presented. This combination causes this validation error.

A validation message filter has been added to the US Core suite template to filter out this Observation BMI dataAbsent reason validation error, and the US Core test kit has been regenerated with this change.

