### PR TITLE
Release v1.1.5 and Client proxying fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.5
+
+* Fix a bug in the client tests proxying.
+
 # 1.1.4
 
 * Adjust v5.0.1 validator message filters for v5.0.1 based on validator version v1.0.79.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    us_core_test_kit (1.1.4)
+    us_core_test_kit (1.1.5)
       inferno_core (~> 1.4, >= 1.4.0)
       smart_app_launch_test_kit (~> 1.0, >= 1.0.2)
       tls_test_kit (~> 1.0, >= 1.0.2)
@@ -533,7 +533,7 @@ CHECKSUMS
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   unicode_utils (1.4.0) sha256=b922d0cf2313b6b7136ada6645ce7154ffc86418ca07d53b058efe9eb72f2a40
-  us_core_test_kit (1.1.4)
+  us_core_test_kit (1.1.5)
   version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737

--- a/lib/us_core_test_kit/client/server_proxy.rb
+++ b/lib/us_core_test_kit/client/server_proxy.rb
@@ -58,12 +58,8 @@ module USCoreTestKit
 
       def replace_bundle_urls(bundle)
         reference_server_base = ENV.fetch('FHIR_REFERENCE_SERVER')
-        bundle&.link&.map! { |link| { relation: link.relation, url: link.url.gsub(reference_server_base, new_link) } }
-        bundle&.entry&.map! do |bundled_resource|
-          { fullUrl: bundled_resource.fullUrl.gsub(reference_server_base, new_link),
-            resource: bundled_resource.resource,
-            search: bundled_resource.search }
-        end
+        bundle&.link&.each { |link| link.url = link.url.gsub(reference_server_base, new_link) }
+        bundle&.entry&.each { |entry| entry.fullUrl = entry.fullUrl.gsub(reference_server_base, new_link) }
         bundle
       end
 

--- a/lib/us_core_test_kit/version.rb
+++ b/lib/us_core_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module USCoreTestKit
-  VERSION = '1.1.4'
-  LAST_UPDATED = '2026-07-09'
+  VERSION = '1.1.5'
+  LAST_UPDATED = '2026-07-13'
 end


### PR DESCRIPTION
# Summary

Proxying of request to the client suite FHIR endpoints to the reference server was failing in deployed environments due to a combination of json gem inconsistencies and a varied object structure introduced by the url replacement method. Now, that method keeps the FHIR object structure consistent to resolve the issue.

# Testing Guidance

Deploy to QA and confirm that running the client vs server suite works correctly.

