### PR TITLE
FI-4268 Allow client read test to accept multiple resource ids

### DIFF
--- a/lib/us_core_test_kit/client/generated/v3.1.1/bodyheight_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/bodyheight_client_group.rb
@@ -38,7 +38,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-bodyheight`
+* `us-core-client-tests-body-height`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v3.1.1/bodytemp_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/bodytemp_client_group.rb
@@ -38,7 +38,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-bodytemp`
+* `us-core-client-tests-body-temperature`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v3.1.1/bodyweight_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/bodyweight_client_group.rb
@@ -38,7 +38,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-bodyweight`
+* `us-core-client-tests-body-weight`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v3.1.1/bp_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/bp_client_group.rb
@@ -38,7 +38,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-bp`
+* `us-core-client-tests-blood-pressure`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v3.1.1/condition_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/condition_client_group.rb
@@ -37,7 +37,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-condition`
+* `us-core-client-tests-condition-encounter-diagnosis`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v3.1.1/head_circumference_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/head_circumference_client_group.rb
@@ -38,7 +38,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-head-circumference`
+* `us-core-client-tests-head-circumference-percentile`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v3.1.1/heartrate_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/heartrate_client_group.rb
@@ -38,7 +38,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-heartrate`
+* `us-core-client-tests-heart-rate`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v3.1.1/resprate_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v3.1.1/resprate_client_group.rb
@@ -38,7 +38,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-resprate`
+* `us-core-client-tests-respiratory-rate`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v4.0.0/condition_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v4.0.0/condition_client_group.rb
@@ -37,7 +37,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-condition`
+* `us-core-client-tests-condition-encounter-diagnosis`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v4.0.0/head_circumference_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v4.0.0/head_circumference_client_group.rb
@@ -38,7 +38,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-head-circumference`
+* `us-core-client-tests-head-circumference-percentile`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v5.0.1/head_circumference_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v5.0.1/head_circumference_client_group.rb
@@ -33,7 +33,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-head-circumference`
+* `us-core-client-tests-head-circumference-percentile`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v6.1.0/head_circumference_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/head_circumference_client_group.rb
@@ -33,7 +33,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-head-circumference`
+* `us-core-client-tests-head-circumference-percentile`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v6.1.0/observation_clinical_result/observation_clinical_result_client_read_test.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/observation_clinical_result/observation_clinical_result_client_read_test.rb
@@ -17,14 +17,14 @@ module USCoreTestKit
         end
 
         def failure_message
-          "Inferno did not receive the expected read request for the target instance of the US Core Observation Clinical Result Profile: `Observation/us-core-client-tests-observation-clinical-result`."
+          "Inferno did not receive the expected read request for the target instance of the US Core Observation Clinical Result Profile: `Observation/us-core-client-tests-observation-clinical-result`, `Observation/us-core-client-tests-observation-lab`."
         end
 
         run do
           requests = load_tagged_requests(READ_OBSERVATION_TAG)
           skip_if requests.blank?, skip_message
 
-          requests_for_id = filter_requests_by_resource_id(requests, 'us-core-client-tests-observation-clinical-result')
+          requests_for_id = filter_requests_by_resource_id(requests, ["us-core-client-tests-observation-clinical-result", "us-core-client-tests-observation-lab"])
           assert requests_for_id.any?, failure_message
         end
       end

