### PR TITLE
FI-3817: MedicationRequest Multiple_Or Search Fix

### DIFF
--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -139,7 +139,9 @@ module USCoreTestKit
 
       check_search_response
 
-      post_search_resources = fetch_and_assert_all_bundled_resources.select { |resource| resource.resourceType == resource_type }
+      post_search_resources = fetch_and_assert_all_bundled_resources.select do |resource|
+        resource.resourceType == resource_type
+      end
 
       filter_conditions(post_search_resources) if resource_type == 'Condition' && metadata.version == 'v5.0.1'
       filter_devices(post_search_resources) if resource_type == 'Device'
@@ -150,7 +152,7 @@ module USCoreTestKit
       search_variant_test_records[:post_variant] = true
 
       assert get_resource_count == post_resource_count,
-             "Expected search by POST to return the same results as search by GET, " \
+             'Expected search by POST to return the same results as search by GET, ' \
              "but GET search returned #{get_resource_count} resources, and POST search " \
              "returned #{post_resource_count} resources."
     end
@@ -293,18 +295,18 @@ module USCoreTestKit
         fetch_and_assert_all_bundled_resources(params: search_params)
           .select { |resource| resource.resourceType == resource_type }
 
-      assert resources_returned.present?, "No resources were returned when searching by `system|code`"
+      assert resources_returned.present?, 'No resources were returned when searching by `system|code`'
 
       search_variant_test_records[:token_variants] = true
     end
 
     def perform_search_with_status(
-          original_params,
-          patient_id,
-          status_search_values: self.status_search_values,
-          resource_type: self.resource_type
-        )
-      assert resource.is_a?(FHIR::OperationOutcome), "Server returned a status of 400 without an OperationOutcome"
+      original_params,
+      patient_id,
+      status_search_values: self.status_search_values,
+      resource_type: self.resource_type
+    )
+      assert resource.is_a?(FHIR::OperationOutcome), 'Server returned a status of 400 without an OperationOutcome'
       # TODO: warn about documenting status requirements
       status_search_values.flat_map do |status_value|
         search_params = original_params.merge("#{status_search_param_name}": status_value)
@@ -336,6 +338,11 @@ module USCoreTestKit
       definition[:multiple_or] == 'SHALL' ? [definition[:values].join(',')] : Array.wrap(definition[:values])
     end
 
+    def contains_all_search_params(resource, search_params)
+      search_params.keys.all? do |param_name|
+        resource.instance_variable_get("@#{param_name}").present? || param_name == 'patient'
+      end
+    end
 
     def perform_multiple_or_search_test
       resolved_one = false
@@ -350,7 +357,12 @@ module USCoreTestKit
         multiple_or_search_params.each do |param_name|
           search_value = default_search_values(param_name.to_sym)
           search_params = search_params.merge("#{param_name}" => search_value)
-          existing_values[param_name.to_sym] = scratch_resources_for_patient(patient_id).map(&param_name.to_sym).compact.uniq
+
+          existing_values[param_name.to_sym] =
+            scratch_resources_for_patient(patient_id)
+              .filter { |resource| contains_all_search_params(resource, search_params) }
+              .map(&param_name.to_sym)
+              .compact.uniq
         end
 
         # skip patient without multiple-or values
@@ -365,7 +377,8 @@ module USCoreTestKit
             .select { |resource| resource.resourceType == resource_type }
 
         multiple_or_search_params.each do |param_name|
-          missing_values[param_name.to_sym] = existing_values[param_name.to_sym] - resources_returned.map(&param_name.to_sym)
+          missing_values[param_name.to_sym] =
+            existing_values[param_name.to_sym] - resources_returned.map(&param_name.to_sym)
         end
 
         missing_value_message = missing_values
@@ -373,7 +386,8 @@ module USCoreTestKit
           .map { |param_name, missing_value| "#{missing_value.join(',')} values from #{param_name}" }
           .join(' and ')
 
-        assert missing_value_message.blank?, "Could not find #{missing_value_message} in any of the resources returned for Patient/#{patient_id}"
+        assert missing_value_message.blank?,
+               "Could not find #{missing_value_message} in any of the resources returned for Patient/#{patient_id}"
 
         break if resolved_one
       end
@@ -428,7 +442,8 @@ module USCoreTestKit
       end
 
       not_matched_included_medications_string = not_matched_included_medications.join(',')
-      assert not_matched_included_medications.empty?, "No #{resource_type} references #{not_matched_included_medications_string} in the search result."
+      assert not_matched_included_medications.empty?,
+             "No #{resource_type} references #{not_matched_included_medications_string} in the search result."
 
       medications.uniq!(&:id)
 
@@ -438,8 +453,8 @@ module USCoreTestKit
       search_variant_test_records[:medication_inclusion] = true
     end
 
