### PR TITLE
FI-4061 Avoid purple error when there is no practitioner references

### DIFF
--- a/lib/us_core_test_kit/practitioner_address_test.rb
+++ b/lib/us_core_test_kit/practitioner_address_test.rb
@@ -25,7 +25,7 @@ module USCoreTestKit
 
     def verify_practitioner_address
       references = scratch.dig(:references, 'Practitioner')
-      assert references.any?, 'No Practitioner references found.'
+      assert references&.any?, 'No Practitioner references found.'
 
       @missing_elements = MUST_SUPPORT_ELEMENTS
       practitioners = []


### PR DESCRIPTION
# Summary

This PR fixes FI-4061 Avoid purple error when there is no practitioner references. 

When there is no references to Practitioner resource, the line
```
references = scratch.dig(:references, 'Practitioner')
```

return `nil` instead of `[]`

This PR use safe navigation to catch `nil` instead of throwing puple error.

# Testing Guidance

