### PR TITLE
FI-4174: Update filters for validator update

### DIFF
--- a/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v3.1.1/us_core_test_suite.rb
@@ -63,8 +63,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Constraint failed: provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
+        /\A\S+: \S+: No definition could be found for URL value '.*'/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
         %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze

--- a/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v4.0.0/us_core_test_suite.rb
@@ -65,8 +65,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Constraint failed: provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
+        /\A\S+: \S+: No definition could be found for URL value '.*'/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
         %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze

--- a/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v5.0.1/us_core_test_suite.rb
@@ -75,8 +75,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Constraint failed: provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
+        /\A\S+: \S+: No definition could be found for URL value '.*'/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
         %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze

--- a/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v6.1.0/us_core_test_suite.rb
@@ -82,8 +82,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Constraint failed: provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
+        /\A\S+: \S+: No definition could be found for URL value '.*'/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
         %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze

--- a/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
+++ b/lib/us_core_test_kit/generated/v7.0.0/us_core_test_suite.rb
@@ -88,8 +88,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Constraint failed: provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
+        /\A\S+: \S+: No definition could be found for URL value '.*'/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
         %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze

--- a/lib/us_core_test_kit/generator/templates/suite.rb.erb
+++ b/lib/us_core_test_kit/generator/templates/suite.rb.erb
@@ -39,8 +39,8 @@ module USCoreTestKit
         /Observation\.effective\.ofType\(Period\): .*us-core-1:/, # Invalid invariant in US Core v3.1.1
         /Provenance.agent\[\d*\]: Constraint failed: provenance-1/, #Invalid invariant in US Core v5.0.1
         %r{Unknown Code System 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags'}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
-        %r{URL value 'http://hl7.org/fhir/us/core/CodeSystem/us-core-tags' does not resolve}, # Validator has an issue with this US Core 5 code system in US Core 6 resource
         /\A\S+: \S+: URL value '.*' does not resolve/,
+        /\A\S+: \S+: No definition could be found for URL value '.*'/,
         %r{Observation.component\[\d+\].value.ofType\(Quantity\): The code provided \(http://unitsofmeasure.org#L/min\) was not found in the value set 'Vital Signs Units'}, # Known issue with the Pulse Oximetry Profile
         %r{Slice 'Observation\.value\[x\]:valueQuantity': a matching slice is required, but not found \(from (http://hl7\.org/fhir/StructureDefinition/bmi\|4\.0\.1|http://hl7\.org/fhir/StructureDefinition/bmi\%7C4\.0\.1)\)}
       ].freeze


### PR DESCRIPTION
# Summary
This branch updates the validator message filters to match updated messages in the new version of the validator.

# Testing Guidance
In inferno_core, run the follwing command in the `validator` directory:
```sh
docker buildx build --platform linux/arm64,linux/amd64 --build-arg "PROJECT_VERSION=1.0.66" --tag "infernocommunity/inferno-resource-validator:1.0.66" --tag infernocommunity/inferno-resource-validator:latest --load .
```
In `docker-compose.background.yml`, update the image for the `hl7_validator_service` to `image: infernocommunity/inferno-resource-validator:1.0.66`.

If you perform these steps and run these tests on the `main` branch, you will see new validator errors, but those errors will be resolved on this branch.

You can also update `docker-compose.background.yml` in g10, and in the g10 Gemfile, add:
```ruby
gem 'us_core_test_kit',
git: 'git@github.com:inferno-framework/us-core-test-kit.git',
branch: 'fi-4174-update-validator'
```
This will allow you to verify that these changes work in g10.