-    def is_reference_match? (reference, local_reference)
-      regex_pattern = /^(#{Regexp.escape(local_reference)}|\S+\/#{Regexp.escape(local_reference)}(?:[\/|]\S+)*)$/
+    def is_reference_match?(reference, local_reference)
+      regex_pattern = %r{^(#{Regexp.escape(local_reference)}|\S+/#{Regexp.escape(local_reference)}(?:[/|]\S+)*)$}
       reference.match?(regex_pattern)
     end
 
@@ -468,7 +483,7 @@ module USCoreTestKit
 
     def fixed_value_search_params(value, patient_id)
       search_param_names.each_with_object({}) do |name, params|
-        patient_id_param?(name) ? params[name] = patient_id : params[name] = value
+        params[name] = patient_id_param?(name) ? patient_id : value
       end
     end
 
@@ -482,9 +497,14 @@ module USCoreTestKit
         end
       end
 
-      params_with_partial_value = resources.each_with_object({}) do |resource, outer_params|
+      resources.each_with_object({}) do |resource, outer_params|
         results_from_one_resource = search_param_names.each_with_object({}) do |name, params|
-          value = patient_id_param?(name) ? patient_id : search_param_value(name, resource, include_system: include_system)
+          value = if patient_id_param?(name)
+                    patient_id
+                  else
+                    search_param_value(name, resource,
+                                       include_system: include_system)
+                  end
           params[name] = value
         end
 
@@ -493,8 +513,6 @@ module USCoreTestKit
         # stop if all parameter values are found
         return outer_params if outer_params.all? { |_key, value| value.present? }
       end
-
-      params_with_partial_value
     end
 
     def patient_id_list
@@ -513,9 +531,7 @@ module USCoreTestKit
 
     def search_param_paths(name)
       paths = metadata.search_definitions[name.to_sym][:paths]
-      if paths.first =='class'
-        paths[0] = 'local_class'
-      end
+      paths[0] = 'local_class' if paths.first == 'class'
 
       paths
     end
@@ -539,39 +555,40 @@ module USCoreTestKit
     def no_resources_skip_message(resource_type = self.resource_type)
       msg = "No #{resource_type} resources appear to be available"
 
-      if (resource_type == 'Device' && implantable_device_codes.present?)
+      if resource_type == 'Device' && implantable_device_codes.present?
         msg.concat(" with the following Device Type Code filter: #{implantable_device_codes}")
       end
 
-      msg + ". Please use patients with more information"
+      msg + '. Please use patients with more information'
     end
 
     def fetch_and_assert_all_bundled_resources(
-          resource_type: self.resource_type,
-          reply_handler: nil,
-          max_pages: 20,
-          additional_resource_types: [],
-          params: nil
-        )
-        tags = tags(params)
-        bundle = resource
-        additional_resource_types << 'Medication' if ['MedicationRequest', 'MedicationDispense'].include?(resource_type)
+      resource_type: self.resource_type,
+      reply_handler: nil,
+      max_pages: 20,
+      additional_resource_types: [],
+      params: nil
+    )
+      tags = tags(params)
+      bundle = resource
+      additional_resource_types << 'Medication' if ['MedicationRequest', 'MedicationDispense'].include?(resource_type)
 
-        assert_handler = Proc.new do |response|
-          assert_response_status(200, response: response)
-          assert_valid_json(response[:body], "Could not resolve bundle as JSON: #{response[:body]}")
-        end
+      assert_handler = proc do |response|
+        assert_response_status(200, response: response)
+        assert_valid_json(response[:body], "Could not resolve bundle as JSON: #{response[:body]}")
+      end
 
-        if reply_handler
-          reply_and_assert_handler = Proc.new do |response|
-            assert_handler.call(response)
-            reply_handler.call(response)
-          end
-        else
-          reply_and_assert_handler = assert_handler
-        end
+      reply_and_assert_handler = if reply_handler
+                                   proc do |response|
+                                     assert_handler.call(response)
+                                     reply_handler.call(response)
+                                   end
+                                 else
+                                   assert_handler
+                                 end
 
-        fetch_all_bundled_resources(resource_type:, bundle:, reply_handler: reply_and_assert_handler, max_pages:, additional_resource_types:, tags:)
+      fetch_all_bundled_resources(resource_type:, bundle:, reply_handler: reply_and_assert_handler, max_pages:,
+                                  additional_resource_types:, tags:)
     end
 
     def search_param_value(name, resource, include_system: false)
@@ -619,8 +636,8 @@ module USCoreTestKit
               #   Goal.target-date has day precision
               #   All others have second + time offset precision
               if /^\d{4}(-\d{2})?$/.match?(element) || # YYYY or YYYY-MM
-                (/^\d{4}-\d{2}-\d{2}$/.match?(element) && resource_type != "Goal") # YYY-MM-DD AND Resource is NOT Goal
-                "gt#{(DateTime.xmlschema(element)-1).xmlschema}"
+                 (/^\d{4}-\d{2}-\d{2}$/.match?(element) && resource_type != 'Goal') # YYY-MM-DD AND Resource is NOT Goal
+                "gt#{(DateTime.xmlschema(element) - 1).xmlschema}"
               else
                 element
               end
@@ -632,8 +649,7 @@ module USCoreTestKit
         break if search_value.present?
       end
 
-      escaped_value = search_value&.gsub(',', '\\,')
-      escaped_value
+      search_value&.gsub(',', '\\,')
     end
 
     def element_has_valid_value?(element, include_system)
@@ -669,12 +685,14 @@ module USCoreTestKit
       scratch[:references][resource_type] << reference
     end
 
-    def save_delayed_references(resources, containing_resource_type = self.resource_type)
+    def save_delayed_references(resources, containing_resource_type = resource_type)
       resources.each do |resource|
         references_to_save(containing_resource_type).each do |reference_to_save|
           resolve_path(resource, reference_to_save[:path])
-            .select { |reference| reference.is_a?(FHIR::Reference) &&
-              !reference.contained? && reference.reference.present? }
+            .select do |reference|
+            reference.is_a?(FHIR::Reference) &&
+              !reference.contained? && reference.reference.present?
+          end
             .each do |reference|
               resource_type = reference.resource_class.name.demodulize
               need_to_save = reference_to_save[:resources].include?(resource_type)
@@ -779,7 +797,7 @@ module USCoreTestKit
               values_found.any? { |identifier| identifier.value == search_value }
             end
           when 'string'
-            searched_values = search_value.downcase.split(/(?<!\\\\),/).map{ |string| string.gsub('\\,', ',') }
+            searched_values = search_value.downcase.split(/(?<!\\\\),/).map { |string| string.gsub('\\,', ',') }
             values_found.any? do |value_found|
               searched_values.any? { |searched_value| value_found.downcase.starts_with? searched_value }
             end

--- a/spec/us_core/search_test_spec.rb
+++ b/spec/us_core/search_test_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe USCoreTestKit::SearchTest do
                 code: 'vital-signs'
               }
             ]
