### PR TITLE
FI-4194: Restore FHIRResourceNavigation and PrimitiveType constants

### DIFF
--- a/lib/us_core_test_kit/fhir_resource_navigation.rb
+++ b/lib/us_core_test_kit/fhir_resource_navigation.rb
@@ -1,0 +1,7 @@
+require_relative './primitive_type'
+
+module USCoreTestKit
+  # This functionality has been moved to Inferno Core, but this reference is
+  # retained to avoid a breaking change.
+  FHIRResourceNavigation = Inferno::DSL::FHIRResourceNavigation
+end

--- a/lib/us_core_test_kit/must_support_test.rb
+++ b/lib/us_core_test_kit/must_support_test.rb
@@ -1,3 +1,5 @@
+require_relative 'fhir_resource_navigation'
+
 module USCoreTestKit
   module MustSupportTest
     include Inferno::DSL::FHIRResourceNavigation

--- a/lib/us_core_test_kit/primitive_type.rb
+++ b/lib/us_core_test_kit/primitive_type.rb
@@ -1,0 +1,5 @@
+module USCoreTestKit
+  # This functionality has been moved to Inferno Core, but this reference is
+  # retained to avoid a breaking change.
+  PrimitiveType = Inferno::DSL::PrimitiveType
+end

--- a/lib/us_core_test_kit/reference_resolution_test.rb
+++ b/lib/us_core_test_kit/reference_resolution_test.rb
@@ -1,3 +1,5 @@
+require_relative 'fhir_resource_navigation'
+
 module USCoreTestKit
   module ReferenceResolutionTest
     include Inferno::DSL::FHIRResourceNavigation

--- a/lib/us_core_test_kit/resource_search_param_checker.rb
+++ b/lib/us_core_test_kit/resource_search_param_checker.rb
@@ -1,3 +1,5 @@
+require_relative 'fhir_resource_navigation'
+
 module USCoreTestKit
   module ResourceSearchParamChecker
     include Inferno::DSL::FHIRResourceNavigation

--- a/lib/us_core_test_kit/search_test.rb
+++ b/lib/us_core_test_kit/search_test.rb
@@ -2,6 +2,7 @@ require_relative 'date_search_validation'
 require_relative 'resource_search_param_checker'
 require_relative 'search_test_properties'
 require_relative 'well_known_code_systems'
+require_relative 'fhir_resource_navigation'
 
 module USCoreTestKit
   module SearchTest


### PR DESCRIPTION
This branch restores the constants for `FHIRResourceNavigation` and `PrimitiveType` so that the switch to the behavior defined in inferno core is not a breaking change.