### PR TITLE
FI-3292: Add CI job to verify test generation is up to date

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,12 +39,12 @@ jobs:
       - name: Debug Git Status
         run: |
           bundle exec rake us_core:generate
-          git status
+          git status --porcelain lib/us_core_test_kit/generated)
           git diff
       - name: Verify test generation is up to date
         run: |
           bundle exec rake us_core:generate
-          if [[ -n "$(git status --porcelain)" ]]; then
+          if [[ -n "$(git status --porcelain lib/us_core_test_kit/generated)" ]]; then
             echo "Generated tests are outdated. Run 'bundle exec rake us_core:generate' and commit the changes."
             git diff
             exit 1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,6 +21,30 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+  verify-test-generation:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.3.6']
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Ensure full history for git diff
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Verify test generation is up to date
+        run: |
+          bundle exec rake us_core:generate
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Generated tests are outdated. Run 'bundle exec rake us_core:generate' and commit the changes."
+            git diff
+            exit 1
+          fi
+
   test:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,11 +36,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: Debug Git Status
-        run: |
-          bundle exec rake us_core:generate
-          git status --porcelain lib/us_core_test_kit/generated
-          git diff
       - name: Verify test generation is up to date
         run: |
           bundle exec rake us_core:generate

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+      - name: Debug Git Status
+        run: |
+          bundle exec rake us_core:generate
+          git status
+          git diff
       - name: Verify test generation is up to date
         run: |
           bundle exec rake us_core:generate

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Debug Git Status
         run: |
           bundle exec rake us_core:generate
-          git status --porcelain lib/us_core_test_kit/generated)
+          git status --porcelain lib/us_core_test_kit/generated
           git diff
       - name: Verify test generation is up to date
         run: |


### PR DESCRIPTION
This PR adds a `verify-test-generation` job to CI to ensure generated tests are up to date. The job runs `bundle exec rake us_core:generate` and fails if there are uncommitted changes.