-          }],
+          }
+        ],
         code: [
           {
             coding: [
@@ -79,25 +80,26 @@ RSpec.describe USCoreTestKit::SearchTest do
                 code: '8302-2'
               }
             ]
-          }],
+          }
+        ],
         subject: {
           reference: "Patient/#{patient_id}"
-        },
+        }
       )
     end
     let(:bundle) do
-      FHIR::Bundle.new(entry: [{resource: observation}])
+      FHIR::Bundle.new(entry: [{ resource: observation }])
     end
 
     before do
       Inferno::Repositories::Tests.new.insert(status_search_test)
       allow_any_instance_of(status_search_test)
         .to receive(:scratch_resources).and_return(
-              {
-                all: [observation],
-                patient_id => [observation]
-              }
-            )
+          {
+            all: [observation],
+            patient_id => [observation]
+          }
+        )
     end
 
     it 'passes if a 200 is received' do
@@ -152,17 +154,17 @@ RSpec.describe USCoreTestKit::SearchTest do
       )
     end
     let(:bundle) do
-      FHIR::Bundle.new(entry: [{resource: encounter}])
+      FHIR::Bundle.new(entry: [{ resource: encounter }])
     end
 
     before do
       allow_any_instance_of(test_class)
         .to receive(:scratch_resources).and_return(
-              {
-                all: [encounter],
-                patient_id => [encounter]
-              }
-            )
+          {
+            all: [encounter],
+            patient_id => [encounter]
+          }
+        )
     end
 
     it 'succeeds if a 400 is received with an OperationOutcome and the status search succeeds' do
@@ -223,7 +225,7 @@ RSpec.describe USCoreTestKit::SearchTest do
               resource_type: 'MedicationRequest',
               search_param_names: ['patient'],
               possible_status_search: true,
-              test_medication_inclusion: true,
+              test_medication_inclusion: true
             )
           end
 
@@ -254,7 +256,7 @@ RSpec.describe USCoreTestKit::SearchTest do
         end
       end
       let(:bundle) do
-        FHIR::Bundle.new(entry: [{resource: medication_request}])
+        FHIR::Bundle.new(entry: [{ resource: medication_request }])
       end
       let(:test_scratch) { {} }
 
