### PR TITLE
FI-3879: Typo and outdated details in Capability Statement Tests

### DIFF
--- a/lib/us_core_test_kit/custom_groups/v3.1.1/capability_statement_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v3.1.1/capability_statement_group.rb
@@ -16,9 +16,7 @@ module USCoreTestKit
         features supported by the API by using the [Capability
         Statement](https://www.hl7.org/fhir/capabilitystatement.html) resource.
         The features described in the Capability Statement must be consistent with
-        the required capabilities of a US Core server. The Capability Statement
-        must also advertise the location of the required SMART on FHIR endpoints
-        that enable authenticated access to the FHIR server resources.
+        the required capabilities of a US Core server.
 
         The Capability Statement resource allows clients to determine which
         resources are supported by a FHIR Server. Not all servers are expected to
@@ -38,12 +36,6 @@ module USCoreTestKit
         * The server claims support for JSON encoding of resources
         * The server claims support for the Patient resource and one other
           resource
-
-        It collects the following information that is saved in the testing session
-        for use by later tests:
-
-        * List of resources supported
-        * List of queries parameters supported
       )
       run_as_group
 

--- a/lib/us_core_test_kit/custom_groups/v3.1.1/resource_support_test.rb
+++ b/lib/us_core_test_kit/custom_groups/v3.1.1/resource_support_test.rb
@@ -2,7 +2,7 @@ module USCoreTestKit
   module USCoreV311
     class ProfileSupportTest < Inferno::Test
       id :us_core_v311_resource_support
-      title 'Capability Statement lists support for required US Core Resoruce Types'
+      title 'Capability Statement lists support for required US Core Resource Types'
       description %(
         The US Core Implementation Guide states:
 

--- a/lib/us_core_test_kit/custom_groups/v4.0.0/capability_statement_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v4.0.0/capability_statement_group.rb
@@ -17,9 +17,7 @@ module USCoreTestKit
         features supported by the API by using the [Capability
         Statement](https://www.hl7.org/fhir/capabilitystatement.html) resource.
         The features described in the Capability Statement must be consistent with
-        the required capabilities of a US Core server. The Capability Statement
-        must also advertise the location of the required SMART on FHIR endpoints
-        that enable authenticated access to the FHIR server resources.
+        the required capabilities of a US Core server.
 
         The Capability Statement resource allows clients to determine which
         resources are supported by a FHIR Server. Not all servers are expected to
@@ -39,12 +37,6 @@ module USCoreTestKit
         * The server claims support for JSON encoding of resources
         * The server claims support for the Patient resource and one other
           resource
-
-        It collects the following information that is saved in the testing session
-        for use by later tests:
-
-        * List of resources supported
-        * List of queries parameters supported
       )
       run_as_group
 

--- a/lib/us_core_test_kit/custom_groups/v5.0.1/capability_statement_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v5.0.1/capability_statement_group.rb
@@ -17,9 +17,7 @@ module USCoreTestKit
         features supported by the API by using the [Capability
         Statement](https://www.hl7.org/fhir/capabilitystatement.html) resource.
         The features described in the Capability Statement must be consistent with
-        the required capabilities of a US Core server. The Capability Statement
-        must also advertise the location of the required SMART on FHIR endpoints
-        that enable authenticated access to the FHIR server resources.
+        the required capabilities of a US Core server.
 
         The Capability Statement resource allows clients to determine which
         resources are supported by a FHIR Server. Not all servers are expected to
@@ -39,12 +37,6 @@ module USCoreTestKit
         * The server claims support for JSON encoding of resources
         * The server claims support for the Patient resource and one other
           resource
-
-        It collects the following information that is saved in the testing session
-        for use by later tests:
-
-        * List of resources supported
-        * List of queries parameters supported
       )
       run_as_group
 

--- a/lib/us_core_test_kit/custom_groups/v6.1.0/capability_statement_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v6.1.0/capability_statement_group.rb
@@ -17,9 +17,7 @@ module USCoreTestKit
         features supported by the API by using the [Capability
         Statement](https://www.hl7.org/fhir/capabilitystatement.html) resource.
         The features described in the Capability Statement must be consistent with
-        the required capabilities of a US Core server. The Capability Statement
-        must also advertise the location of the required SMART on FHIR endpoints
-        that enable authenticated access to the FHIR server resources.
+        the required capabilities of a US Core server.
 
         The Capability Statement resource allows clients to determine which
         resources are supported by a FHIR Server. Not all servers are expected to
@@ -39,12 +37,6 @@ module USCoreTestKit
         * The server claims support for JSON encoding of resources
         * The server claims support for the Patient resource and one other
           resource
-
-        It collects the following information that is saved in the testing session
-        for use by later tests:
-
-        * List of resources supported
-        * List of queries parameters supported
       )
       run_as_group
 

--- a/lib/us_core_test_kit/custom_groups/v7.0.0/capability_statement_group.rb
+++ b/lib/us_core_test_kit/custom_groups/v7.0.0/capability_statement_group.rb
@@ -18,9 +18,7 @@ module USCoreTestKit
         features supported by the API by using the [Capability
         Statement](https://www.hl7.org/fhir/capabilitystatement.html) resource.
         The features described in the Capability Statement must be consistent with
-        the required capabilities of a US Core server. The Capability Statement
-        must also advertise the location of the required SMART on FHIR endpoints
-        that enable authenticated access to the FHIR server resources.
+        the required capabilities of a US Core server.
 
         The Capability Statement resource allows clients to determine which
         resources are supported by a FHIR Server. Not all servers are expected to
@@ -40,12 +38,6 @@ module USCoreTestKit
         * The server claims support for JSON encoding of resources
         * The server claims support for the Patient resource and one other
           resource
-
-        It collects the following information that is saved in the testing session
-        for use by later tests:
-
-        * List of resources supported
-        * List of queries parameters supported
       )
       run_as_group
 


### PR DESCRIPTION
# Summary

- The Capability Statement group description referenced SMART on FHIR requirements and detailed saved information that wasn't actually saved by the tests.
- In the 3.1.1 version, the word "Resource" was misspelled in the test title "Capability Statement lists support for required US Core Resoruce Types".

# Testing Guidance

- Run the 3.1.1 tests and verify that the spelling has been corrected in the title of test 2.1.05
- Run all versions of the tests and verify that the Capability Statement group description does not reference SMART on FHIR or saving any information