### PR TITLE
Check for client generator diff in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Verify test generation is up to date
         run: |
           bundle exec rake us_core:generate
-          if [[ -n "$(git status --porcelain lib/us_core_test_kit/generated)" ]]; then
+          if [[ -n "$(git status --porcelain lib/us_core_test_kit/generated lib/us_core_test_kit/client/generated)" ]]; then
             echo "Generated tests are outdated. Run 'bundle exec rake us_core:generate' and commit the changes."
             git diff
             exit 1


### PR DESCRIPTION
# Summary

The `Verify test generation is up to date` CI step does not check for client generator diffs. This PR adds that directory to the status check.

# Testing Guidance

Edit one of the client generator templates and run the generator. Run the original CI command. Run the modified command.