@@ -321,7 +323,7 @@ RSpec.describe USCoreTestKit::SearchTest do
         stub_request(:get, "#{url}/Device?patient=Patient/#{patient_id}")
           .to_return(status: 200, body: bundle.to_json)
         stub_request(:post, "#{url}/Device/_search")
-          .with(body: {"patient"=>patient_id})
+          .with(body: { 'patient' => patient_id })
           .to_return(status: 200, body: bundle.to_json)
       end
 
@@ -354,7 +356,7 @@ RSpec.describe USCoreTestKit::SearchTest do
         def properties
           @properties ||= USCoreTestKit::SearchTestProperties.new(
             resource_type: 'MedicationRequest',
-            search_param_names: ['patient', 'intent'],
+            search_param_names: ['patient', 'intent', 'encounter'],
             multiple_or_search_params: ['intent']
           )
         end
@@ -386,6 +388,7 @@ RSpec.describe USCoreTestKit::SearchTest do
       end
     end
     let(:patient_id) { '123' }
+    let(:encounter_id) { '456' }
     let(:intent_1) { 'order' }
     let(:intent_2) { 'plan' }
     let(:medication_request_1) do
@@ -394,6 +397,9 @@ RSpec.describe USCoreTestKit::SearchTest do
         intent: intent_1,
         subject: {
           reference: "Patient/#{patient_id}"
+        },
+        encounter: {
+          reference: "Encounter/#{encounter_id}"
         }
       )
     end
@@ -403,41 +409,62 @@ RSpec.describe USCoreTestKit::SearchTest do
         intent: intent_2,
         subject: {
           reference: "Patient/#{patient_id}"
+        },
+        encounter: {
+          reference: "Encounter/#{encounter_id}"
         }
       )
     end
     let(:bundle_1) do
-      FHIR::Bundle.new(entry: [{resource: medication_request_1}])
+      FHIR::Bundle.new(entry: [{ resource: medication_request_1 }])
     end
     let(:bundle_2) do
-      FHIR::Bundle.new(entry: [{resource: medication_request_2}])
+      FHIR::Bundle.new(entry: [{ resource: medication_request_2 }])
+    end
+
+    let(:bundle_3) do
+      FHIR::Bundle.new(entry: [{ resource: medication_request_1 }, { resource: medication_request_2 }])
     end
 
     before do
       Inferno::Repositories::Tests.new.insert(multiple_or_search_test)
       allow_any_instance_of(multiple_or_search_test)
         .to receive(:scratch_resources).and_return(
-              {
-                all: [medication_request_1, medication_request_2],
-                patient_id => [medication_request_1, medication_request_2]
-              }
-            )
+          {
+            all: [medication_request_1, medication_request_2],
+            patient_id => [medication_request_1, medication_request_2]
+          }
+        )
     end
 
     it 'fails if multiple-or search test does not return all existing values' do
-      stub_request(:get, "#{url}/MedicationRequest?patient=#{patient_id}&intent=#{intent_1}")
+      stub_request(:get, "#{url}/MedicationRequest?encounter=Encounter/#{encounter_id}&intent=#{intent_1}&patient=#{patient_id}")
         .to_return(status: 200, body: bundle_1.to_json)
-      stub_request(:get, "#{url}/MedicationRequest?patient=#{patient_id}&intent=proposal,plan,order,original-order,reflex-order,filler-order,instance-order,option")
+      stub_request(:get, "#{url}/MedicationRequest?encounter=Encounter/#{encounter_id}&intent=proposal,plan,order,original-order,reflex-order,filler-order,instance-order,option&patient=#{patient_id}")
         .to_return(status: 200, body: bundle_2.to_json)
       result = run(multiple_or_search_test, patient_ids: patient_id, url: url)
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to eq("Could not find order values from intent in any of the resources returned for Patient/#{patient_id}")
     end
+
+    it 'passes if multiple-or search test does not return all existing values if associated resources do not contain all search params' do
+      medication_request_2.encounter = nil
+      bundle_2.entry[0].resource.encounter = nil
+
+      stub_request(:get, "#{url}/MedicationRequest?encounter=Encounter/#{encounter_id}&intent=#{intent_1}&patient=#{patient_id}")
+        .to_return(status: 200, body: bundle_1.to_json)
+      stub_request(:get, "#{url}/MedicationRequest?encounter=Encounter/#{encounter_id}&intent=proposal,plan,order,original-order,reflex-order,filler-order,instance-order,option&patient=#{patient_id}")
+        .to_return(status: 200, body: bundle_3.to_json)
+      result = run(multiple_or_search_test, patient_ids: patient_id, url: url)
+
+      expect(result.result).to eq('pass')
+    end
   end
 
   describe 'search date/dateTime precision' do
     let(:patient_id) { '123' }
