### PR TITLE
FI-4221 Remove codes other than sdoh from MustSupport for Condition.category:screening-assessment

### DIFF
--- a/lib/us_core_test_kit/generated/v8.0.0/condition_problems_health_concerns/metadata.yml
+++ b/lib/us_core_test_kit/generated/v8.0.0/condition_problems_health_concerns/metadata.yml
@@ -293,36 +293,6 @@
       :values:
       - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
         :code: sdoh
-      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-        :code: functional-status
-      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-        :code: disability-status
-      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-        :code: cognitive-status
-      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-        :code: treatment-intervention-preference
-      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-        :code: care-experience-preference
-      - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-        :code: observation-adi-documentation
-      - :system: http://terminology.hl7.org/CodeSystem/observation-category
-        :code: social-history
-      - :system: http://terminology.hl7.org/CodeSystem/observation-category
-        :code: vital-signs
-      - :system: http://terminology.hl7.org/CodeSystem/observation-category
-        :code: imaging
-      - :system: http://terminology.hl7.org/CodeSystem/observation-category
-        :code: laboratory
-      - :system: http://terminology.hl7.org/CodeSystem/observation-category
-        :code: procedure
-      - :system: http://terminology.hl7.org/CodeSystem/observation-category
-        :code: survey
-      - :system: http://terminology.hl7.org/CodeSystem/observation-category
-        :code: exam
-      - :system: http://terminology.hl7.org/CodeSystem/observation-category
-        :code: therapy
-      - :system: http://terminology.hl7.org/CodeSystem/observation-category
-        :code: activity
     :uscdi_only: true
   :elements:
   - :path: meta

--- a/lib/us_core_test_kit/generated/v8.0.0/metadata.yml
+++ b/lib/us_core_test_kit/generated/v8.0.0/metadata.yml
@@ -1339,36 +1339,6 @@
         :values:
         - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
           :code: sdoh
-        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-          :code: functional-status
-        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-          :code: disability-status
-        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-          :code: cognitive-status
-        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-          :code: treatment-intervention-preference
-        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-          :code: care-experience-preference
-        - :system: http://hl7.org/fhir/us/core/CodeSystem/us-core-category
-          :code: observation-adi-documentation
-        - :system: http://terminology.hl7.org/CodeSystem/observation-category
-          :code: social-history
-        - :system: http://terminology.hl7.org/CodeSystem/observation-category
-          :code: vital-signs
-        - :system: http://terminology.hl7.org/CodeSystem/observation-category
-          :code: imaging
-        - :system: http://terminology.hl7.org/CodeSystem/observation-category
-          :code: laboratory
-        - :system: http://terminology.hl7.org/CodeSystem/observation-category
-          :code: procedure
-        - :system: http://terminology.hl7.org/CodeSystem/observation-category
-          :code: survey
-        - :system: http://terminology.hl7.org/CodeSystem/observation-category
-          :code: exam
-        - :system: http://terminology.hl7.org/CodeSystem/observation-category
-          :code: therapy
-        - :system: http://terminology.hl7.org/CodeSystem/observation-category
-          :code: activity
       :uscdi_only: true
     :elements:
     - :path: meta

--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_8.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor_us_core_8.rb
@@ -27,6 +27,7 @@ module USCoreTestKit
         add_must_support_choices
         us_core_6_extractor.remove_practitioner_address
         remove_patient_and_encounter_interpreter_extension
+        apply_condition_sdoh_guaidance
       end
 
       def add_must_support_choices
@@ -50,6 +51,19 @@ module USCoreTestKit
           must_supports[:choices] ||= []
           must_supports[:choices].concat(more_choices)
         end
+      end
+
+      # US Core v8 Condition Problems and Health Concerns Implementation Guidance:
+      # The category of "problem-list-item" or "health-concern" is required, and, at a minimum,
+      # Certifying Systems SHALL support, a category of "sdoh"
+      def apply_condition_sdoh_guaidance
+        return unless profile.url == 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns'
+
+        target_slice = must_supports[:slices].find { |slice| slice[:slice_id] == 'Condition.category:screening-assessment' }
+        return unless target_slice
+
+        target_slice[:discriminator][:values].delete_if { |value| value[:code] != 'sdoh'}
+
       end
     end
   end


### PR DESCRIPTION
# Summary

US Core v8 Condition Problems and Health Concerns Profile has a guidance that

The category of "problem-list-item" or "health-concern" is required, and, at a minimum, Certifying Systems SHALL support, a category of "sdoh"

This PR removes codings other than `sdoh` from the MustSupport metadata

# Testing Guidance

