### PR TITLE
Fix client target patient MRN system

### DIFF
--- a/lib/us_core_test_kit/client/generated/v3.1.1/us_core_client_test_suite.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/us_core_client_test_suite.rb
@@ -159,9 +159,9 @@ Once registration is complete, run the "Read & Search" group to have Inferno wai
 read and search requests from the client, return the requested US Core
 resources to the client, and verify the interactions. The Patient that the client
 needs to request data for has the following demographic details:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generated/v3.1.1/wait_group.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/wait_group.rb
@@ -77,9 +77,9 @@ Inferno will now wait for the client under test to make the required requests ag
 
 All requests will be recorded. When finished, the requests will be inspected to ensure that the client under test is making the required requests.
 Requests should target the following patient record:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generated/v4.0.0/us_core_client_test_suite.rb
+++ b/lib/us_core_test_kit/client/generated/v4.0.0/us_core_client_test_suite.rb
@@ -165,9 +165,9 @@ Once registration is complete, run the "Read & Search" group to have Inferno wai
 read and search requests from the client, return the requested US Core
 resources to the client, and verify the interactions. The Patient that the client
 needs to request data for has the following demographic details:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generated/v4.0.0/wait_group.rb
+++ b/lib/us_core_test_kit/client/generated/v4.0.0/wait_group.rb
@@ -77,9 +77,9 @@ Inferno will now wait for the client under test to make the required requests ag
 
 All requests will be recorded. When finished, the requests will be inspected to ensure that the client under test is making the required requests.
 Requests should target the following patient record:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generated/v5.0.1/us_core_client_test_suite.rb
+++ b/lib/us_core_test_kit/client/generated/v5.0.1/us_core_client_test_suite.rb
@@ -195,9 +195,9 @@ Once registration is complete, run the "Read & Search" group to have Inferno wai
 read and search requests from the client, return the requested US Core
 resources to the client, and verify the interactions. The Patient that the client
 needs to request data for has the following demographic details:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generated/v5.0.1/wait_group.rb
+++ b/lib/us_core_test_kit/client/generated/v5.0.1/wait_group.rb
@@ -77,9 +77,9 @@ Inferno will now wait for the client under test to make the required requests ag
 
 All requests will be recorded. When finished, the requests will be inspected to ensure that the client under test is making the required requests.
 Requests should target the following patient record:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generated/v6.1.0/us_core_client_test_suite.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/us_core_client_test_suite.rb
@@ -210,9 +210,9 @@ Once registration is complete, run the "Read & Search" group to have Inferno wai
 read and search requests from the client, return the requested US Core
 resources to the client, and verify the interactions. The Patient that the client
 needs to request data for has the following demographic details:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generated/v6.1.0/wait_group.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/wait_group.rb
@@ -77,9 +77,9 @@ Inferno will now wait for the client under test to make the required requests ag
 
 All requests will be recorded. When finished, the requests will be inspected to ensure that the client under test is making the required requests.
 Requests should target the following patient record:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generated/v7.0.0/us_core_client_test_suite.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/us_core_client_test_suite.rb
@@ -222,9 +222,9 @@ Once registration is complete, run the "Read & Search" group to have Inferno wai
 read and search requests from the client, return the requested US Core
 resources to the client, and verify the interactions. The Patient that the client
 needs to request data for has the following demographic details:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generated/v7.0.0/wait_group.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/wait_group.rb
@@ -77,9 +77,9 @@ Inferno will now wait for the client under test to make the required requests ag
 
 All requests will be recorded. When finished, the requests will be inspected to ensure that the client under test is making the required requests.
 Requests should target the following patient record:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generator/suite_generator.rb
+++ b/lib/us_core_test_kit/client/generator/suite_generator.rb
@@ -91,9 +91,9 @@ module USCoreTestKit
             read and search requests from the client, return the requested US Core
             resources to the client, and verify the interactions. The Patient that the client
             needs to request data for has the following demographic details:
-            - **Resource ID**: us-core-client-tests-patient
+            - **Resource ID**: `us-core-client-tests-patient`
             - **Name**: ClientTests USCore
-            - **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+            - **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
             - **Date of Birth**: 1940-03-29
             - **Gender**: male
 

--- a/lib/us_core_test_kit/client/generator/templates/wait_group.rb.erb
+++ b/lib/us_core_test_kit/client/generator/templates/wait_group.rb.erb
@@ -69,9 +69,9 @@ Inferno will now wait for the client under test to make the required requests ag
 
 All requests will be recorded. When finished, the requests will be inspected to ensure that the client under test is making the required requests.
 Requests should target the following patient record:
-- **Resource ID**: us-core-client-tests-patient
+- **Resource ID**: `us-core-client-tests-patient`
 - **Name**: ClientTests USCore
-- **Member Identifier**: us-core-client-tests-patient (system: Inferno)
+- **Member Identifier**: `us-core-client-tests-patient` (system: `urn:inferno:mrn`)
 - **Date of Birth**: 1940-03-29
 - **Gender**: male
 


### PR DESCRIPTION
# Summary

When the client data was finalized, the test patient's mrn identifier system was [updated](https://github.com/inferno-framework/inferno-reference-server-data/pull/2/commits/47a9a554e7e1edf70b02fccb54a7fc6159895e43#diff-8ec787cf201c51ed40c6c97aa7d3ab3a995096c1b502f13e5a65414b9835d576L92) from `Inferno` to `urn:inferno:mrn`. This updates the documentation to match.

# Testing Guidance

1. Start a session for US Core Client v7.0.0 and verify that in the suite documentation under the "Quick Start" section indicates in the patient demographic list that "urn:inferno:mrn" as the Member Identifier's system.
2. Run the tests using the "Demo: Run against the US Core Server Suite" preset and in the second wait dialog, check that the demographics list has been similarly updated.
3. Make sure that you have an instance of the reference server with the latest from the [inferno-reference-server-data repo](https://github.com/inferno-framework/inferno-reference-server-data). Using postman or something else, make a HTTP request: GET http://localhost:4567/custom/us_core_client_v700/fhir/Patient?identifier=urn:inferno:mrn|us-core-client-tests-patient with Authorization header `Bearer eyJjbGllbnRfaWQiOiJ1c19jb3JlX2NsaWVudF9kZW1vIn0`