+
     context 'with date precision' do
       let(:test_class) do
         Class.new(USCoreTestKit::USCoreV400::GoalPatientTargetDateSearchTest) do
@@ -468,20 +495,20 @@ RSpec.describe USCoreTestKit::SearchTest do
         )
       end
       let(:goal_datetime) do
-          FHIR::Goal.new(
-            id: 'datetime',
-            subject: {
-              reference: "Patient/#{patient_id}"
-            },
-            target: [
-              { dueDate: '2020-03-04T13:01:01-04:00' }
-            ]
-          )
+        FHIR::Goal.new(
+          id: 'datetime',
+          subject: {
+            reference: "Patient/#{patient_id}"
+          },
+          target: [
+            { dueDate: '2020-03-04T13:01:01-04:00' }
+          ]
+        )
       end
 
-      let(:bundle_year) { FHIR::Bundle.new(entry: [ {resource: goal_year} ]) }
-      let(:bundle_date) { FHIR::Bundle.new(entry: [ {resource: goal_date} ]) }
-      let(:bundle_datetime) { FHIR::Bundle.new(entry: [ {resource: goal_datetime} ]) }
+      let(:bundle_year) { FHIR::Bundle.new(entry: [{ resource: goal_year }]) }
+      let(:bundle_date) { FHIR::Bundle.new(entry: [{ resource: goal_date }]) }
+      let(:bundle_datetime) { FHIR::Bundle.new(entry: [{ resource: goal_datetime }]) }
 
       it 'uses comparator search if value is year' do
         allow_any_instance_of(test_class)
@@ -505,7 +532,7 @@ RSpec.describe USCoreTestKit::SearchTest do
           .to_return(status: 200, body: bundle_year.to_json)
 
         result = run(test_class, patient_ids: patient_id, url: url)
-        expect(request).not_to have_been_made
+        expect(request).to_not have_been_made
         expect(result.result).to eq('pass')
       end
 
@@ -588,18 +615,18 @@ RSpec.describe USCoreTestKit::SearchTest do
         )
       end
       let(:immunization_datetime) do
-          FHIR::Immunization.new(
-            id: 'datetime',
-            patient: {
-              reference: "Patient/#{patient_id}"
-            },
-            occurrenceDateTime: '2020-03-04T13:01:01-04:00'
-          )
+        FHIR::Immunization.new(
+          id: 'datetime',
+          patient: {
+            reference: "Patient/#{patient_id}"
+          },
+          occurrenceDateTime: '2020-03-04T13:01:01-04:00'
+        )
       end
 
-      let(:bundle_year) { FHIR::Bundle.new(entry: [ {resource: immunization_year} ]) }
-      let(:bundle_date) { FHIR::Bundle.new(entry: [ {resource: immunization_date} ]) }
-      let(:bundle_datetime) { FHIR::Bundle.new(entry: [ {resource: immunization_datetime} ]) }
+      let(:bundle_year) { FHIR::Bundle.new(entry: [{ resource: immunization_year }]) }
+      let(:bundle_date) { FHIR::Bundle.new(entry: [{ resource: immunization_date }]) }
+      let(:bundle_datetime) { FHIR::Bundle.new(entry: [{ resource: immunization_datetime }]) }
 
       it 'uses comparator search if value is year' do
         allow_any_instance_of(test_class)
@@ -623,7 +650,7 @@ RSpec.describe USCoreTestKit::SearchTest do
           .to_return(status: 200, body: bundle_year.to_json)
 
         result = run(test_class, patient_ids: patient_id, url: url)
-        expect(request).not_to have_been_made
+        expect(request).to_not have_been_made
         expect(result.result).to eq('pass')
       end
 
@@ -649,7 +676,7 @@ RSpec.describe USCoreTestKit::SearchTest do
           .to_return(status: 200, body: bundle_date.to_json)
 
         result = run(test_class, patient_ids: patient_id, url: url)
-        expect(request).not_to have_been_made.once
+        expect(request).to_not have_been_made.once
         expect(result.result).to eq('pass')
       end
 
@@ -684,11 +711,11 @@ RSpec.describe USCoreTestKit::SearchTest do
   describe '#all_search_params' do
     let(:test_class) { USCoreTestKit::USCoreV311::DocumentReferencePatientCategoryDateSearchTest }
     let(:test) { test_class.new }
-    let(:patient_id) {'123'}
-    let(:patient_no_resource) {'no-resource'}
-    let(:category_code) {'clinical-note'}
-    let(:date) {'2020-05-14T11:02:00+05:00'}
-    let(:resource_with_category_date) {
+    let(:patient_id) { '123' }
+    let(:patient_no_resource) { 'no-resource' }
+    let(:category_code) { 'clinical-note' }
+    let(:date) { '2020-05-14T11:02:00+05:00' }
+    let(:resource_with_category_date) do
       FHIR::DocumentReference.new(
         subject: {
           reference: "Patient/#{patient_id}"
@@ -704,7 +731,7 @@ RSpec.describe USCoreTestKit::SearchTest do
         ],
         date: date
       )
-    }
+    end
 
     before do
       allow_any_instance_of(test_class)
