### PR TITLE
Remove USCoreTestKit::SearchTest#fetch_all_bundled_resources

### DIFF
--- a/lib/us_core_test_kit/granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/granular_scope_search_test.rb
@@ -28,7 +28,8 @@ module USCoreTestKit
           if request.status != 200
             []
           else
-            fetch_all_bundled_resources.select { |resource| resource.resourceType == resource_type }
+            fetch_all_bundled_resources(resource_type: resource_type, bundle: resource)
+              .select { |resource| resource.resourceType == resource_type }
           end
 
         mismatched_ids = mismatched_resource_ids(found_resources)

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -555,6 +555,7 @@ module USCoreTestKit
         )
         tags = tags(params)
         bundle = resource
+        additional_resource_types << 'Medication' if ['MedicationRequest', 'MedicationDispense'].include?(resource_type)
 
         assert_handler = Proc.new do |response|
           assert_response_status(200, response: response)

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -558,9 +558,7 @@ module USCoreTestKit
 
         assert_handler = Proc.new do |response|
           assert_response_status(200, response: response)
-
-          # error_message = cant_resolve_next_bundle_message(response[:body])
-          assert_valid_json(response[:body])#, TODO error_message)
+          assert_valid_json(response[:body], "Could not resolve bundle as JSON: #{response[:body]}")
         end
 
         if reply_handler
@@ -573,10 +571,6 @@ module USCoreTestKit
         end
 
         fetch_all_bundled_resources(resource_type:, bundle:, reply_handler: reply_and_assert_handler, max_pages:, additional_resource_types:, tags:)
-    end
-
-    def cant_resolve_next_bundle_message(link)
-      "Could not resolve next bundle: #{link}"
     end
 
     def search_param_value(name, resource, include_system: false)

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -69,7 +69,7 @@ module USCoreTestKit
 
             # TODO: check that only provenance resources for resources matching
             # granular scopes returned
-            fetch_all_bundled_resources(additional_resource_types: ['Provenance'], params:)
+            fetch_and_assert_all_bundled_resources(additional_resource_types: ['Provenance'], params:)
               .select { |resource| resource.resourceType == 'Provenance' }
           end
         end
@@ -104,7 +104,7 @@ module USCoreTestKit
       check_search_response
 
       resources_returned =
-        fetch_all_bundled_resources(params:).select { |resource| resource.resourceType == resource_type }
+        fetch_and_assert_all_bundled_resources(params:).select { |resource| resource.resourceType == resource_type }
 
       return [] if resources_returned.blank?
 
@@ -139,7 +139,7 @@ module USCoreTestKit
 
       check_search_response
 
-      post_search_resources = fetch_all_bundled_resources.select { |resource| resource.resourceType == resource_type }
+      post_search_resources = fetch_and_assert_all_bundled_resources.select { |resource| resource.resourceType == resource_type }
 
       filter_conditions(post_search_resources) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
       filter_devices(post_search_resources) if resource_type == 'Device'
@@ -247,7 +247,7 @@ module USCoreTestKit
 
           search_and_check_response(params_with_comparator)
 
-          comparator_resources = fetch_all_bundled_resources(params: params_with_comparator).each do |resource|
+          comparator_resources = fetch_and_assert_all_bundled_resources(params: params_with_comparator).each do |resource|
             check_resource_against_params(resource, params_with_comparator) if resource.resourceType == resource_type
           end
         end
@@ -264,7 +264,7 @@ module USCoreTestKit
       search_and_check_response(new_search_params)
 
       reference_with_type_resources =
-        fetch_all_bundled_resources(params: new_search_params)
+        fetch_and_assert_all_bundled_resources(params: new_search_params)
           .select { |resource| resource.resourceType == resource_type }
 
       filter_conditions(reference_with_type_resources) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
@@ -290,7 +290,7 @@ module USCoreTestKit
       search_and_check_response(search_params)
 
       resources_returned =
