### PR TITLE
Fix type_slices method using correct elements variable

### DIFF
--- a/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
+++ b/lib/us_core_test_kit/generator/must_support_metadata_extractor.rb
@@ -84,21 +84,25 @@ module USCoreTestKit
           type_path = '' if type_path == '$this'
           type_element =
             if type_path.present?
-              elements.find { |element| element.id == "#{current_element.id}.#{type_path}" }
+              profile_elements.find { |element| element.id == "#{current_element.id}.#{type_path}" }
             else
               current_element
             end
 
           type_code = type_element.type.first.code
 
+          discriminator = {
+            type: 'type',
+            code: type_code.upcase_first
+          }
+          
+          discriminator[:path] = type_path unless type_path.empty?
+
           {
             slice_id: current_element.id,
             slice_name: current_element.sliceName,
             path: current_element.path.gsub("#{resource}.", ''),
-            discriminator: {
-              type: 'type',
-              code: type_code.upcase_first
-            }
+            discriminator: discriminator
           }.tap do |metadata|
             if is_uscdi_requirement_element?(current_element)
               metadata[:uscdi_only] = true


### PR DESCRIPTION
# Summary

This PR fixes Issue #283 

The first issue is that the `elements` variable used in current version does not exist at all. This PR changes it to the correct instance variable `profile_elements`.

This PR also saves the `type_path` into the metadata if it has value.

Since US Core does not have type slice with path, so this code section has not been touched by US Core generator.

# Testing Guidance

Run `us_core:generate`, there SHALL NOT be any change to the generated us core tests.