@@ -721,20 +748,20 @@ RSpec.describe USCoreTestKit::SearchTest do
     it 'handles patient with or without resources' do
       params = test.all_search_params
 
-      expect(params).not_to be_empty
+      expect(params).to_not be_empty
       expect(params[patient_no_resource]).to be_empty
-      expect(params[patient_id]).not_to be_empty
+      expect(params[patient_id]).to_not be_empty
     end
   end
 
   describe '#search_params_with_values' do
     let(:test_class) { USCoreTestKit::USCoreV311::DocumentReferencePatientCategoryDateSearchTest }
     let(:test) { test_class.new }
-    let(:patient_id) {'123'}
-    let(:patient_no_resource) {'456'}
-    let(:category_code) {'something-else'}
-    let(:date) {'2020-05-14T11:02:00+05:00'}
-    let(:resource_with_category) {
+    let(:patient_id) { '123' }
+    let(:patient_no_resource) { '456' }
+    let(:category_code) { 'something-else' }
+    let(:date) { '2020-05-14T11:02:00+05:00' }
+    let(:resource_with_category) do
       FHIR::DocumentReference.new(
         subject: {
           reference: "Patient/#{patient_id}"
@@ -749,8 +776,8 @@ RSpec.describe USCoreTestKit::SearchTest do
           }
         ]
       )
-    }
-    let(:resource_with_category_date) {
+    end
+    let(:resource_with_category_date) do
       FHIR::DocumentReference.new(
         subject: {
           reference: "Patient/#{patient_id}"
@@ -766,18 +793,18 @@ RSpec.describe USCoreTestKit::SearchTest do
         ],
         date: date
       )
-    }
+    end
 
     it 'returns search values from the same resource' do
       allow_any_instance_of(test_class)
         .to receive(:scratch_resources_for_patient).and_return([
-          resource_with_category,
-          resource_with_category_date
-        ])
+                                                                 resource_with_category,
+                                                                 resource_with_category_date
+                                                               ])
 
       params = test.search_params_with_values(test.search_param_names, patient_id)
 
-      expect(params).not_to be_empty
+      expect(params).to_not be_empty
       expect(params['patient']).to eq(patient_id)
       expect(params['category']).to eq(category_code)
       expect(params['date']).to eq(date)
@@ -791,7 +818,7 @@ RSpec.describe USCoreTestKit::SearchTest do
 
       params = test.search_params_with_values(test.search_param_names, patient_id)
 
-      expect(params).not_to be_empty
+      expect(params).to_not be_empty
       expect(params['patient']).to eq(patient_id)
       expect(params['category']).to be_nil
       expect(params['date']).to be_nil
@@ -887,8 +914,8 @@ RSpec.describe USCoreTestKit::SearchTest do
     context 'Array element having DAR extension' do
       let(:test_class) { USCoreTestKit::USCoreV311::PatientNameSearchTest }
       let(:test) { test_class.new }
-      let(:search_value) {'family_name'}
-      let(:patient) {
+      let(:search_value) { 'family_name' }
+      let(:patient) do
         FHIR::Patient.new(
           name: [
             {
@@ -907,7 +934,7 @@ RSpec.describe USCoreTestKit::SearchTest do
             }
           ]
         )
-      }
+      end
 
       it 'returns search value from the first none-DAR name of name array' do
         element = test.search_param_value('name', Array.wrap(patient))
@@ -972,7 +999,7 @@ RSpec.describe USCoreTestKit::SearchTest do
     end
     let(:test) { test_class.new }
     let(:patient_id) { '85' }
-    let(:immunization) {
+    let(:immunization) do
       FHIR::Immunization.new(
         id: 'datetime',
         patient: {
@@ -980,15 +1007,15 @@ RSpec.describe USCoreTestKit::SearchTest do
         },
         occurrenceDateTime: '2020-03-04T13:01:01-04:00'
       )
-    }
-    let(:bundle) {
+    end
+    let(:bundle) do
       FHIR::Bundle.new(
         entry: [
           { resource: immunization },
           { resource: FHIR::OperationOutcome.new }
         ]
       )
-    }
+    end
 
     it 'passes with additional OperationOutcome entry' do
       allow_any_instance_of(test_class)
@@ -1020,7 +1047,7 @@ RSpec.describe USCoreTestKit::SearchTest do
     end
     let(:test) { test_class.new }
     let(:patient_id) { '85' }
