### PR TITLE
Improve Proxied Responses

### DIFF
--- a/lib/us_core_test_kit/client/generated/v3.1.1/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/read_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV311
       class ReadEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,13 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          proxy_client.get("#{resource_type}/#{resource_id}", request_params)
+          build_proxied_read_response
         end
 
         def tags
@@ -78,6 +74,10 @@ module USCoreTestKit
 
         def request_params
           request.params.to_h.except(:resource_id, :resource_type).stringify_keys
+        end
+
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generated/v3.1.1/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/read_endpoint.rb
@@ -64,10 +64,6 @@ module USCoreTestKit
           end
         end
 
-        def resource_id
-          request.params[:resource_id]
-        end
-
         def resource_type
           request.params[:resource_type]
         end

--- a/lib/us_core_test_kit/client/generated/v3.1.1/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/read_endpoint.rb
@@ -68,10 +68,6 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_id, :resource_type).stringify_keys
-        end
-
         def suite_id
           USCoreClientTestSuite.id
         end

--- a/lib/us_core_test_kit/client/generated/v3.1.1/search_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/search_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV311
       class SearchEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,14 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          puts request_params
-          proxy_client.get(resource_type, request_params)
+          build_proxied_search_response
         end
 
         def tags
@@ -73,8 +68,8 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_type).stringify_keys
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generated/v4.0.0/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v4.0.0/read_endpoint.rb
@@ -64,10 +64,6 @@ module USCoreTestKit
           end
         end
 
-        def resource_id
-          request.params[:resource_id]
-        end
-
         def resource_type
           request.params[:resource_type]
         end

--- a/lib/us_core_test_kit/client/generated/v4.0.0/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v4.0.0/read_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV400
       class ReadEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,13 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          proxy_client.get("#{resource_type}/#{resource_id}", request_params)
+          build_proxied_read_response
         end
 
         def tags
@@ -78,6 +74,10 @@ module USCoreTestKit
 
         def request_params
           request.params.to_h.except(:resource_id, :resource_type).stringify_keys
+        end
+
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generated/v4.0.0/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v4.0.0/read_endpoint.rb
@@ -68,10 +68,6 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_id, :resource_type).stringify_keys
-        end
-
         def suite_id
           USCoreClientTestSuite.id
         end

--- a/lib/us_core_test_kit/client/generated/v4.0.0/search_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v4.0.0/search_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV400
       class SearchEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,14 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          puts request_params
-          proxy_client.get(resource_type, request_params)
+          build_proxied_search_response
         end
 
         def tags
@@ -73,8 +68,8 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_type).stringify_keys
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generated/v5.0.1/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v5.0.1/read_endpoint.rb
@@ -76,10 +76,6 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_id, :resource_type).stringify_keys
-        end
-
         def suite_id
           USCoreClientTestSuite.id
         end

--- a/lib/us_core_test_kit/client/generated/v5.0.1/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v5.0.1/read_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV501
       class ReadEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,13 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          proxy_client.get("#{resource_type}/#{resource_id}", request_params)
+          build_proxied_read_response
         end
 
         def tags
@@ -86,6 +82,10 @@ module USCoreTestKit
 
         def request_params
           request.params.to_h.except(:resource_id, :resource_type).stringify_keys
+        end
+
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generated/v5.0.1/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v5.0.1/read_endpoint.rb
@@ -72,10 +72,6 @@ module USCoreTestKit
           end
         end
 
-        def resource_id
-          request.params[:resource_id]
-        end
-
         def resource_type
           request.params[:resource_type]
         end

--- a/lib/us_core_test_kit/client/generated/v5.0.1/search_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v5.0.1/search_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV501
       class SearchEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,14 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          puts request_params
-          proxy_client.get(resource_type, request_params)
+          build_proxied_search_response
         end
 
         def tags
@@ -81,8 +76,8 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_type).stringify_keys
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generated/v6.1.0/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/read_endpoint.rb
@@ -78,10 +78,6 @@ module USCoreTestKit
           end
         end
 