--- a/lib/us_core_test_kit/client/generated/v6.1.0/observation_clinical_result_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/observation_clinical_result_client_group.rb
@@ -33,7 +33,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-observation-clinical-result`
+* `us-core-client-tests-observation-clinical-result`\n* `us-core-client-tests-observation-lab`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v6.1.0/observation_clinical_result_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v6.1.0/observation_clinical_result_client_group.rb
@@ -33,7 +33,8 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-observation-clinical-result`\n* `us-core-client-tests-observation-lab`
+* `us-core-client-tests-observation-clinical-result`
+* `us-core-client-tests-observation-lab`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v7.0.0/head_circumference_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/head_circumference_client_group.rb
@@ -34,7 +34,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-head-circumference`
+* `us-core-client-tests-head-circumference-percentile`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v7.0.0/observation_clinical_result/observation_clinical_result_client_read_test.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/observation_clinical_result/observation_clinical_result_client_read_test.rb
@@ -17,14 +17,14 @@ module USCoreTestKit
         end
 
         def failure_message
-          "Inferno did not receive the expected read request for the target instance of the US Core Observation Clinical Result Profile: `Observation/us-core-client-tests-observation-clinical-result`."
+          "Inferno did not receive the expected read request for the target instance of the US Core Observation Clinical Result Profile: `Observation/us-core-client-tests-observation-clinical-result`, `Observation/us-core-client-tests-observation-lab`."
         end
 
         run do
           requests = load_tagged_requests(READ_OBSERVATION_TAG)
           skip_if requests.blank?, skip_message
 
-          requests_for_id = filter_requests_by_resource_id(requests, 'us-core-client-tests-observation-clinical-result')
+          requests_for_id = filter_requests_by_resource_id(requests, ["us-core-client-tests-observation-clinical-result", "us-core-client-tests-observation-lab"])
           assert requests_for_id.any?, failure_message
         end
       end

--- a/lib/us_core_test_kit/client/generated/v7.0.0/observation_clinical_result_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/observation_clinical_result_client_group.rb
@@ -34,7 +34,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-observation-clinical-result`
+* `us-core-client-tests-observation-clinical-result`\n* `us-core-client-tests-observation-lab`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v7.0.0/observation_clinical_result_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v7.0.0/observation_clinical_result_client_group.rb
@@ -34,7 +34,8 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-observation-clinical-result`\n* `us-core-client-tests-observation-lab`
+* `us-core-client-tests-observation-clinical-result`
+* `us-core-client-tests-observation-lab`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v8.0.0/head_circumference_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v8.0.0/head_circumference_client_group.rb
@@ -34,7 +34,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-head-circumference`
+* `us-core-client-tests-head-circumference-percentile`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v8.0.0/observation_clinical_result/observation_clinical_result_client_read_test.rb
+++ b/lib/us_core_test_kit/client/generated/v8.0.0/observation_clinical_result/observation_clinical_result_client_read_test.rb
@@ -17,14 +17,14 @@ module USCoreTestKit
         end
 
         def failure_message
-          "Inferno did not receive the expected read request for the target instance of the US Core Observation Clinical Result Profile: `Observation/us-core-client-tests-observation-clinical-result`."
+          "Inferno did not receive the expected read request for the target instance of the US Core Observation Clinical Result Profile: `Observation/us-core-client-tests-observation-clinical-result`, `Observation/us-core-client-tests-observation-lab`."
         end
 
         run do
           requests = load_tagged_requests(READ_OBSERVATION_TAG)
           skip_if requests.blank?, skip_message
 
-          requests_for_id = filter_requests_by_resource_id(requests, 'us-core-client-tests-observation-clinical-result')
+          requests_for_id = filter_requests_by_resource_id(requests, ["us-core-client-tests-observation-clinical-result", "us-core-client-tests-observation-lab"])
           assert requests_for_id.any?, failure_message
         end
       end

--- a/lib/us_core_test_kit/client/generated/v8.0.0/observation_clinical_result_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v8.0.0/observation_clinical_result_client_group.rb
@@ -34,7 +34,7 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-observation-clinical-result`
+* `us-core-client-tests-observation-clinical-result`\n* `us-core-client-tests-observation-lab`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generated/v8.0.0/observation_clinical_result_client_group.rb
+++ b/lib/us_core_test_kit/client/generated/v8.0.0/observation_clinical_result_client_group.rb
@@ -34,7 +34,8 @@ for the resource type is required, and omitted otherwise.
 ## Reading
 This test will check that the client performed a read of the following id:
 
-* `us-core-client-tests-observation-clinical-result`\n* `us-core-client-tests-observation-lab`
+* `us-core-client-tests-observation-clinical-result`
+* `us-core-client-tests-observation-lab`
 
 ## Searching
 These tests will check that the client performed searches agains the

--- a/lib/us_core_test_kit/client/generator/group_generator.rb
+++ b/lib/us_core_test_kit/client/generator/group_generator.rb
@@ -37,7 +37,7 @@ module USCoreTestKit
             conforming to the #{profile_name}.
 
             # Testing Methodology
-            
+
             ## Data Access Supported
 
             Clients may not be required to support the #{resource_type} FHIR resource type. However, if they
@@ -49,18 +49,18 @@ module USCoreTestKit
             ## Reading
             This test will check that the client performed a read of the following id:
 
-            * `us-core-client-tests-#{profile_identifier.underscore.dasherize}`
+            #{expected_resource_id_string}
 
             ## Searching
             These tests will check that the client performed searches agains the
             #{resource_type} resource type with the following required parameters:
 
             #{search_param_name_string}
-            
+
             Inferno will also look for searches using the following optional parameters:
 
             #{optional_search_param_name_string}
-            
+
           DESCRIPTION
         end
 
@@ -83,6 +83,15 @@ module USCoreTestKit
           File.write(output_file_name, output)
           group_metadata.id = group_id
           group_metadata.file_name = base_output_file_name
+        end
+
+        def expected_resource_id_string
+          expected_resource_id = [ Naming.instance_id_for_profile_identifier(profile_identifier) ]
+          if profile_identifier == 'observation_clinical_result'
+            expected_resource_id << Naming.instance_id_for_profile_identifier('observation_lab')
+          end
+
+          expected_resource_id.map { |id| "* `#{id}`"}.join('\n')
         end
       end
     end