-    let(:diagnostic_report) {
+    let(:diagnostic_report) do
       FHIR::DiagnosticReport.new(
         id: '1',
         subject: {
@@ -1028,25 +1055,25 @@ RSpec.describe USCoreTestKit::SearchTest do
         },
         category: [
           {
-            "coding":
+            coding:
             [
               {
-                "system": "urn:oid:1.2.840.114350.1.13.1545.1.7.10.798268.30",
-                "code": "Path,Cyt"
+                system: 'urn:oid:1.2.840.114350.1.13.1545.1.7.10.798268.30',
+                code: 'Path,Cyt'
               }
             ]
           }
         ],
-        effectiveDateTime: '2021-11-24T15:55:00Z',
+        effectiveDateTime: '2021-11-24T15:55:00Z'
       )
-    }
-    let(:bundle) {
+    end
+    let(:bundle) do
       FHIR::Bundle.new(
         entry: [
           { resource: diagnostic_report }
         ]
       )
-    }
+    end
 
     it 'passes with comma in search value' do
       allow_any_instance_of(test_class)
@@ -1080,7 +1107,7 @@ RSpec.describe USCoreTestKit::SearchTest do
     end
     let(:test) { test_class.new }
     let(:patient_id) { '85' }
-    let(:condition) {
+    let(:condition) do
       FHIR::Condition.new(
         id: '1',
         extension: [
@@ -1103,21 +1130,21 @@ RSpec.describe USCoreTestKit::SearchTest do
           }
         ]
       )
-    }
-    let(:bundle) {
+    end
+    let(:bundle) do
       FHIR::Bundle.new(
         entry: [
           { resource: condition }
         ]
       )
-    }
+    end
 
     it 'allows searching in extension' do
       allow_any_instance_of(test_class)
         .to receive(:scratch_resources_for_patient)
         .and_return([condition])
 
-        stub_request(:get, "#{url}/Condition?patient=#{patient_id}&asserted-date=2021-11-24T15:55:00Z")
+      stub_request(:get, "#{url}/Condition?patient=#{patient_id}&asserted-date=2021-11-24T15:55:00Z")
         .to_return(status: 200, body: bundle.to_json)
       stub_request(:get, "#{url}/Condition?patient=#{patient_id}&asserted-date=gt2021-11-23T15:55:00%2B00:00")
         .to_return(status: 200, body: bundle.to_json)
@@ -1144,7 +1171,7 @@ RSpec.describe USCoreTestKit::SearchTest do
     let(:patient_id) { '85' }
     let(:test_scratch) { {} }
     let(:intent) { 'order' }
-    let(:medication_request_1) {
+    let(:medication_request_1) do
       FHIR::MedicationRequest.new(
         id: 'medication-request-local-reference',
         subject: {
@@ -1155,8 +1182,8 @@ RSpec.describe USCoreTestKit::SearchTest do
           reference: 'Medication/medication-1'
         }
       )
-    }
-    let(:medication_request_2) {
+    end
+    let(:medication_request_2) do
       FHIR::MedicationRequest.new(
         id: 'medication-request-url',
         subject: {
@@ -1167,36 +1194,36 @@ RSpec.describe USCoreTestKit::SearchTest do
           reference: 'http://example.com/Medication/medication-2'
         }
       )
-    }
-    let(:medication_requests) {
+    end
+    let(:medication_requests) do
       [
         medication_request_1,
         medication_request_2
       ]
-    }
-    let(:medication_1) {
+    end
+    let(:medication_1) do
       FHIR::Medication.new(
         id: 'medication-1'
       )
-    }
-    let(:medication_2) {
+    end
+    let(:medication_2) do
       FHIR::Medication.new(
         id: 'medication-2'
       )
-    }
-    let(:medication_3) {
+    end
+    let(:medication_3) do
       FHIR::Medication.new(
         id: 'medication-3'
       )
-    }
-    let(:bundle) {
+    end
+    let(:bundle) do
       FHIR::Bundle.new(
         entry: [
           { resource: medication_request_1 },
           { resource: medication_request_2 }
         ]
       )
-    }
+    end
 
     before do
       allow_any_instance_of(test_class)
@@ -1219,7 +1246,7 @@ RSpec.describe USCoreTestKit::SearchTest do
       stub_request(:get, "#{url}/MedicationRequest?patient=#{patient_id}&intent=order")
         .to_return(status: 200, body: bundle.to_json)
       stub_request(:post, "#{url}/MedicationRequest/_search")
-        .with(body: {patient: patient_id, intent: 'order'})
+        .with(body: { patient: patient_id, intent: 'order' })
         .to_return(status: 200, body: bundle.to_json)
       stub_request(:get, "#{url}/MedicationRequest?patient=Patient/#{patient_id}&intent=order")
         .to_return(status: 200, body: bundle.to_json)