-        def resource_id
-          request.params[:resource_id]
-        end
-
         def resource_type
           request.params[:resource_type]
         end

--- a/lib/us_core_test_kit/client/generated/v6.1.0/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/read_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV610
       class ReadEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,13 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          proxy_client.get("#{resource_type}/#{resource_id}", request_params)
+          build_proxied_read_response
         end
 
         def tags
@@ -92,6 +88,10 @@ module USCoreTestKit
 
         def request_params
           request.params.to_h.except(:resource_id, :resource_type).stringify_keys
+        end
+
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generated/v6.1.0/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/read_endpoint.rb
@@ -82,10 +82,6 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_id, :resource_type).stringify_keys
-        end
-
         def suite_id
           USCoreClientTestSuite.id
         end

--- a/lib/us_core_test_kit/client/generated/v6.1.0/search_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/search_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV610
       class SearchEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,14 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          puts request_params
-          proxy_client.get(resource_type, request_params)
+          build_proxied_search_response
         end
 
         def tags
@@ -87,8 +82,8 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_type).stringify_keys
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generated/v7.0.0/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/read_endpoint.rb
@@ -84,10 +84,6 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_id, :resource_type).stringify_keys
-        end
-
         def suite_id
           USCoreClientTestSuite.id
         end

--- a/lib/us_core_test_kit/client/generated/v7.0.0/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/read_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV700
       class ReadEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,13 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          proxy_client.get("#{resource_type}/#{resource_id}", request_params)
+          build_proxied_read_response
         end
 
         def tags
@@ -94,6 +90,10 @@ module USCoreTestKit
 
         def request_params
           request.params.to_h.except(:resource_id, :resource_type).stringify_keys
+        end
+
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generated/v7.0.0/read_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/read_endpoint.rb
@@ -80,10 +80,6 @@ module USCoreTestKit
           end
         end
 
-        def resource_id
-          request.params[:resource_id]
-        end
-
         def resource_type
           request.params[:resource_type]
         end

--- a/lib/us_core_test_kit/client/generated/v7.0.0/search_endpoint.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/search_endpoint.rb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module USCoreClientV700
       class SearchEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,14 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          puts request_params
-          proxy_client.get(resource_type, request_params)
+          build_proxied_search_response
         end
 
         def tags
@@ -89,8 +84,8 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_type).stringify_keys
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generator/templates/read_endpoint.rb.erb
+++ b/lib/us_core_test_kit/client/generator/templates/read_endpoint.rb.erb
@@ -34,10 +34,6 @@ module USCoreTestKit
           end
         end
 
-        def resource_id
-          request.params[:resource_id]
-        end
-
         def resource_type
           request.params[:resource_type]
         end

--- a/lib/us_core_test_kit/client/generator/templates/read_endpoint.rb.erb
+++ b/lib/us_core_test_kit/client/generator/templates/read_endpoint.rb.erb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module <%= module_name %>
       class ReadEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,13 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          proxy_client.get("#{resource_type}/#{resource_id}", request_params)
+          build_proxied_read_response
         end
 
         def tags
@@ -48,6 +44,10 @@ module USCoreTestKit
 
         def request_params
           request.params.to_h.except(:resource_id, :resource_type).stringify_keys
+        end
+
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/generator/templates/read_endpoint.rb.erb
+++ b/lib/us_core_test_kit/client/generator/templates/read_endpoint.rb.erb
@@ -38,10 +38,6 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_id, :resource_type).stringify_keys
-        end
-
         def suite_id
           USCoreClientTestSuite.id
         end

--- a/lib/us_core_test_kit/client/generator/templates/search_endpoint.rb.erb
+++ b/lib/us_core_test_kit/client/generator/templates/search_endpoint.rb.erb
@@ -2,12 +2,14 @@
 
 require_relative '../../server_proxy'
 require_relative 'tags'
+require_relative 'urls'
 
 module USCoreTestKit
   module Client
     module <%= module_name %>
       class SearchEndpoint < Inferno::DSL::SuiteEndpoint
         include ServerProxy