--- a/lib/us_core_test_kit/client/generator/group_generator.rb
+++ b/lib/us_core_test_kit/client/generator/group_generator.rb
@@ -91,7 +91,7 @@ module USCoreTestKit
             expected_resource_id << Naming.instance_id_for_profile_identifier('observation_lab')
           end
 
-          expected_resource_id.map { |id| "* `#{id}`"}.join('\n')
+          expected_resource_id.map { |id| "* `#{id}`"}.join("\n")
         end
       end
     end

--- a/lib/us_core_test_kit/client/generator/read_test_generator.rb
+++ b/lib/us_core_test_kit/client/generator/read_test_generator.rb
@@ -38,7 +38,15 @@ module USCoreTestKit
         end
 
         def expected_resource_id
-          Naming.instance_id_for_profile_identifier(profile_identifier)
+          if profile_identifier == 'observation_clinical_result'
+            return [ Naming.instance_id_for_profile_identifier(profile_identifier), Naming.instance_id_for_profile_identifier('observation_lab') ]
+          else
+            Naming.instance_id_for_profile_identifier(profile_identifier)
+          end
+        end
+
+        def expected_resource_id_string
+          Array(expected_resource_id).map { |id| "`#{resource_type}/#{id}`"}.join(', ')
         end
 
         def title

--- a/lib/us_core_test_kit/client/generator/templates/read_test.rb.erb
+++ b/lib/us_core_test_kit/client/generator/templates/read_test.rb.erb
@@ -31,14 +31,18 @@ module USCoreTestKit
         end
 
         def failure_message
-          "Inferno did not receive the expected read request for the target instance of the <%= group_metadata.profile_name %>: `<%= resource_type %>/<%= expected_resource_id %>`."
+          "Inferno did not receive the expected read request for the target instance of the <%= group_metadata.profile_name %>: <%= expected_resource_id_string %>."
         end
 
         run do
           requests = load_tagged_requests(READ_<%= resource.underscore.upcase %>_TAG)
           skip_if requests.blank?, skip_message
 
+          <%- if profile_identifier == 'observation_clinical_result' -%>
+          requests_for_id = filter_requests_by_resource_id(requests, <%= expected_resource_id %>)
+          <%- else -%>
           requests_for_id = filter_requests_by_resource_id(requests, '<%= expected_resource_id %>')
+          <%- end -%>
           assert requests_for_id.any?, failure_message
         end
       end

--- a/lib/us_core_test_kit/client/test_helper.rb
+++ b/lib/us_core_test_kit/client/test_helper.rb
@@ -10,11 +10,9 @@ module USCoreTestKit
       end
 
       def filter_requests_by_resource_id(requests, resource_id)
-        if resource_id.is_a?(Array)
-          resource_id.flat_map { |id| filter_requests_by_resource_id(requests, id) }
-        else
+        Array(resource_id).flat_map do |id|
           requests.select do |request|
-            request.url.split('/').last.split('?').first&.casecmp?(resource_id)
+            request.url.split('/').last.split('?').first&.casecmp?(id)
           end
         end
       end

--- a/lib/us_core_test_kit/client/test_helper.rb
+++ b/lib/us_core_test_kit/client/test_helper.rb
@@ -10,14 +10,18 @@ module USCoreTestKit
       end
 
       def filter_requests_by_resource_id(requests, resource_id)
-        requests.select do |request|
-          request.url.split('/').last.split('?').first&.casecmp?(resource_id)
+        if resource_id.is_a?(Array)
+          resource_id.flat_map { |id| filter_requests_by_resource_id(requests, id) }
+        else
+          requests.select do |request|
+            request.url.split('/').last.split('?').first&.casecmp?(resource_id)
+          end
         end
       end
 
       def filter_requests_by_search_parameters(requests, search_parameters)
         requests.select do |request|
-          included_params = 
+          included_params =
             if request.verb.downcase == 'get'
               url_params(request.url).keys
             elsif request.verb.downcase == 'post'


### PR DESCRIPTION
# Summary

Observation Clinical Test Result profile is a parent profile for Observcation Lab Result profile. When client sends query for Clinical Test Result with patient ID, Lab Result Observation are also returned. So when client run read test, the resource id could be either `observation-clinical-test-result`, or `observation-lab`.

This PR allows client read test to accept multiple resource ids

This PR also fixed some incorrect resource ids mentioned in the group discription text which does not affect actual testing.

# Testing Guidance

Run US Core Client test for v6.1.0, v7.0.0, or v8.0.0. 
Verify Observation Clinical Test Result group passed