@@ -1228,7 +1255,7 @@ RSpec.describe USCoreTestKit::SearchTest do
     end
 
     it 'passes when references and included Medications are exact match' do
-      bundle.entry.concat([ {resource: medication_1 }, {resource: medication_2}])
+      bundle.entry.concat([{ resource: medication_1 }, { resource: medication_2 }])
       stub_request(:get, "#{url}/MedicationRequest?_include=MedicationRequest:medication&intent=#{intent}&patient=#{patient_id}")
         .to_return(status: 200, body: bundle.to_json)
 
@@ -1237,7 +1264,7 @@ RSpec.describe USCoreTestKit::SearchTest do
     end
 
     it 'passes when there are more references than included Medications' do
-      bundle.entry.concat([ {resource: medication_1 }])
+      bundle.entry.concat([{ resource: medication_1 }])
       stub_request(:get, "#{url}/MedicationRequest?_include=MedicationRequest:medication&intent=#{intent}&patient=#{patient_id}")
         .to_return(status: 200, body: bundle.to_json)
 
@@ -1246,7 +1273,7 @@ RSpec.describe USCoreTestKit::SearchTest do
     end
 
     it 'fails when there are less references than included Medications' do
-      bundle.entry.concat([ {resource: medication_1}, {resource: medication_2}, {resource: medication_3 }])
+      bundle.entry.concat([{ resource: medication_1 }, { resource: medication_2 }, { resource: medication_3 }])
       stub_request(:get, "#{url}/MedicationRequest?_include=MedicationRequest:medication&intent=#{intent}&patient=#{patient_id}")
         .to_return(status: 200, body: bundle.to_json)
 
@@ -1259,7 +1286,7 @@ RSpec.describe USCoreTestKit::SearchTest do
   describe '#is_reference_match' do
     let(:test_class) { USCoreTestKit::USCoreV311::MedicationRequestPatientIntentSearchTest }
     let(:test) { test_class.new }
-    let(:pattern_reference) {'Medication/1'}
+    let(:pattern_reference) { 'Medication/1' }
 
     it 'handles local reference' do
       result = test.is_reference_match?('Medication/1', pattern_reference)
@@ -1297,7 +1324,6 @@ RSpec.describe USCoreTestKit::SearchTest do
     let(:test) { test_class.new }
     let(:patient_gender) { 'male' }
     let(:patient_id) { '85' }
-
 
     it 'matches the primitive value' do
       patient = FHIR::Patient.new(
@@ -1368,7 +1394,7 @@ RSpec.describe USCoreTestKit::SearchTest do
             ]
           }
         ],
-        performer:[
+        performer: [
           {
             reference: 'Organization/1'
           },
@@ -1389,11 +1415,10 @@ RSpec.describe USCoreTestKit::SearchTest do
       test.save_delayed_references([diagnostic_report])
 
       result = test_scratch[:references]
-      expect(result).not_to be_empty
-      expect(result['Organization']).not_to be_empty
+      expect(result).to_not be_empty
+      expect(result['Organization']).to_not be_empty
       expect(result['Organization'].count).to be(1)
       expect(result['Organization'].first.reference).to eq('Organization/1')
     end
   end
-
 end


### PR DESCRIPTION
# Summary

The MedicationRequest resource has two optional search requirements on `patient+intent+encounter` and `patient+intent+authoredon`. Previously, when testing it with reference server with patient 355 only, both test failed with errors:

```
Could not find plan values from intent in any of the resources returned for Patient/355
or
Could not find order values from intent in any of the resources returned for Patient/355
```

These searches are not the first search, so the tests use the result from first search to compile search values. From the first search, there is one MedicationRequest with `intent=order` and `encounter=Encounter/1`, and also a MedicationRequest with `intent=plan` and no encounter reference. The multiple_or search test therefore expected that patient 355 had MedicationRequests with `intent=order, plan` and `encounter=Encounter/1`, but it was not able to recognize that the only MedicationRequest with `intent=order` did not have an encounter reference. 

Added a fix for this problem by adding a filter to the list of existing values that the multiple_or search test compiles. This filter makes it so that a multiple_or parameter value will not be added to the list of existing values if the value comes from a resource that does not include all of the search parameters that are currently being searched by. So, in this example, it would not add `order` to the list of existing values for the `intent` search param, since the resource that contains`intent` with this value does not contain all of the search parameters for the `patient+intent+encounter` search (missing encounter).

# Testing Guidance
Run the MedicationRequest test with patient 355 and ensure the `patient+intent+encounter` and `patient+intent+authoredon`search tests pass. Also, run the spec tests and ensure those pass.