+        include URLs
 
         def test_run_identifier
           UDAPSecurityTestKit::MockUDAPServer.issued_token_to_client_id(
@@ -16,14 +18,7 @@ module USCoreTestKit
         end
 
         def make_response
-          server_response = proxy_request
-          response.status = server_response.status
-          response.body = server_response.body
-        end
-
-        def proxy_request
-          puts request_params
-          proxy_client.get(resource_type, request_params)
+          build_proxied_search_response
         end
 
         def tags
@@ -43,8 +38,8 @@ module USCoreTestKit
           request.params[:resource_type]
         end
 
-        def request_params
-          request.params.to_h.except(:resource_type).stringify_keys
+        def suite_id
+          USCoreClientTestSuite.id
         end
       end
     end

--- a/lib/us_core_test_kit/client/server_proxy.rb
+++ b/lib/us_core_test_kit/client/server_proxy.rb
@@ -20,6 +20,56 @@ module USCoreTestKit
           'Authorization' => 'Bearer SAMPLE_TOKEN',
         }
       end
+
+      def build_proxied_read_response
+        resource_id = request.params[:resource_id]
+        resource_type = request.params[:resource_type]
+        request_params = request.params.to_h.except(:resource_id, :resource_type).stringify_keys
+        
+        server_response = proxy_client.get("#{resource_type}/#{resource_id}", request_params)
+        response.status = server_response.status
+        response.body = server_response.body
+        response.headers.merge!(server_response.headers)
+        remove_transfer_encoding_and_content_length_header(response.headers)
+        response.headers.delete('content-location') if response.headers['content-location'].present?
+      end
+
+      def build_proxied_search_response
+        resource_type = request.params[:resource_type]
+        request_params = request.params.to_h.except(:resource_type).stringify_keys
+        
+        server_response = proxy_client.get(resource_type, request_params)
+        response.status = server_response.status
+        response.body = if response.status == 200
+                          replace_bundle_urls(FHIR.from_contents(server_response.body)).to_json
+                        else
+                          server_response.body
+                        end
+        response.headers.merge!(server_response.headers)
+        remove_transfer_encoding_and_content_length_header(response.headers)
+      end
+
+      def remove_transfer_encoding_and_content_length_header(headers)
+        headers.delete('transfer-encoding') if headers['transfer-encoding'].present?
+        headers.delete('Content-Length') if headers['Content-Length'].present?
+
+        nil
+      end
+
+      def replace_bundle_urls(bundle)
+        reference_server_base = ENV.fetch('FHIR_REFERENCE_SERVER')
+        bundle&.link&.map! { |link| { relation: link.relation, url: link.url.gsub(reference_server_base, new_link) } }
+        bundle&.entry&.map! do |bundled_resource|
+          { fullUrl: bundled_resource.fullUrl.gsub(reference_server_base, new_link),
+            resource: bundled_resource.resource,
+            search: bundled_resource.search }
+        end
+        bundle
+      end
+
+      def new_link
+        "#{Inferno::Application['base_url']}/custom/#{suite_id}/fhir"
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary

Previously, the client tests returned only the status and response body when proxying requests to the inferno reference server. Now, it returns modified headers and also updates links to use the test suite's host and base fhir path.

# Testing Guidance

Run the client tests, make a FHIR request, and verify that responses returned by the client suite include appropriate content-type headers (e.g., application/fhir+json). Minimal test:
- make sure that the inferno-reference-server is running on port 8080
- start an instance of the US Core client v7.0.0 suite.
- select the "Demo: run against the server tests" preset
- Run all tests, clicking through the first wait dialog to confirm setup.
- in another tab, start an instance of test US Core server v7.0.0 suite
- select the "Demo: run against the client tests" preset
- Run group "3.5 Standalone Launch" to get an access token
- Run group "4.2 Patient Tests" to make a request
- look at the search requests in test 4.2.01 and the read request in test 4.2.09 and confirm the response and the response headers look right

