### PR TITLE
ID-34: ignore resource-level scopes during granular scope query-in-scope evaluation

### DIFF
--- a/lib/us_core_test_kit/granular_scope_search_test.rb
+++ b/lib/us_core_test_kit/granular_scope_search_test.rb
@@ -66,26 +66,22 @@ module USCoreTestKit
     end
 
     def query_in_scope?(resource_type, params)
-      received_scopes.split(' ').each do |scope|
+      received_scopes.split(' ').any? do |scope|
         parsed_scope = URI.parse(scope)
         
         # check for resource type, search scope, and matched params
-        next unless parsed_scope.path =~ /\/#{resource_type}\./ &&
-                    parsed_scope.path.split('.')[1].include?('s') &&
-                    granular_params_present?(parsed_scope.query, params)
-      
-        return true
+        parsed_scope.path =~ /\/#{resource_type}\./ &&
+          parsed_scope.path.split('.')[1].include?('s') &&
+          search_is_for_the_granular_values?(parsed_scope.query, params)
       end
-
-      false
     end
 
-    def granular_params_present?(granular_params, search_params)
-      CGI.parse(granular_params).each do |param_name, value|
-        return false unless search_params.key?(param_name) && value.include?(search_params[param_name])
+    def search_is_for_the_granular_values?(granular_params, search_params)
+      return false if granular_params.blank? # ignore resource-level scopes
+      
+      CGI.parse(granular_params).all? do |param_name, value|
+        search_params.key?(param_name) && value.include?(search_params[param_name])
       end
-
-      true
     end
 
     def previous_resources(params)

--- a/spec/us_core/granular_scope_search_spec.rb
+++ b/spec/us_core/granular_scope_search_spec.rb
@@ -256,7 +256,21 @@ RSpec.describe USCoreTestKit::GranularScopeSearchTest, :runnable do
           expect(result.result).to eq('pass')
         end
 
-         context 'with POST requests' do
+        it 'ignores resource-level scopes provided' do
+          stub_request(request.verb.to_sym, request.url.split('?').first)
+            .with(query: request.query_parameters)
+            .to_return(body: FHIR::Bundle.new(
+                                entry: [
+                                  { resource: matching_resource.to_hash },
+                                  { resource: matching_resource2.to_hash }
+                                ]
+                              ).to_json)
+          
+          result = run(granular_scope_test, url:, patient_ids:, received_scopes: "patient/Observation.rs #{received_scopes}")
+          expect(result.result).to eq('pass')
+        end
+
+        context 'with POST requests' do
           let!(:post_request) do
             repo_create(
               :request,
@@ -426,9 +440,7 @@ RSpec.describe USCoreTestKit::GranularScopeSearchTest, :runnable do
           expect(result.result).to eq('fail')
           expect(result.result_message).to eq(expected_message)
         end
-
       end
-
     end
   end
 end


### PR DESCRIPTION
# Summary

Previously, if a resource-level scope was granted during the granular scope tests, Inferno would throw a purple error. Now, Inferno disregards resource-level scopes.

Additionally, the `query_in_scope?` function logic was updated to be easier to understand by
- using list functions like `any?` and `all?`.
- making function names more descriptive.

# Testing Guidance

1. Start an instance of the US Core server tests for US Core version 6.1.0 and SMART version 2.0
2. Apply the "Inferno Reference Server" preset
3. Run groups 1.3, 2.6, and 2.7 (no changes to inputs needed)
4. Run group 3.2.1.1, adding scope `patient/Condition.rs` to the list of requested scopes in the `Scopes (required)` input (the list is space delimited). Test 3.2.1.1.2.08 will fail since a resource-level scope shouldn't be granted.
5. Run group 3.2.2.1 (no changes to inputs needed). Confirm that all search tests succeed (no purple errors). The read test will fail because Inferno assumes that no resource-level scopes are granted.