-        fetch_all_bundled_resources(params: search_params)
+        fetch_and_assert_all_bundled_resources(params: search_params)
           .select { |resource| resource.resourceType == resource_type }
 
       assert resources_returned.present?, "No resources were returned when searching by `system|code`"
@@ -361,7 +361,7 @@ module USCoreTestKit
         search_and_check_response(search_params)
 
         resources_returned =
-          fetch_all_bundled_resources(params: search_params)
+          fetch_and_assert_all_bundled_resources(params: search_params)
             .select { |resource| resource.resourceType == resource_type }
 
         multiple_or_search_params.each do |param_name|
@@ -409,7 +409,7 @@ module USCoreTestKit
       search_and_check_response(search_params)
 
       medications =
-        fetch_all_bundled_resources(params: search_params)
+        fetch_and_assert_all_bundled_resources(params: search_params)
           .select { |resource| resource.resourceType == 'Medication' }
       assert medications.present?, 'No Medications were included in the search results'
 
@@ -546,52 +546,33 @@ module USCoreTestKit
       msg + ". Please use patients with more information"
     end
 
-    def fetch_all_bundled_resources(
+    def fetch_and_assert_all_bundled_resources(
+          resource_type: self.resource_type,
           reply_handler: nil,
           max_pages: 20,
           additional_resource_types: [],
-          resource_type: self.resource_type,
           params: nil
         )
-      page_count = 1
-      resources = []
-      bundle = resource
+        tags = tags(params)
+        bundle = resource
 
-      until bundle.nil? || page_count == max_pages
-        resources += bundle&.entry&.map { |entry| entry&.resource }
-        next_bundle_link = bundle&.link&.find { |link| link.relation == 'next' }&.url
-        reply_handler&.call(response)
+        assert_handler = Proc.new do |response|
+          assert_response_status(200, response: response)
 
-        break if next_bundle_link.blank?
+          # error_message = cant_resolve_next_bundle_message(response[:body])
+          assert_valid_json(response[:body])#, TODO error_message)
+        end
 
-        reply = fhir_client.raw_read_url(next_bundle_link)
+        if reply_handler
+          reply_and_assert_handler = Proc.new do |response|
+            assert_handler.call(response)
+            reply_handler.call(response)
+          end
+        else
+          reply_and_assert_handler = assert_handler
+        end
 
-        store_request('outgoing', tags: tags(params)) { reply }
-        error_message = cant_resolve_next_bundle_message(next_bundle_link)
-
-        assert_response_status(200)
-        assert_valid_json(reply.body, error_message)
-
-        bundle = fhir_client.parse_reply(FHIR::Bundle, fhir_client.default_format, reply)
-
-        page_count += 1
-      end
-
-      valid_resource_types = [resource_type, 'OperationOutcome'].concat(additional_resource_types)
-      valid_resource_types << 'Medication' if ['MedicationRequest', 'MedicationDispense'].include?(resource_type)
-
-      invalid_resource_types =
-        resources.reject { |entry| valid_resource_types.include? entry.resourceType }
-                 .map(&:resourceType)
-                 .uniq
-
-      if invalid_resource_types.any?
-        info "Received resource type(s) #{invalid_resource_types.join(', ')} in search bundle, " \
-             "but only expected resource types #{valid_resource_types.join(', ')}. " + \
-             "This is unusual but allowed if the server believes additional resource types are relevant."
-      end
-
-      resources
+        fetch_all_bundled_resources(resource_type:, bundle:, reply_handler: reply_and_assert_handler, max_pages:, additional_resource_types:, tags:)
     end
 
     def cant_resolve_next_bundle_message(link)


### PR DESCRIPTION
# Summary
 - remove `USCoreTestKit::SearchTest#fetch_all_bundled_resources` which is now defined in core
 - implement `fetch_and_assert_all_bundled_resources`, which wraps the former function and adds the assertion statements the original definition had
 - fix rspec tests so they pass with new functions

# Testing
 1. Checkout branch
 2. `bundle exec rspec`